### PR TITLE
fix: align cc-sdk session ID with Acepe session ID

### DIFF
--- a/file.txt
+++ b/file.txt
@@ -1,1 +1,0 @@
-original

--- a/packages/desktop/src-tauri/Cargo.toml
+++ b/packages/desktop/src-tauri/Cargo.toml
@@ -114,6 +114,6 @@ tokio-test = "0.4"
 insta = { version = "1", features = ["json"] }
 hound = "3"
 
-# TODO: switch back to crates.io once ZhangHanDong/claude-code-api-rs#14 is merged and released
+# TODO(ZhangHanDong/claude-code-api-rs#14): switch back to crates.io once upstream PR is merged and released
 [patch.crates-io]
-cc-sdk = { git = "https://github.com/flazouh/claude-code-api-rs.git", branch = "feature/explicit-session-id" }
+cc-sdk = { git = "https://github.com/flazouh/claude-code-api-rs.git", rev = "dc6ac1027a96c0700adf1ac2851ee86bf423ca8b" }


### PR DESCRIPTION
## Summary

- Pass Acepe's session ID through `ClaudeCodeOptions::session_id()` so Claude CLI uses the same identity instead of hardcoding `"default"`
- Use fork of cc-sdk via `[patch.crates-io]` until upstream PR is merged

Upstream PR: ZhangHanDong/claude-code-api-rs#14

## Test plan

- [x] `cargo check` passes
- [x] `cargo test` — 1246 passed, 0 failures
- [ ] Manual: verify streaming log shows matching session IDs for `in` and `out` events
- [ ] Manual: verify resume session works with canonical ID