### PR TITLE
fix(acp): stabilize permission request identity

### DIFF
--- a/packages/desktop/src/lib/acp/logic/__tests__/inbound-request-handler.test.ts
+++ b/packages/desktop/src/lib/acp/logic/__tests__/inbound-request-handler.test.ts
@@ -111,11 +111,15 @@ describe("InboundRequestHandler", () => {
 
 			expect(permissionCallback).toHaveBeenCalledTimes(1);
 			const permission: PermissionRequest = permissionCallback.mock.calls[0][0];
-			expect(permission.id).toBe("tool-123");
+			expect(permission.id).toBe("tool-123::123");
 			expect(permission.sessionId).toBe("test-session");
 			expect(permission.jsonRpcRequestId).toBe(123);
 			expect(permission.permission).toBe("Run tests");
 			expect(permission.always).toEqual(["allow_always"]);
+			expect(permission.tool).toEqual({
+				messageID: "",
+				callID: "tool-123",
+			});
 		});
 
 		it("should reject request without id", async () => {
@@ -330,6 +334,52 @@ describe("InboundRequestHandler", () => {
 			expect(question.questions).toHaveLength(1);
 			expect(question.questions[0].question).toBe("Which framework do you prefer?");
 			expect(question.questions[0].header).toBe("Framework");
+			expect(question.questions[0].options).toHaveLength(2);
+			expect(question.questions[0].multiSelect).toBe(false);
+		});
+
+		it("should route upstream AskUserQuestion requests without _meta to question callback", async () => {
+			await handler.start(permissionCallback, questionCallback);
+
+			const request = {
+				id: 7,
+				jsonrpc: "2.0",
+				method: ACP_INBOUND_METHODS.REQUEST_PERMISSION,
+				params: {
+					sessionId: "session-7",
+					options: [{ kind: "allow", name: "Continue", optionId: "continue" }],
+					toolCall: {
+						toolCallId: "tc-question-7",
+						name: "AskUserQuestion",
+						rawInput: {
+							questions: [
+								{
+									question: "Which runtime should we use?",
+									header: "Runtime",
+									options: [
+										{ label: "Bun", description: "Fast runtime" },
+										{ label: "Node", description: "Broad compatibility" },
+									],
+									multiSelect: false,
+								},
+							],
+						},
+					},
+				},
+			};
+
+			eventCallback?.({ payload: request });
+
+			expect(questionCallback).toHaveBeenCalledTimes(1);
+			expect(permissionCallback).not.toHaveBeenCalled();
+
+			const question: QuestionRequest = questionCallback.mock.calls[0][0];
+			expect(question.id).toBe("tc-question-7");
+			expect(question.sessionId).toBe("session-7");
+			expect(question.jsonRpcRequestId).toBe(7);
+			expect(question.questions).toHaveLength(1);
+			expect(question.questions[0].question).toBe("Which runtime should we use?");
+			expect(question.questions[0].header).toBe("Runtime");
 			expect(question.questions[0].options).toHaveLength(2);
 			expect(question.questions[0].multiSelect).toBe(false);
 		});

--- a/packages/desktop/src/lib/acp/logic/inbound-request-handler.ts
+++ b/packages/desktop/src/lib/acp/logic/inbound-request-handler.ts
@@ -37,6 +37,10 @@ const logger = createLogger({
 	name: "Inbound Request Handler",
 });
 
+function buildPermissionRequestId(toolCallId: string, jsonRpcRequestId: number): string {
+	return `${toolCallId}::${jsonRpcRequestId}`;
+}
+
 /**
  * Callback type for permission request events.
  */
@@ -70,12 +74,12 @@ export class InboundRequestHandler {
 		if (this.unlistenFn !== null) {
 			logger.debug("Inbound request handler already running, skipping duplicate start");
 			this.onPermissionRequest = onPermissionRequest;
-			this.onQuestionRequest = onQuestionRequest ?? null;
+			this.onQuestionRequest = onQuestionRequest !== undefined ? onQuestionRequest : null;
 			return okAsync(undefined);
 		}
 
 		this.onPermissionRequest = onPermissionRequest;
-		this.onQuestionRequest = onQuestionRequest ?? null;
+		this.onQuestionRequest = onQuestionRequest !== undefined ? onQuestionRequest : null;
 
 		return openAcpEventSource((envelope) => {
 			if (envelope.eventName !== "acp-inbound-request") {
@@ -166,7 +170,7 @@ export class InboundRequestHandler {
 
 		// Upstream v0.18+: AskUserQuestion goes through canUseTool → requestPermission
 		// without _meta.askUserQuestion. Detect by tool name and extract questions from rawInput.
-		const toolName = params.toolCall.name ?? params.toolCall.title;
+		const toolName = params.toolCall.name !== undefined ? params.toolCall.name : params.toolCall.title;
 		const rawInputResult = RawInputWithQuestionsSchema.safeParse(params.toolCall.rawInput);
 		if (toolName === "AskUserQuestion" && rawInputResult.success && this.onQuestionRequest) {
 			this.handleQuestionRequest(request, params, {
@@ -175,12 +179,16 @@ export class InboundRequestHandler {
 			return;
 		}
 
-		// Create a permission request with the JSON-RPC request ID
+		// Create a permission request with a stable request identity.
 		const permission: PermissionRequest = {
-			id: params.toolCall.toolCallId,
+			id: buildPermissionRequestId(params.toolCall.toolCallId, request.id),
 			sessionId: params.sessionId,
 			jsonRpcRequestId: request.id,
-			permission: params.toolCall.title || params.toolCall.name || "Execute tool",
+			permission: params.toolCall.title
+				? params.toolCall.title
+				: params.toolCall.name
+					? params.toolCall.name
+					: "Execute tool",
 			patterns: [],
 			metadata: {
 				rawInput: params.toolCall.rawInput,
@@ -223,12 +231,14 @@ export class InboundRequestHandler {
 			jsonRpcRequestId: request.id,
 			questions: questionData.questions.map((q) => ({
 				question: q.question,
-				header: q.header ?? "",
-				options: (q.options ?? []).map((opt) => ({
-					label: opt.label,
-					description: opt.description ?? "",
-				})),
-				multiSelect: q.multiSelect ?? false,
+				header: q.header !== undefined ? q.header : "",
+				options: q.options !== undefined
+					? q.options.map((opt) => ({
+						label: opt.label,
+						description: opt.description !== undefined ? opt.description : "",
+					}))
+					: [],
+				multiSelect: q.multiSelect !== undefined ? q.multiSelect : false,
 			})),
 			tool: {
 				messageID: "",

--- a/packages/desktop/src/lib/acp/store/__tests__/permission-store.vitest.ts
+++ b/packages/desktop/src/lib/acp/store/__tests__/permission-store.vitest.ts
@@ -79,7 +79,7 @@ describe("PermissionStore", () => {
 
 		it("should add permission with jsonRpcRequestId", () => {
 			const permission: PermissionRequest = {
-				id: "perm-2",
+				id: "perm-2::123",
 				sessionId: "session-2",
 				jsonRpcRequestId: 123,
 				permission: "Bash",
@@ -95,7 +95,7 @@ describe("PermissionStore", () => {
 
 		it("should keep multiple ACP permissions for the same tool call", () => {
 			store.add({
-				id: "tool-1",
+				id: "tool-1::100",
 				sessionId: "session-1",
 				jsonRpcRequestId: 100,
 				permission: "Execute",
@@ -105,7 +105,7 @@ describe("PermissionStore", () => {
 				tool: { messageID: "", callID: "tool-1" },
 			});
 			store.add({
-				id: "tool-1",
+				id: "tool-1::101",
 				sessionId: "session-1",
 				jsonRpcRequestId: 101,
 				permission: "Execute",
@@ -122,7 +122,7 @@ describe("PermissionStore", () => {
 
 		it("should resolve permission by tool call id", () => {
 			store.add({
-				id: "tool-1",
+				id: "tool-1::100",
 				sessionId: "session-1",
 				jsonRpcRequestId: 100,
 				permission: "Execute",
@@ -132,7 +132,7 @@ describe("PermissionStore", () => {
 				tool: { messageID: "", callID: "tool-1" },
 			});
 			store.add({
-				id: "tool-1",
+				id: "tool-1::101",
 				sessionId: "session-1",
 				jsonRpcRequestId: 101,
 				permission: "Execute",
@@ -145,6 +145,7 @@ describe("PermissionStore", () => {
 			const permission = store.getForToolCall("tool-1");
 
 			expect(permission?.jsonRpcRequestId).toBe(101);
+			expect(permission?.id).toBe("tool-1::101");
 		});
 	});
 
@@ -243,7 +244,7 @@ describe("PermissionStore", () => {
 			store.setAutoAccept((p) => p.sessionId === "child-session");
 
 			const permission: PermissionRequest = {
-				id: "perm-child",
+				id: "perm-child::200",
 				sessionId: "child-session",
 				jsonRpcRequestId: 200,
 				permission: "Bash",
@@ -282,7 +283,7 @@ describe("PermissionStore", () => {
 			store.setAutoAccept(() => true);
 
 			const permission: PermissionRequest = {
-				id: "perm-opts",
+				id: "perm-opts::300",
 				sessionId: "child-session",
 				jsonRpcRequestId: 300,
 				permission: "Bash",
@@ -344,7 +345,7 @@ describe("PermissionStore", () => {
 			const { respondToPermission } = await import("../../logic/inbound-request-handler.js");
 
 			const permission: PermissionRequest = {
-				id: "perm-jsonrpc",
+				id: "perm-jsonrpc::456",
 				sessionId: "session-jsonrpc",
 				jsonRpcRequestId: 456,
 				permission: "Bash",
@@ -365,7 +366,7 @@ describe("PermissionStore", () => {
 			const { respondToPermission } = await import("../../logic/inbound-request-handler.js");
 
 			const permission: PermissionRequest = {
-				id: "perm-always",
+				id: "perm-always::789",
 				sessionId: "session-always",
 				jsonRpcRequestId: 789,
 				permission: "Bash",
@@ -384,7 +385,7 @@ describe("PermissionStore", () => {
 			const { respondToPermission } = await import("../../logic/inbound-request-handler.js");
 
 			const permission: PermissionRequest = {
-				id: "perm-reject",
+				id: "perm-reject::101",
 				sessionId: "session-reject",
 				jsonRpcRequestId: 101,
 				permission: "Bash",

--- a/packages/desktop/src/lib/acp/store/permission-store.svelte.ts
+++ b/packages/desktop/src/lib/acp/store/permission-store.svelte.ts
@@ -39,13 +39,6 @@ export class PermissionStore {
 		};
 	}
 
-	private buildStorageKey(permission: PermissionRequest): string {
-		if (permission.jsonRpcRequestId !== undefined) {
-			return `${permission.id}::${permission.jsonRpcRequestId}`;
-		}
-		return permission.id;
-	}
-
 	/**
 	 * Add a pending permission request.
 	 *
@@ -53,19 +46,15 @@ export class PermissionStore {
 	 * when an `isChildSession` check is configured via `setChildSessionCheck()`.
 	 */
 	add(permission: PermissionRequest): void {
-		const storageKey = this.buildStorageKey(permission);
-		const normalized: PermissionRequest =
-			storageKey === permission.id ? permission : { ...permission, id: storageKey };
-
-		this.pending.set(storageKey, normalized);
+		this.pending.set(permission.id, permission);
 
 		if (this.shouldAutoAccept?.(permission)) {
 			logger.info("Auto-accepting permission", {
-				permissionId: normalized.id,
+				permissionId: permission.id,
 				sessionId: permission.sessionId,
 				tool: permission.permission,
 			});
-			void this.reply(storageKey, "once").match(
+			void this.reply(permission.id, "once").match(
 				() => {},
 				(err) => logger.error("Failed to auto-accept permission", { error: err })
 			);
@@ -73,9 +62,9 @@ export class PermissionStore {
 		}
 
 		logger.debug("Permission request added", {
-			permissionId: normalized.id,
-			toolCallId: normalized.tool?.callID,
-			jsonRpcRequestId: normalized.jsonRpcRequestId,
+			permissionId: permission.id,
+			toolCallId: permission.tool?.callID,
+			jsonRpcRequestId: permission.jsonRpcRequestId,
 		});
 	}
 
@@ -85,7 +74,7 @@ export class PermissionStore {
 	getForToolCall(toolCallId: string): PermissionRequest | undefined {
 		let latest: PermissionRequest | undefined;
 		for (const permission of this.pending.values()) {
-			const permissionToolCallId = permission.tool?.callID ?? permission.id;
+			const permissionToolCallId = permission.tool ? permission.tool.callID : permission.id;
 			if (permissionToolCallId === toolCallId) {
 				latest = permission;
 			}

--- a/packages/desktop/src/lib/acp/types/permission.ts
+++ b/packages/desktop/src/lib/acp/types/permission.ts
@@ -5,7 +5,11 @@
  */
 export interface PermissionRequest {
 	/**
-	 * Unique identifier for this permission request.
+	 * Unique identifier for this pending permission request.
+	 *
+	 * This is the canonical request identity used by the UI and stores.
+	 * For ACP requests it is distinct from both the tool-call anchor and the
+	 * JSON-RPC transport request ID.
 	 */
 	id: string;
 
@@ -16,7 +20,7 @@ export interface PermissionRequest {
 
 	/**
 	 * The JSON-RPC request ID for this permission request.
-	 * Used to send the response back to the ACP subprocess.
+	 * Used only to route the response back to the ACP subprocess.
 	 * Only present for ACP mode (not OpenCode HTTP mode).
 	 */
 	jsonRpcRequestId?: number;
@@ -43,6 +47,9 @@ export interface PermissionRequest {
 
 	/**
 	 * Optional reference to the tool call that triggered this permission.
+	 *
+	 * `callID` is the stable tool-row anchor used to attach this permission to
+	 * the originating tool call in the UI.
 	 */
 	tool?: {
 		messageID: string;


### PR DESCRIPTION
## Summary
- normalize ACP permission request IDs at ingress as `toolCallId::jsonRpcRequestId`
- stop rewriting permission IDs in `PermissionStore` while keeping tool-row lookups anchored on `tool.callID`
- update focused ACP tests, including upstream `AskUserQuestion` routing without `_meta`

## Test plan
- [x] `cd packages/desktop && bun test src/lib/acp/logic/__tests__/inbound-request-handler.test.ts`
- [x] `cd packages/desktop && bun test ./src/lib/acp/store/__tests__/permission-store.vitest.ts`
- [x] `cd packages/desktop && bun run check`
- [ ] Manual ACP permission smoke test

🤖 Generated with [Claude Code](https://claude.com/claude-code)