### PR TITLE
feat: preload agent skills for preconnect slash commands

### DIFF
--- a/packages/desktop/src-tauri/src/lib.rs
+++ b/packages/desktop/src-tauri/src/lib.rs
@@ -111,6 +111,7 @@ use skills::commands::{
     skills_delete,
     skills_get,
     skills_get_plugin_skill,
+    skills_list_agent_skills,
     skills_list_plugin_skills,
     // Plugin skills commands
     skills_list_plugins,
@@ -921,6 +922,7 @@ pub fn run() {
             checkpoint_revert_file,
             checkpoint_get_file_snapshots,
             // Skills commands
+            skills_list_agent_skills,
             skills_list_tree,
             skills_get,
             skills_create,

--- a/packages/desktop/src-tauri/src/skills/commands.rs
+++ b/packages/desktop/src-tauri/src/skills/commands.rs
@@ -8,8 +8,8 @@ use crate::db::repository::SkillsRepository;
 use crate::skills::service::SkillsService;
 use crate::skills::sync::SyncEngine;
 use crate::skills::types::{
-    LibrarySkill, LibrarySkillWithSync, PluginInfo, PluginSkill, Skill, SkillTreeNode, SyncResult,
-    SyncTarget,
+    AgentSkillsGroup, LibrarySkill, LibrarySkillWithSync, PluginInfo, PluginSkill, Skill,
+    SkillTreeNode, SyncResult, SyncTarget,
 };
 
 /// List all agents and their skills as a tree structure.
@@ -19,6 +19,15 @@ pub async fn skills_list_tree(
     service: State<'_, Arc<SkillsService>>,
 ) -> Result<Vec<SkillTreeNode>, String> {
     service.get_skills_tree().await
+}
+
+/// List parsed skills for all configured agents.
+#[tauri::command]
+#[specta::specta]
+pub async fn skills_list_agent_skills(
+    service: State<'_, Arc<SkillsService>>,
+) -> Result<Vec<AgentSkillsGroup>, String> {
+    service.list_agent_skills().await
 }
 
 /// Get a specific skill by ID.

--- a/packages/desktop/src-tauri/src/skills/service.rs
+++ b/packages/desktop/src-tauri/src/skills/service.rs
@@ -10,7 +10,9 @@ use tokio::sync::Mutex;
 
 use crate::skills::parser::{generate_skill_content, parse_skill_content};
 use crate::skills::plugins::PluginDiscovery;
-use crate::skills::types::{PluginInfo, PluginSkill, Skill, SkillAgent, SkillTreeNode};
+use crate::skills::types::{
+    AgentSkillsGroup, PluginInfo, PluginSkill, Skill, SkillAgent, SkillTreeNode,
+};
 
 /// Agent configuration with ID, name, and skills directory path.
 #[derive(Debug, Clone)]
@@ -256,6 +258,34 @@ impl SkillsService {
         }
 
         Ok(skills)
+    }
+
+    /// List parsed skills for every configured agent.
+    pub async fn list_agent_skills(&self) -> Result<Vec<AgentSkillsGroup>, String> {
+        let mut agent_configs: Vec<_> = self.agents.values().collect();
+        agent_configs.sort_by(|a, b| a.name.cmp(&b.name));
+
+        let mut groups = Vec::with_capacity(agent_configs.len());
+
+        for config in agent_configs {
+            let skills = match self.list_skills_for_agent(&config.id).await {
+                Ok(skills) => skills,
+                Err(error) => {
+                    tracing::warn!(
+                        agent_id = %config.id,
+                        error = %error,
+                        "Failed to load agent skills for grouped listing"
+                    );
+                    Vec::new()
+                }
+            };
+            groups.push(AgentSkillsGroup {
+                agent_id: config.id.clone(),
+                skills,
+            });
+        }
+
+        Ok(groups)
     }
 
     /// Load a skill from a SKILL.md file path.
@@ -552,5 +582,200 @@ impl SkillsService {
 impl Default for SkillsService {
     fn default() -> Self {
         Self::new()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::TempDir;
+
+    fn build_service(agent_dir: &std::path::Path) -> SkillsService {
+        let mut agents = HashMap::new();
+        agents.insert(
+            "claude-code".to_string(),
+            AgentConfig {
+                id: "claude-code".to_string(),
+                name: "Claude Code".to_string(),
+                skills_dir: agent_dir.to_path_buf(),
+            },
+        );
+
+        SkillsService {
+            agents,
+            watcher_active: Arc::new(Mutex::new(false)),
+            plugin_discovery: PluginDiscovery::new(),
+        }
+    }
+
+    async fn write_skill(
+        root: &std::path::Path,
+        folder_name: &str,
+        content: &str,
+    ) -> Result<(), String> {
+        let skill_dir = root.join(folder_name);
+        tokio::fs::create_dir_all(&skill_dir)
+            .await
+            .map_err(|e| format!("failed to create skill dir: {}", e))?;
+        tokio::fs::write(skill_dir.join("SKILL.md"), content)
+            .await
+            .map_err(|e| format!("failed to write skill file: {}", e))
+    }
+
+    #[tokio::test]
+    async fn list_skills_for_agent_returns_empty_for_missing_directory() {
+        let temp_dir = TempDir::new().expect("temp dir");
+        let missing_dir = temp_dir.path().join("missing-skills");
+        let service = build_service(&missing_dir);
+
+        let skills = service
+            .list_skills_for_agent("claude-code")
+            .await
+            .expect("skills should load");
+
+        assert!(skills.is_empty());
+    }
+
+    #[tokio::test]
+    async fn list_skills_for_agent_skips_invalid_entries_and_keeps_valid_siblings() {
+        let temp_dir = TempDir::new().expect("temp dir");
+        let skills_dir = temp_dir.path().join("skills");
+        tokio::fs::create_dir_all(&skills_dir)
+            .await
+            .expect("create skills dir");
+
+        write_skill(
+            &skills_dir,
+            "ce-brainstorm",
+            "---\nname: \"ce:brainstorm\"\ndescription: \"Brainstorm a feature\"\n---\n\n# Brainstorm",
+        )
+        .await
+        .expect("write valid skill");
+
+        write_skill(
+            &skills_dir,
+            "broken-skill",
+            "---\ndescription: \"Missing name\"\n---\n\n# Broken",
+        )
+        .await
+        .expect("write invalid skill");
+
+        tokio::fs::create_dir_all(skills_dir.join("missing-markdown"))
+            .await
+            .expect("create empty skill folder");
+
+        let service = build_service(&skills_dir);
+
+        let skills = service
+            .list_skills_for_agent("claude-code")
+            .await
+            .expect("skills should load");
+
+        assert_eq!(skills.len(), 1);
+        assert_eq!(skills[0].name, "ce:brainstorm");
+        assert_eq!(skills[0].description, "Brainstorm a feature");
+        assert_eq!(skills[0].folder_name, "ce-brainstorm");
+    }
+
+    #[tokio::test]
+    async fn list_agent_skills_groups_results_by_agent() {
+        let temp_dir = TempDir::new().expect("temp dir");
+        let skills_dir = temp_dir.path().join("skills");
+        tokio::fs::create_dir_all(&skills_dir)
+            .await
+            .expect("create skills dir");
+
+        write_skill(
+            &skills_dir,
+            "ce-plan",
+            "---\nname: \"ce:plan\"\ndescription: \"Plan implementation\"\n---\n\n# Plan",
+        )
+        .await
+        .expect("write skill");
+
+        write_skill(
+            &skills_dir,
+            "broken-skill",
+            "---\ndescription: \"Missing name\"\n---\n\n# Broken",
+        )
+        .await
+        .expect("write invalid skill");
+
+        let service = build_service(&skills_dir);
+
+        let groups = service
+            .list_agent_skills()
+            .await
+            .expect("groups should load");
+
+        assert_eq!(groups.len(), 1);
+        assert_eq!(groups[0].agent_id, "claude-code");
+        assert_eq!(groups[0].skills.len(), 1);
+        assert_eq!(groups[0].skills[0].name, "ce:plan");
+        assert_eq!(groups[0].skills[0].description, "Plan implementation");
+    }
+
+    #[tokio::test]
+    async fn list_agent_skills_returns_other_agents_when_one_path_is_unreadable() {
+        let temp_dir = TempDir::new().expect("temp dir");
+        let valid_dir = temp_dir.path().join("valid-skills");
+        tokio::fs::create_dir_all(&valid_dir)
+            .await
+            .expect("create valid dir");
+        write_skill(
+            &valid_dir,
+            "ce-plan",
+            "---\nname: \"ce:plan\"\ndescription: \"Plan implementation\"\n---\n\n# Plan",
+        )
+        .await
+        .expect("write valid skill");
+
+        let unreadable_path = temp_dir.path().join("not-a-directory");
+        tokio::fs::write(&unreadable_path, "plain file")
+            .await
+            .expect("write plain file");
+
+        let mut agents = HashMap::new();
+        agents.insert(
+            "claude-code".to_string(),
+            AgentConfig {
+                id: "claude-code".to_string(),
+                name: "Claude Code".to_string(),
+                skills_dir: valid_dir,
+            },
+        );
+        agents.insert(
+            "cursor".to_string(),
+            AgentConfig {
+                id: "cursor".to_string(),
+                name: "Cursor".to_string(),
+                skills_dir: unreadable_path,
+            },
+        );
+
+        let service = SkillsService {
+            agents,
+            watcher_active: Arc::new(Mutex::new(false)),
+            plugin_discovery: PluginDiscovery::new(),
+        };
+
+        let groups = service
+            .list_agent_skills()
+            .await
+            .expect("groups should load");
+
+        assert_eq!(groups.len(), 2);
+        let claude_group = groups
+            .iter()
+            .find(|group| group.agent_id == "claude-code")
+            .expect("claude group");
+        let cursor_group = groups
+            .iter()
+            .find(|group| group.agent_id == "cursor")
+            .expect("cursor group");
+
+        assert_eq!(claude_group.skills.len(), 1);
+        assert_eq!(claude_group.skills[0].name, "ce:plan");
+        assert!(cursor_group.skills.is_empty());
     }
 }

--- a/packages/desktop/src-tauri/src/skills/types.rs
+++ b/packages/desktop/src-tauri/src/skills/types.rs
@@ -42,6 +42,16 @@ pub struct Skill {
     pub modified_at: i64,
 }
 
+/// Parsed skills grouped by agent for startup consumers.
+#[derive(Debug, Clone, Serialize, Deserialize, specta::Type)]
+#[serde(rename_all = "camelCase")]
+pub struct AgentSkillsGroup {
+    /// Agent ID these skills belong to
+    pub agent_id: String,
+    /// Parsed skills for this agent
+    pub skills: Vec<Skill>,
+}
+
 /// Tree node for UI rendering.
 #[derive(Debug, Clone, Serialize, Deserialize, specta::Type)]
 #[serde(rename_all = "camelCase")]

--- a/packages/desktop/src/lib/acp/components/agent-input/agent-input-ui.svelte
+++ b/packages/desktop/src/lib/acp/components/agent-input/agent-input-ui.svelte
@@ -34,6 +34,7 @@ import VoiceRecordingOverlay from "./components/voice-recording-overlay.svelte";
 import { VoiceInputState } from "./state/voice-input-state.svelte.js";
 import { shouldShowVoiceOverlay } from "./logic/voice-ui-state.js";
 import { createImageAttachment, isImageMimeType } from "./logic/image-attachment.js";
+import { resolveSlashCommandSource } from "./logic/slash-command-source.js";
 import {
 	findInlineArtefactRangeAtPosition,
 	INLINE_TOKEN_PREFIX,
@@ -76,6 +77,7 @@ import { normalizeVoiceInputText } from "./logic/voice-input-text.js";
 import { shouldStartVoiceHold, shouldStopVoiceHold } from "./logic/voice-keyboard.js";
 import { AgentInputState } from "./state/agent-input-state.svelte.js";
 import type { AgentInputProps } from "./types/agent-input-props.js";
+import { getPreconnectionAgentSkillsStore } from "$lib/skills/store/preconnection-agent-skills-store.svelte.js";
 
 // Keep props as reactive object instead of destructuring
 const props: AgentInputProps = $props();
@@ -85,6 +87,7 @@ const kb = getKeybindingsService();
 const sessionStore = getSessionStore();
 const panelStore = getPanelStore();
 const messageQueueStore = getMessageQueueStore();
+const preconnectionAgentSkillsStore = getPreconnectionAgentSkillsStore();
 const voiceSettingsStore = getVoiceSettingsStore();
 const effectiveVoiceSessionId = $derived(props.voiceSessionId ?? props.sessionId ?? null);
 
@@ -186,7 +189,32 @@ const effectiveCurrentModelId = $derived.by(() =>
 	})
 );
 
-const effectiveAvailableCommands = $derived(sessionHotState?.availableCommands ?? []);
+const liveAvailableCommands = $derived.by(() => {
+	if (sessionHotState && sessionHotState.availableCommands) {
+		return sessionHotState.availableCommands;
+	}
+
+	return [];
+});
+const preconnectionAvailableCommands = $derived.by(() => {
+	if (!capabilitiesAgentId) {
+		return [];
+	}
+
+	return preconnectionAgentSkillsStore.getCommandsForAgent(capabilitiesAgentId);
+});
+const slashCommandSource = $derived.by(() => {
+	return resolveSlashCommandSource({
+		liveCommands: liveAvailableCommands,
+		hasConnectedSession: sessionRuntimeState?.connectionPhase === "connected",
+		selectedAgentId: capabilitiesAgentId,
+		preconnectionCommands: preconnectionAvailableCommands,
+	});
+});
+const effectiveAvailableCommands = $derived(slashCommandSource.commands);
+const isSlashDropdownVisible = $derived(
+	inputState.showSlashDropdown && slashCommandSource.source !== "none"
+);
 
 // Input is ready when we have a session or project path (loading state no longer blocks input)
 const inputReady = $derived(!!props.sessionId || !!props.projectPath);
@@ -470,8 +498,9 @@ function handleEditorInput(options?: { suppressAutocomplete?: boolean }): void {
 
 			const slashTriggerResult = parseSlashCommandTrigger(inputState.message, cursorPos);
 			if (slashTriggerResult.isOk() && slashTriggerResult.value) {
+				const currentSlashCommandSource = slashCommandSource;
 				const dropdownPosition = getCaretDropdownPosition();
-				if (!dropdownPosition) {
+				if (!dropdownPosition || currentSlashCommandSource.source === "none") {
 					inputState.showSlashDropdown = false;
 					inputState.slashQuery = "";
 				} else {
@@ -986,7 +1015,7 @@ function handleEditorKeyDown(event: KeyboardEvent): void {
 	if (inputState.showFileDropdown && inputState.fileDropdownRef?.handleKeyDown(event)) {
 		return;
 	}
-	if (inputState.showSlashDropdown && inputState.slashDropdownRef?.handleKeyDown(event)) {
+	if (isSlashDropdownVisible && inputState.slashDropdownRef?.handleKeyDown(event)) {
 		return;
 	}
 
@@ -1146,7 +1175,7 @@ function handleCommandSelect(command: AvailableCommand): void {
 	const cursorPos = getSerializedCursorOffset(editorRef);
 	const before = inputState.message.substring(0, inputState.slashStartIndex);
 	const after = inputState.message.substring(cursorPos);
-	const tokenText = toInlineTokenText("command", `/${command.name}`);
+	const tokenText = toInlineTokenText(slashCommandSource.tokenType, `/${command.name}`);
 	inputState.message = `${before}${tokenText} ${after}`;
 	inputState.showSlashDropdown = false;
 	inputState.slashQuery = "";
@@ -1559,7 +1588,7 @@ async function handleCancel() {
 				<SlashCommandDropdown
 					bind:this={inputState.slashDropdownRef}
 					commands={effectiveAvailableCommands}
-					isOpen={inputState.showSlashDropdown}
+					isOpen={isSlashDropdownVisible}
 					query={inputState.slashQuery}
 					position={inputState.slashPosition}
 					onSelect={(cmd: AvailableCommand) => handleCommandSelect(cmd)}

--- a/packages/desktop/src/lib/acp/components/agent-input/logic/slash-command-source.ts
+++ b/packages/desktop/src/lib/acp/components/agent-input/logic/slash-command-source.ts
@@ -1,0 +1,44 @@
+import type { AvailableCommand } from "$lib/acp/types/available-command.js";
+
+export type SlashCommandSource = {
+	source: "live" | "preconnection" | "none";
+	commands: AvailableCommand[];
+	tokenType: "command" | "skill";
+};
+
+export function resolveSlashCommandSource(input: {
+	liveCommands: ReadonlyArray<AvailableCommand>;
+	hasConnectedSession: boolean;
+	selectedAgentId: string | null;
+	preconnectionCommands: ReadonlyArray<AvailableCommand>;
+}): SlashCommandSource {
+	if (input.liveCommands.length > 0) {
+		return {
+			source: "live",
+			commands: Array.from(input.liveCommands),
+			tokenType: "command",
+		};
+	}
+
+	if (input.hasConnectedSession) {
+		return {
+			source: "none",
+			commands: [],
+			tokenType: "command",
+		};
+	}
+
+	if (input.selectedAgentId && input.preconnectionCommands.length > 0) {
+		return {
+			source: "preconnection",
+			commands: Array.from(input.preconnectionCommands),
+			tokenType: "skill",
+		};
+	}
+
+	return {
+		source: "none",
+		commands: [],
+		tokenType: "command",
+	};
+}

--- a/packages/desktop/src/lib/acp/components/agent-input/logic/slash-command-source.vitest.ts
+++ b/packages/desktop/src/lib/acp/components/agent-input/logic/slash-command-source.vitest.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it } from "vitest";
+import { resolveSlashCommandSource } from "./slash-command-source.js";
+
+describe("resolveSlashCommandSource", () => {
+	it("prefers live commands when they exist", () => {
+		const source = resolveSlashCommandSource({
+			liveCommands: [{ name: "review", description: "Review code" }],
+			hasConnectedSession: true,
+			selectedAgentId: "claude-code",
+			preconnectionCommands: [{ name: "ce:brainstorm", description: "Brainstorm" }],
+		});
+
+		expect(source).toEqual({
+			source: "live",
+			commands: [{ name: "review", description: "Review code" }],
+			tokenType: "command",
+		});
+	});
+
+	it("uses preconnection commands when live commands are absent", () => {
+		const source = resolveSlashCommandSource({
+			liveCommands: [],
+			hasConnectedSession: false,
+			selectedAgentId: "claude-code",
+			preconnectionCommands: [{ name: "ce:brainstorm", description: "Brainstorm" }],
+		});
+
+		expect(source).toEqual({
+			source: "preconnection",
+			commands: [{ name: "ce:brainstorm", description: "Brainstorm" }],
+			tokenType: "skill",
+		});
+	});
+
+	it("returns none when no selected agent or no commands exist", () => {
+		const source = resolveSlashCommandSource({
+			liveCommands: [],
+			hasConnectedSession: false,
+			selectedAgentId: null,
+			preconnectionCommands: [],
+		});
+
+		expect(source).toEqual({
+			source: "none",
+			commands: [],
+			tokenType: "command",
+		});
+	});
+
+	it("does not fall back to preconnection skills after connection when live commands are empty", () => {
+		const source = resolveSlashCommandSource({
+			liveCommands: [],
+			hasConnectedSession: true,
+			selectedAgentId: "claude-code",
+			preconnectionCommands: [{ name: "ce:brainstorm", description: "Brainstorm" }],
+		});
+
+		expect(source).toEqual({
+			source: "none",
+			commands: [],
+			tokenType: "command",
+		});
+	});
+});

--- a/packages/desktop/src/lib/acp/components/agent-input/state/agent-input-state.svelte.ts
+++ b/packages/desktop/src/lib/acp/components/agent-input/state/agent-input-state.svelte.ts
@@ -7,7 +7,6 @@ import type { ProjectIndex } from "../../../../services/converted-session-types.
 import { LOGGER_IDS } from "../../../constants/logger-ids.js";
 import type { PanelStore } from "../../../store/panel-store.svelte.js";
 import type { SessionStore } from "../../../store/session-store.svelte.js";
-import type { AvailableCommand } from "../../../types/available-command.js";
 import type { FilePickerEntry } from "../../../types/file-picker-entry.js";
 import { createLogger } from "../../../utils/logger.js";
 
@@ -873,24 +872,6 @@ export class AgentInputState {
 	// ============================================
 
 	/**
-	 * Handles selection of a slash command.
-	 *
-	 * @param command - The selected command
-	 */
-	handleCommandSelect(command: AvailableCommand): void {
-		// Replace "/partial" with an inline command token.
-		const before = this.message.substring(0, this.slashStartIndex);
-		const cursorPos = this.textareaRef?.selectionStart ?? this.message.length;
-		const after = this.message.substring(cursorPos);
-		const tokenType = this.isSkillCommand(command) ? "skill" : "command";
-		this.message = `${before}@[${tokenType}:/${command.name}] ${after}`;
-		this.showSlashDropdown = false;
-		this.slashQuery = "";
-
-		this.focusInput();
-	}
-
-	/**
 	 * Closes the slash command dropdown.
 	 */
 	handleDropdownClose(): void {
@@ -1045,8 +1026,4 @@ export class AgentInputState {
 		}
 	}
 
-	private isSkillCommand(command: AvailableCommand): boolean {
-		const desc = command.description.toLowerCase();
-		return desc.includes("skill") || command.name.includes("_");
-	}
 }

--- a/packages/desktop/src/lib/components/main-app-view.svelte
+++ b/packages/desktop/src/lib/components/main-app-view.svelte
@@ -58,6 +58,7 @@ import type { PlanData } from "$lib/services/converted-session-types.js";
 import { createNotificationPreferencesStore } from "$lib/stores/notification-preferences-store.svelte.js";
 import { createVoiceSettingsStore } from "$lib/stores/voice-settings-store.svelte.js";
 import { createWindowFocusStore } from "$lib/stores/window-focus-store.svelte.js";
+import { createPreconnectionAgentSkillsStore } from "$lib/skills/store/preconnection-agent-skills-store.svelte.js";
 import { tauriClient } from "$lib/utils/tauri-client.js";
 import { playSound, preloadSound } from "$lib/acp/utils/sound.js";
 import { SoundEffect } from "$lib/acp/types/sounds.js";
@@ -154,6 +155,7 @@ const tabBarStore = createTabBarStore(
 
 // Create voice settings store (context for voice-section and agent-input-ui)
 const voiceSettingsStore = createVoiceSettingsStore();
+const preconnectionAgentSkillsStore = createPreconnectionAgentSkillsStore();
 
 // Wire unseen-clear on panel focus
 panelStore.onPanelFocused = (panelId) => {
@@ -382,7 +384,8 @@ const viewState = new MainAppViewState(
 	agentPreferencesStore,
 	kb,
 	selectorRegistry,
-	worktreeDefaultStore
+	worktreeDefaultStore,
+	preconnectionAgentSkillsStore
 );
 
 // Add repository dialog (unified import/clone/browse modal)

--- a/packages/desktop/src/lib/components/main-app-view/logic/main-app-view-state.svelte.ts
+++ b/packages/desktop/src/lib/components/main-app-view/logic/main-app-view-state.svelte.ts
@@ -33,6 +33,7 @@ import type {
 import type { WorkspaceStore } from "$lib/acp/store/workspace-store.svelte.js";
 import { CHANGELOG, type ChangelogEntry } from "$lib/changelog/index.js";
 import type { KeybindingsService } from "$lib/keybindings/service.svelte.js";
+import type { PreconnectionAgentSkillsStore } from "$lib/skills/store/preconnection-agent-skills-store.svelte.js";
 import { getSqlStudioStore } from "$lib/sql-studio/index.js";
 import type { MainAppViewError } from "../errors/main-app-view-error.js";
 import type { CreateSessionOptions } from "../types/create-session-options.js";
@@ -253,6 +254,7 @@ export class MainAppViewState {
 	 * @param keybindingsService - The keybindings service
 	 * @param selectorRegistry - The selector registry
 	 * @param worktreeDefaultStore - Single source for "use worktrees by default" (reactive)
+	 * @param preconnectionAgentSkillsStore - Startup-loaded agent skills for pre-connect slash commands
 	 */
 	constructor(
 		private readonly sessionStore: SessionStore,
@@ -264,7 +266,8 @@ export class MainAppViewState {
 		private readonly agentPreferencesStore: AgentPreferencesStore,
 		private readonly keybindingsService: KeybindingsService,
 		private readonly selectorRegistry: SelectorRegistry,
-		private readonly worktreeDefaultStore: WorktreeDefaultStore
+		private readonly worktreeDefaultStore: WorktreeDefaultStore,
+		private readonly preconnectionAgentSkillsStore: PreconnectionAgentSkillsStore
 	) {
 		// Initialize managers
 		this.initializationManager = new InitializationManager(
@@ -275,7 +278,8 @@ export class MainAppViewState {
 			this.workspaceStore,
 			this.projectManager,
 			this.agentPreferencesStore,
-			this.keybindingsService
+			this.keybindingsService,
+			this.preconnectionAgentSkillsStore
 		);
 		this.sessionHandler = new SessionHandler(
 			this,

--- a/packages/desktop/src/lib/components/main-app-view/logic/managers/initialization-manager.ts
+++ b/packages/desktop/src/lib/components/main-app-view/logic/managers/initialization-manager.ts
@@ -51,6 +51,7 @@ import type { WorkspaceStore } from "$lib/acp/store/workspace-store.svelte.js";
 import { createLogger } from "$lib/acp/utils/logger.js";
 import { getChangelogEntriesSince } from "$lib/changelog/index.js";
 import type { KeybindingsService } from "$lib/keybindings/service.svelte.js";
+import type { PreconnectionAgentSkillsStore } from "$lib/skills/store/preconnection-agent-skills-store.svelte.js";
 import { getZoomService } from "$lib/services/zoom.svelte.js";
 import type { MainAppViewState } from "../main-app-view-state.svelte.js";
 
@@ -88,7 +89,8 @@ export class InitializationManager {
 		private readonly workspaceStore: WorkspaceStore,
 		private readonly projectManager: ProjectManager,
 		private readonly agentPreferencesStore: AgentPreferencesStore,
-		private readonly keybindingsService: KeybindingsService
+		private readonly keybindingsService: KeybindingsService,
+		private readonly preconnectionAgentSkillsStore: PreconnectionAgentSkillsStore
 	) {}
 
 	/**
@@ -309,6 +311,12 @@ export class InitializationManager {
 					(error) =>
 						new InitializationError("initializeZoom", error instanceof Error ? error : undefined)
 				),
+			this.preconnectionAgentSkillsStore.initialize().orElse((error) => {
+				logger.warn("Failed to warm preconnection agent skills; continuing startup", {
+					error,
+				});
+				return okAsync(undefined);
+			}),
 		]).map(() => undefined);
 	}
 

--- a/packages/desktop/src/lib/components/main-app-view/tests/initialization-manager.vitest.ts
+++ b/packages/desktop/src/lib/components/main-app-view/tests/initialization-manager.vitest.ts
@@ -1,6 +1,6 @@
-import { beforeEach, describe, expect, it, mock } from "bun:test";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import { errAsync, okAsync } from "neverthrow";
-import { AgentError } from "$lib/acp/errors/app-error.js";
+import { AgentError } from "../../../acp/errors/app-error";
 import type { ProjectManager } from "$lib/acp/logic/project-manager.svelte.js";
 import type { AgentPreferencesStore } from "$lib/acp/store/agent-preferences-store.svelte.js";
 import type { AgentStore } from "$lib/acp/store/agent-store.svelte.js";
@@ -8,9 +8,9 @@ import type { PanelStore } from "$lib/acp/store/panel-store.svelte.js";
 import type { SessionStore } from "$lib/acp/store/session-store.svelte.js";
 import type { WorkspaceStore } from "$lib/acp/store/workspace-store.svelte.js";
 import type { KeybindingsService } from "$lib/keybindings/service.svelte.js";
+import type { PreconnectionAgentSkillsStore } from "$lib/skills/store/preconnection-agent-skills-store.svelte.js";
 
-// Mock the zoom service module to avoid $state runtime issues
-mock.module("$lib/services/zoom.svelte.js", () => ({
+vi.mock("$lib/services/zoom.svelte.js", () => ({
 	getZoomService: () => ({
 		initialize: () => okAsync(undefined),
 		zoomIn: () => okAsync(undefined),
@@ -48,13 +48,14 @@ describe("InitializationManager", () => {
 	let mockProjectManager: ProjectManager;
 	let mockAgentPreferencesStore: AgentPreferencesStore;
 	let mockKeybindingsService: KeybindingsService;
+	let mockPreconnectionAgentSkillsStore: PreconnectionAgentSkillsStore;
 	let manager: InitializationManager;
 
 	beforeEach(() => {
 		// Mock window for keybindings service
 		global.window = {
-			addEventListener: mock(() => {}),
-			removeEventListener: mock(() => {}),
+			addEventListener: vi.fn(() => {}),
+			removeEventListener: vi.fn(() => {}),
 		} as unknown as Window & typeof globalThis;
 
 		// Create mocks
@@ -68,31 +69,31 @@ describe("InitializationManager", () => {
 		} as unknown as MainAppViewState;
 
 		mockSessionStore = {
-			initializeSessionUpdates: mock(() => okAsync(undefined)),
-			loadSessions: mock(() => okAsync([])),
-			loadStartupSessions: mock(() => okAsync({ missing: [] })),
-			preloadSessions: mock(() => okAsync({ loaded: [], missing: [] })),
-			loadSessionById: mock(() => okAsync({ id: "session-1" })),
-			isPreloaded: mock(() => false),
-			connectSession: mock(() => okAsync({})),
-			scanSessions: mock(() => okAsync(undefined)),
-			createSession: mock(() => okAsync({ id: "session-1" })),
-			getSessionCold: mock(() => undefined),
+			initializeSessionUpdates: vi.fn(() => okAsync(undefined)),
+			loadSessions: vi.fn(() => okAsync([])),
+			loadStartupSessions: vi.fn(() => okAsync({ missing: [] })),
+			preloadSessions: vi.fn(() => okAsync({ loaded: [], missing: [] })),
+			loadSessionById: vi.fn(() => okAsync({ id: "session-1" })),
+			isPreloaded: vi.fn(() => false),
+			connectSession: vi.fn(() => okAsync({})),
+			scanSessions: vi.fn(() => okAsync(undefined)),
+			createSession: vi.fn(() => okAsync({ id: "session-1" })),
+			getSessionCold: vi.fn(() => undefined),
 		} as unknown as SessionStore;
 
 		mockAgentStore = {
-			loadAvailableAgents: mock(() => okAsync([])),
+			loadAvailableAgents: vi.fn(() => okAsync([])),
 		} as unknown as AgentStore;
 
 		mockPanelStore = {
 			panels: [],
-			updatePanelSession: mock(() => {}),
-			closePanelBySessionId: mock(() => {}),
-			clearPanels: mock(() => {}),
+			updatePanelSession: vi.fn(() => {}),
+			closePanelBySessionId: vi.fn(() => {}),
+			clearPanels: vi.fn(() => {}),
 		} as unknown as PanelStore;
 
 		mockWorkspaceStore = {
-			load: mock(() =>
+			load: vi.fn(() =>
 				okAsync({
 					version: 1,
 					panels: [],
@@ -101,28 +102,32 @@ describe("InitializationManager", () => {
 					savedAt: new Date().toISOString(),
 				})
 			),
-			restore: mock(() => []),
+			restore: vi.fn(() => []),
 		} as unknown as WorkspaceStore;
 
 		mockProjectManager = {
 			recentProjects: [],
 			projects: [],
 			projectCount: 0,
-			loadProjects: mock(() => okAsync(undefined)),
+			loadProjects: vi.fn(() => okAsync(undefined)),
 		} as unknown as ProjectManager;
 
 		mockAgentPreferencesStore = {
-			initialize: mock(() => okAsync(undefined)),
+			initialize: vi.fn(() => okAsync(undefined)),
 		} as unknown as AgentPreferencesStore;
 
 		mockKeybindingsService = {
-			initialize: mock(() => ({ isOk: () => true, isErr: () => false })),
-			upsertAction: mock(() => {}),
-			install: mock(() => {}),
-			loadUserKeybindings: mock(() => okAsync(undefined)),
-			reinstall: mock(() => {}),
-			uninstall: mock(() => {}),
+			initialize: vi.fn(() => ({ isOk: () => true, isErr: () => false })),
+			upsertAction: vi.fn(() => {}),
+			install: vi.fn(() => {}),
+			loadUserKeybindings: vi.fn(() => okAsync(undefined)),
+			reinstall: vi.fn(() => {}),
+			uninstall: vi.fn(() => {}),
 		} as unknown as KeybindingsService;
+
+		mockPreconnectionAgentSkillsStore = {
+			initialize: vi.fn(() => okAsync(undefined)),
+		} as unknown as PreconnectionAgentSkillsStore;
 
 		manager = new InitializationManager(
 			mockState,
@@ -132,7 +137,8 @@ describe("InitializationManager", () => {
 			mockWorkspaceStore,
 			mockProjectManager,
 			mockAgentPreferencesStore,
-			mockKeybindingsService
+			mockKeybindingsService,
+			mockPreconnectionAgentSkillsStore
 		);
 	});
 
@@ -168,16 +174,28 @@ describe("InitializationManager", () => {
 			expect(mockSessionStore.initializeSessionUpdates).toHaveBeenCalled();
 		});
 
-		it("should load keybindings, agents, and projects in parallel", async () => {
+		it("should load keybindings, agents, projects, and preconnection skills in parallel", async () => {
 			await manager.initialize();
 			expect(mockKeybindingsService.loadUserKeybindings).toHaveBeenCalled();
 			expect(mockAgentStore.loadAvailableAgents).toHaveBeenCalled();
 			expect(mockProjectManager.loadProjects).toHaveBeenCalled();
+			expect(mockPreconnectionAgentSkillsStore.initialize).toHaveBeenCalled();
 		});
 
 		it("should initialize agent preferences after loading metadata", async () => {
 			await manager.initialize();
 			expect(mockAgentPreferencesStore.initialize).toHaveBeenCalled();
+		});
+
+		it("continues startup when preconnection skills warming fails", async () => {
+			mockPreconnectionAgentSkillsStore.initialize = vi.fn(() =>
+				errAsync(new AgentError("skills_list_agent_skills", new Error("Failed")))
+			) as unknown as PreconnectionAgentSkillsStore["initialize"];
+
+			const result = await manager.initialize();
+
+			expect(result.isOk()).toBe(true);
+			expect(mockState.initializationComplete).toBe(true);
 		});
 
 		it("should restore workspace state", async () => {
@@ -215,7 +233,7 @@ describe("InitializationManager", () => {
 				configurable: true,
 				get: () => currentPanels,
 			});
-			mockPanelStore.updatePanelSession = mock((panelId: string, sessionId: string | null) => {
+			mockPanelStore.updatePanelSession = vi.fn((panelId: string, sessionId: string | null) => {
 				currentPanels = currentPanels.map((panel) =>
 					panel.id === panelId ? { ...panel, sessionId } : panel
 				);
@@ -246,7 +264,7 @@ describe("InitializationManager", () => {
 					sessionTitle: null,
 				},
 			];
-			mockSessionStore.getSessionCold = mock((sessionId: string) =>
+			mockSessionStore.getSessionCold = vi.fn((sessionId: string) =>
 				sessionId === "session-1"
 					? {
 						id: "session-1",
@@ -308,7 +326,7 @@ describe("InitializationManager", () => {
 		});
 
 		it("should handle initialization errors", async () => {
-			mockAgentStore.loadAvailableAgents = mock(() =>
+			mockAgentStore.loadAvailableAgents = vi.fn(() =>
 				errAsync(new AgentError("loadAgents", new Error("Failed")))
 			);
 			const result = await manager.initialize();

--- a/packages/desktop/src/lib/components/main-app-view/tests/main-app-view-state.vitest.ts
+++ b/packages/desktop/src/lib/components/main-app-view/tests/main-app-view-state.vitest.ts
@@ -20,6 +20,7 @@ import type { WorkspaceStore } from "$lib/acp/store/workspace-store.svelte.js";
 import type { KeybindingsService } from "$lib/keybindings/service.svelte.js";
 import type { SelectorRegistry } from "$lib/acp/logic/selector-registry.svelte.js";
 import type { WorktreeDefaultStore } from "$lib/acp/components/worktree-toggle/worktree-default-store.svelte.js";
+import type { PreconnectionAgentSkillsStore } from "$lib/skills/store/preconnection-agent-skills-store.svelte.js";
 import { MainAppViewState } from "../logic/main-app-view-state.svelte.js";
 
 function createState(options?: {
@@ -65,7 +66,8 @@ function createState(options?: {
 			toggleFocused: vi.fn(),
 			cycleFocused: vi.fn(),
 		} as unknown as SelectorRegistry,
-		{} as WorktreeDefaultStore
+		{} as WorktreeDefaultStore,
+		{} as PreconnectionAgentSkillsStore
 	);
 
 	return { state, workspaceStore, panelStore, projectManager };

--- a/packages/desktop/src/lib/skills/api/skills-api.ts
+++ b/packages/desktop/src/lib/skills/api/skills-api.ts
@@ -10,6 +10,7 @@ import type { ResultAsync } from "neverthrow";
 import type { AppError } from "../../acp/errors/app-error.js";
 import { tauriClient } from "../../utils/tauri-client.js";
 import type {
+	AgentSkillsGroup,
 	LibrarySkill,
 	LibrarySkillWithSync,
 	PluginInfo,
@@ -20,6 +21,13 @@ import type {
 	SyncResult,
 	SyncTarget,
 } from "../types/index.js";
+
+/**
+ * List parsed skills for all configured agents.
+ */
+export function listAgentSkills(): ResultAsync<AgentSkillsGroup[], AppError> {
+	return tauriClient.skills.listAgentSkills();
+}
 
 /**
  * List all agents and their skills as a tree structure.
@@ -102,6 +110,7 @@ export function onSkillsChanged(
  * Skills API object for convenient access.
  */
 export const skillsApi = {
+	listAgentSkills,
 	listTree,
 	getSkill,
 	createSkill,

--- a/packages/desktop/src/lib/skills/store/preconnection-agent-skills-store.svelte.ts
+++ b/packages/desktop/src/lib/skills/store/preconnection-agent-skills-store.svelte.ts
@@ -1,0 +1,97 @@
+import { okAsync, type ResultAsync } from "neverthrow";
+import { getContext, setContext } from "svelte";
+import { SvelteMap } from "svelte/reactivity";
+import type { AvailableCommand } from "$lib/acp/types/available-command.js";
+import type { AppError } from "$lib/acp/errors/app-error.js";
+import { createLogger } from "$lib/acp/utils/logger.js";
+import { skillsApi } from "../api/skills-api.js";
+import type { AgentSkillsGroup, Skill } from "../types/index.js";
+
+const PRECONNECTION_AGENT_SKILLS_STORE_KEY = Symbol("preconnection-agent-skills-store");
+const logger = createLogger({
+	id: "preconnection-agent-skills-store",
+	name: "PreconnectionAgentSkillsStore",
+});
+
+export function normalizeAgentSkillsToCommands(skills: Skill[]): AvailableCommand[] {
+	const commands: AvailableCommand[] = [];
+	const seenNames = new Set<string>();
+
+	for (const skill of skills) {
+		const commandName = skill.name;
+		if (seenNames.has(commandName)) {
+			logger.warn("Skipping duplicate preconnection skill command", {
+				agentId: skill.agentId,
+				commandName,
+				folderName: skill.folderName,
+			});
+			continue;
+		}
+
+		seenNames.add(commandName);
+		commands.push({
+			name: commandName,
+			description: skill.description,
+		});
+	}
+
+	return commands;
+}
+
+export class PreconnectionAgentSkillsStore {
+	loading = $state(false);
+	loaded = $state(false);
+	error = $state<string | null>(null);
+	private readonly commandsByAgent = new SvelteMap<string, AvailableCommand[]>();
+
+	initialize(): ResultAsync<void, AppError> {
+		if (this.loading || this.loaded) {
+			return okAsync(undefined);
+		}
+
+		this.loading = true;
+		this.error = null;
+
+		return skillsApi
+			.listAgentSkills()
+			.map((groups) => {
+				this.replaceCommands(groups);
+				this.loading = false;
+				this.loaded = true;
+			})
+			.mapErr((error) => {
+				this.commandsByAgent.clear();
+				this.loading = false;
+				this.loaded = false;
+				this.error = error.message;
+				return error;
+			});
+	}
+
+	getCommandsForAgent(agentId: string | null | undefined): AvailableCommand[] {
+		if (!agentId) {
+			return [];
+		}
+
+		const commands = this.commandsByAgent.get(agentId);
+		return commands ? commands : [];
+	}
+
+	private replaceCommands(groups: AgentSkillsGroup[]): void {
+		this.commandsByAgent.clear();
+
+		for (const group of groups) {
+			this.commandsByAgent.set(group.agentId, normalizeAgentSkillsToCommands(group.skills));
+		}
+	}
+}
+
+export function createPreconnectionAgentSkillsStore(): PreconnectionAgentSkillsStore {
+	const store = new PreconnectionAgentSkillsStore();
+	setContext(PRECONNECTION_AGENT_SKILLS_STORE_KEY, store);
+	return store;
+}
+
+export function getPreconnectionAgentSkillsStore(): PreconnectionAgentSkillsStore {
+	return getContext<PreconnectionAgentSkillsStore>(PRECONNECTION_AGENT_SKILLS_STORE_KEY);
+}

--- a/packages/desktop/src/lib/skills/store/preconnection-agent-skills-store.vitest.ts
+++ b/packages/desktop/src/lib/skills/store/preconnection-agent-skills-store.vitest.ts
@@ -1,0 +1,143 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { errAsync, okAsync } from "neverthrow";
+import { AgentError } from "../../acp/errors/app-error";
+import { skillsApi } from "../api/skills-api.js";
+import {
+	normalizeAgentSkillsToCommands,
+	PreconnectionAgentSkillsStore,
+} from "./preconnection-agent-skills-store.svelte.js";
+
+vi.mock("../api/skills-api.js", () => ({
+	skillsApi: {
+		listAgentSkills: vi.fn(),
+	},
+}));
+
+describe("PreconnectionAgentSkillsStore", () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+	});
+
+	it("normalizes skills by agent using frontmatter name and description", async () => {
+		vi.mocked(skillsApi.listAgentSkills).mockReturnValue(
+			okAsync([
+				{
+					agentId: "claude-code",
+					skills: [
+						{
+							id: "claude-code::ce-brainstorm",
+							agentId: "claude-code",
+							folderName: "ce-brainstorm",
+							path: "/tmp/ce-brainstorm/SKILL.md",
+							name: "ce:brainstorm",
+							description: "Brainstorm a feature",
+							content: "",
+							modifiedAt: 1,
+						},
+					],
+				},
+				{
+					agentId: "cursor",
+					skills: [],
+				},
+			])
+		);
+
+		const store = new PreconnectionAgentSkillsStore();
+		const result = await store.initialize();
+
+		expect(result.isOk()).toBe(true);
+		expect(store.loaded).toBe(true);
+		expect(store.getCommandsForAgent("claude-code")).toEqual([
+			{
+				name: "ce:brainstorm",
+				description: "Brainstorm a feature",
+			},
+		]);
+		expect(store.getCommandsForAgent("cursor")).toEqual([]);
+	});
+
+	it("drops later duplicate names within one agent deterministically", () => {
+		const commands = normalizeAgentSkillsToCommands([
+			{
+				id: "claude-code::ce-brainstorm",
+				agentId: "claude-code",
+				folderName: "ce-brainstorm",
+				path: "/tmp/one/SKILL.md",
+				name: "ce:brainstorm",
+				description: "First description",
+				content: "",
+				modifiedAt: 1,
+			},
+			{
+				id: "claude-code::brainstorm-duplicate",
+				agentId: "claude-code",
+				folderName: "brainstorm-duplicate",
+				path: "/tmp/two/SKILL.md",
+				name: "ce:brainstorm",
+				description: "Second description",
+				content: "",
+				modifiedAt: 2,
+			},
+		]);
+
+		expect(commands).toEqual([
+			{
+				name: "ce:brainstorm",
+				description: "First description",
+			},
+		]);
+	});
+
+	it("keeps the store retryable when initialization fails", async () => {
+		vi.mocked(skillsApi.listAgentSkills).mockReturnValue(
+			errAsync(new AgentError("skills_list_agent_skills", new Error("boom")))
+		);
+
+		const store = new PreconnectionAgentSkillsStore();
+		const result = await store.initialize();
+
+		expect(result.isErr()).toBe(true);
+		expect(store.loaded).toBe(false);
+		expect(store.error).toBe("Agent operation failed: skills_list_agent_skills");
+		expect(store.getCommandsForAgent("claude-code")).toEqual([]);
+	});
+
+	it("can retry successfully after an initialization failure", async () => {
+		const mockedListAgentSkills = vi.mocked(skillsApi.listAgentSkills);
+		mockedListAgentSkills
+			.mockReturnValueOnce(errAsync(new AgentError("skills_list_agent_skills", new Error("boom"))))
+			.mockReturnValueOnce(
+				okAsync([
+					{
+						agentId: "claude-code",
+						skills: [
+							{
+								id: "claude-code::ce-plan",
+								agentId: "claude-code",
+								folderName: "ce-plan",
+								path: "/tmp/ce-plan/SKILL.md",
+								name: "ce:plan",
+								description: "Plan implementation",
+								content: "",
+								modifiedAt: 1,
+							},
+						],
+					},
+				])
+			);
+
+		const store = new PreconnectionAgentSkillsStore();
+		const firstResult = await store.initialize();
+		const secondResult = await store.initialize();
+
+		expect(firstResult.isErr()).toBe(true);
+		expect(secondResult.isOk()).toBe(true);
+		expect(store.getCommandsForAgent("claude-code")).toEqual([
+			{
+				name: "ce:plan",
+				description: "Plan implementation",
+			},
+		]);
+	});
+});

--- a/packages/desktop/src/lib/skills/types/agent-skills-group.ts
+++ b/packages/desktop/src/lib/skills/types/agent-skills-group.ts
@@ -1,0 +1,11 @@
+import type { Skill } from "./skill.js";
+
+/**
+ * Parsed skills grouped by agent for startup consumers.
+ */
+export interface AgentSkillsGroup {
+	/** Agent ID these skills belong to. */
+	agentId: string;
+	/** Parsed skills for this agent. */
+	skills: Skill[];
+}

--- a/packages/desktop/src/lib/skills/types/index.ts
+++ b/packages/desktop/src/lib/skills/types/index.ts
@@ -1,4 +1,5 @@
 // Unified library types
+export type { AgentSkillsGroup } from "./agent-skills-group.js";
 export type { LibrarySkill } from "./library-skill.js";
 export type { LibrarySkillWithSync } from "./library-skill-with-sync.js";
 // Plugin types

--- a/packages/desktop/src/lib/utils/tauri-client/commands.ts
+++ b/packages/desktop/src/lib/utils/tauri-client/commands.ts
@@ -176,6 +176,7 @@ export const CMD = {
 	} as const,
 
 	skills: {
+		list_agent_skills: "skills_list_agent_skills",
 		list_tree: "skills_list_tree",
 		get: "skills_get",
 		create: "skills_create",

--- a/packages/desktop/src/lib/utils/tauri-client/skills.ts
+++ b/packages/desktop/src/lib/utils/tauri-client/skills.ts
@@ -1,6 +1,7 @@
 import type { ResultAsync } from "neverthrow";
 import type { AppError } from "../../acp/errors/app-error.js";
 import type {
+	AgentSkillsGroup,
 	LibrarySkill,
 	LibrarySkillWithSync,
 	PluginInfo,
@@ -15,6 +16,10 @@ import { CMD } from "./commands.js";
 import { invokeAsync } from "./invoke.js";
 
 export const skills = {
+	listAgentSkills: (): ResultAsync<AgentSkillsGroup[], AppError> => {
+		return invokeAsync(CMD.skills.list_agent_skills);
+	},
+
 	listTree: (): ResultAsync<SkillTreeNode[], AppError> => {
 		return invokeAsync(CMD.skills.list_tree);
 	},


### PR DESCRIPTION
## Summary
- load grouped on-disk agent skills at app startup so a selected agent can surface slash skills before an ACP session connects
- switch the slash dropdown source back to live session commands after connection, without merging cached skills into connected sessions
- tolerate missing or unreadable skill directories during startup so preconnection warmup never blocks the app

## Testing
- cd packages/desktop && bunx vitest run src/lib/skills/store/preconnection-agent-skills-store.vitest.ts src/lib/acp/components/agent-input/logic/slash-command-source.vitest.ts src/lib/components/main-app-view/tests/initialization-manager.vitest.ts src/lib/components/main-app-view/tests/main-app-view-state.vitest.ts
- cd packages/desktop && bun run check
- cd packages/desktop/src-tauri && cargo test --lib skills::service
- cd packages/desktop/src-tauri && cargo clippy --lib --tests -- -D warnings