### PR TITLE
Fix mic button tooltip to show correct keyboard shortcut

### DIFF
--- a/packages/desktop/src/lib/acp/components/agent-input/components/mic-button.svelte
+++ b/packages/desktop/src/lib/acp/components/agent-input/components/mic-button.svelte
@@ -148,7 +148,7 @@ const STOP_RED = "#FF5D5A";
 		<div class="flex items-center gap-2">
 			<span>{hoverTitle}</span>
 			{#if visualState === "mic"}
-				<KbdGroup><Kbd>Space</Kbd></KbdGroup>
+				<KbdGroup><Kbd>Right ⌥</Kbd></KbdGroup>
 			{/if}
 		</div>
 	</Tooltip.Content>


### PR DESCRIPTION
## Summary
- The mic button tooltip was showing "Space" as the keyboard shortcut, but the actual binding is Right Option (⌥)
- Updates the tooltip to match the real keybinding so users aren't misled

## Changes
- **`packages/desktop/src/lib/acp/components/agent-input/components/mic-button.svelte`** (+1 -1) — Fix keyboard shortcut label from "Space" to "Right ⌥"

## Testing
1. Hover over the mic button in the agent input area
2. Verify the tooltip shows "Right ⌥" instead of "Space"
3. Confirm the shortcut only appears when the visual state is "mic"

---

[![Created with Acepe](https://img.shields.io/badge/Created_with-Acepe-6366f1)](https://acepe.dev)