### PR TITLE
Fix footer buttons hidden by long branch names

### DIFF
--- a/packages/desktop/src/lib/acp/components/agent-panel/components/agent-panel-footer.svelte
+++ b/packages/desktop/src/lib/acp/components/agent-panel/components/agent-panel-footer.svelte
@@ -61,23 +61,25 @@ const worktreeProjectPath = $derived(projectPath || "");
 
 <div class="shrink-0 flex items-center h-7 border-t border-border/50">
 	{#if hasProjectPath}
-		<WorktreeToggleControl
-			{panelId}
-			projectPath={worktreeProjectPath}
-			projectName={null}
-			{activeWorktreePath}
-			{hasEdits}
-			{hasMessages}
-			{globalWorktreeDefault}
-			{worktreeDeleted}
-			{onWorktreeCreated}
-			{onWorktreeRenamed}
-			{onPendingChange}
-		/>
+		<div class="min-w-0 flex-1">
+			<WorktreeToggleControl
+				{panelId}
+				projectPath={worktreeProjectPath}
+				projectName={null}
+				{activeWorktreePath}
+				{hasEdits}
+				{hasMessages}
+				{globalWorktreeDefault}
+				{worktreeDeleted}
+				{onWorktreeCreated}
+				{onWorktreeRenamed}
+				{onPendingChange}
+				/>
+		</div>
 	{/if}
 
 	{#if onSettings && hasProjectPath}
-		<div class="flex items-center border-l border-border/50">
+		<div class="shrink-0 flex items-center border-l border-border/50">
 			<EmbeddedIconButton
 				title={m.project_settings()}
 				ariaLabel={m.project_settings()}
@@ -88,7 +90,7 @@ const worktreeProjectPath = $derived(projectPath || "");
 		</div>
 	{/if}
 
-	<div class="ml-auto flex items-center border-l border-border/50">
+	<div class="shrink-0 flex items-center border-l border-border/50">
 		<EmbeddedIconButton
 			active={isBrowserSidebarOpen}
 			title="Toggle browser"

--- a/packages/desktop/src/lib/acp/components/worktree-toggle/branch-picker.svelte
+++ b/packages/desktop/src/lib/acp/components/worktree-toggle/branch-picker.svelte
@@ -205,7 +205,7 @@ function openCreateBranchDialog(): void {
 	>
 		{#snippet renderButton()}
 			<GitBranch class="size-3 shrink-0" weight="fill" style="color: {Colors.purple}" />
-			<span class="text-xs font-mono max-w-[9rem] truncate" title={currentBranch || "branch"}>
+			<span class="text-xs font-mono truncate" title={currentBranch || "branch"}>
 				{currentBranch || "branch"}
 			</span>
 			{#if diffStats}

--- a/packages/desktop/src/lib/acp/components/worktree-toggle/worktree-toggle.svelte
+++ b/packages/desktop/src/lib/acp/components/worktree-toggle/worktree-toggle.svelte
@@ -214,7 +214,7 @@ const tooltipText = $derived(
 const showDividers = $derived(props.variant !== "minimal");
 </script>
 
-<div class="flex items-center justify-between w-full h-full">
+<div class="flex items-center justify-between w-full h-full min-w-0">
 	<!-- Left: Worktree picker -->
 	<div class={cn("flex items-center h-full", showDividers && "border-r border-border/50")}>
 		<WorktreeToggleButton


### PR DESCRIPTION
Constrain worktree/branch section with min-w-0 flex-1 so it shrinks, and pin settings/terminal/browser buttons with shrink-0 so they always remain visible regardless of branch name length.

## Summary

<!-- What does this PR do? Keep it to 1-3 bullet points. -->

## Changes

<!-- List the key changes made. -->

## Test plan

<!-- How did you verify this works? -->

## Screenshots

<!-- If applicable, add screenshots or recordings. -->
