### PR TITLE
fix(website): bypass download proxy for macOS release

### DIFF
--- a/packages/website/src/routes/api/download/+server.ts
+++ b/packages/website/src/routes/api/download/+server.ts
@@ -1,6 +1,9 @@
 import { error, redirect } from '@sveltejs/kit';
 import type { RequestHandler } from './$types';
 
+const GITHUB_RELEASES_API_URL = 'https://api.github.com/repos/flazouh/acepe/releases/latest';
+const GITHUB_RELEASES_LATEST_URL = 'https://github.com/flazouh/acepe/releases/latest';
+
 export const GET: RequestHandler = async ({ url }) => {
 	const arch = url.searchParams.get('arch');
 
@@ -8,12 +11,12 @@ export const GET: RequestHandler = async ({ url }) => {
 		throw error(400, 'Invalid architecture. Use ?arch=aarch64 or ?arch=x64');
 	}
 
-	const res = await fetch('https://api.github.com/repos/flazouh/acepe/releases/latest', {
+	const res = await fetch(GITHUB_RELEASES_API_URL, {
 		headers: { Accept: 'application/vnd.github+json' }
-	});
+	}).catch(() => null);
 
-	if (!res.ok) {
-		throw error(502, 'Failed to fetch latest release from GitHub');
+	if (!res || !res.ok) {
+		throw redirect(302, GITHUB_RELEASES_LATEST_URL);
 	}
 
 	const release = (await res.json()) as { assets: { name: string; browser_download_url: string }[] };
@@ -23,7 +26,7 @@ export const GET: RequestHandler = async ({ url }) => {
 	);
 
 	if (!asset) {
-		throw error(404, `No .dmg asset found for arch: ${arch}`);
+		throw redirect(302, GITHUB_RELEASES_LATEST_URL);
 	}
 
 	throw redirect(302, asset.browser_download_url);

--- a/packages/website/src/routes/download/+page.server.ts
+++ b/packages/website/src/routes/download/+page.server.ts
@@ -2,8 +2,11 @@ import { dev } from '$app/environment';
 import { redirect } from '@sveltejs/kit';
 import type { PageServerLoad } from './$types';
 
+const GITHUB_RELEASES_API_URL = 'https://api.github.com/repos/flazouh/acepe/releases/latest';
+const GITHUB_RELEASES_BASE_URL = 'https://github.com/flazouh/acepe/releases';
+
 async function getLatestVersion(): Promise<string | null> {
-	const res = await fetch('https://api.github.com/repos/flazouh/acepe/releases/latest', {
+	const res = await fetch(GITHUB_RELEASES_API_URL, {
 		headers: { Accept: 'application/vnd.github+json' }
 	});
 
@@ -12,6 +15,14 @@ async function getLatestVersion(): Promise<string | null> {
 	const data = (await res.json()) as { tag_name?: string };
 	// tag_name is like "v2026.3.30" — strip the leading "v"
 	return data.tag_name ? data.tag_name.replace(/^v/, '') : null;
+}
+
+function getDownloadUrl(version: string | null): string {
+	if (!version) {
+		return `${GITHUB_RELEASES_BASE_URL}/latest`;
+	}
+
+	return `${GITHUB_RELEASES_BASE_URL}/download/v${version}/Acepe_${version}_aarch64.dmg`;
 }
 
 export const load: PageServerLoad = async ({ parent }) => {
@@ -23,5 +34,8 @@ export const load: PageServerLoad = async ({ parent }) => {
 
 	const version = await getLatestVersion();
 
-	return { version };
+	return {
+		version,
+		downloadUrl: getDownloadUrl(version)
+	};
 };

--- a/packages/website/src/routes/download/+page.svelte
+++ b/packages/website/src/routes/download/+page.svelte
@@ -61,7 +61,7 @@
 				<!-- Body -->
 				<div class="p-4">
 					<a
-						href="/api/download?arch=aarch64"
+						href={data.downloadUrl}
 						onclick={handleDownload}
 						class="theme-invert-btn flex h-9 w-full items-center justify-center gap-2 rounded-lg text-sm font-medium transition-colors"
 					>


### PR DESCRIPTION
## Summary
Fix the macOS download button so it no longer depends on the website origin being able to reach the GitHub Releases API at click time.

The download page now links directly to the current GitHub release asset, and the legacy download endpoint falls back to the GitHub releases page instead of surfacing upstream errors.

## Verification
1. bun run check
2. NODE_OPTIONS=--max-old-space-size=6144 bun run build

---

[![Compound Engineering vunknown](https://img.shields.io/badge/Compound_Engineering-vunknown-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
🤖 Generated with GPT-5.4 via GitHub Copilot