### PR TITLE
fix(history): preserve Claude worktree sessions across restart

### DIFF
--- a/packages/desktop/src-tauri/src/db/repository.rs
+++ b/packages/desktop/src-tauri/src/db/repository.rs
@@ -600,19 +600,33 @@ pub type SessionMetadataRecord = (String, String, i64, String, String, String, i
 pub struct SessionMetadataRepository;
 
 impl SessionMetadataRepository {
-    fn base_project_path_from_worktree_path(worktree_path: &str) -> Option<String> {
-        let canonical_worktree_path =
-            crate::git::worktree_config::validate_worktree_path(std::path::Path::new(worktree_path))
-                .ok()?;
-        let git_file_path = canonical_worktree_path.join(".git");
+    fn git_main_repo_from_worktree_path(
+        worktree_path: &std::path::Path,
+    ) -> Option<std::path::PathBuf> {
+        let git_file_path = worktree_path.join(".git");
         let git_file_content = std::fs::read_to_string(&git_file_path).ok()?;
         let git_dir_path = git_file_content.strip_prefix("gitdir: ")?.trim();
-        let git_dir = std::path::PathBuf::from(git_dir_path);
+        let git_dir = std::path::Path::new(git_dir_path);
+        let resolved_git_dir = if git_dir.is_absolute() {
+            git_dir.to_path_buf()
+        } else {
+            worktree_path.join(git_dir)
+        };
 
-        git_dir
+        resolved_git_dir
             .parent()
             .and_then(|path| path.parent())
             .and_then(|path| path.parent())
+            .map(std::path::Path::to_path_buf)
+    }
+
+    fn base_project_path_from_worktree_path(worktree_path: &str) -> Option<String> {
+        let canonical_worktree_path = std::path::Path::new(worktree_path)
+            .canonicalize()
+            .ok()
+            .filter(|path| path.is_dir())?;
+
+        Self::git_main_repo_from_worktree_path(&canonical_worktree_path)
             .map(|path| path.to_string_lossy().into_owned())
     }
 
@@ -850,8 +864,7 @@ impl SessionMetadataRepository {
         ) in records
         {
             if let Some(existing_model) = existing_map.get(&session_id) {
-                let project_path =
-                    Self::project_path_for_update(existing_model, project_path);
+                let project_path = Self::project_path_for_update(existing_model, project_path);
 
                 // Check if file has changed (skip if mtime+size match).
                 // Non-Claude agents use mtime=0/size=0 sentinel — always refresh those.

--- a/packages/desktop/src-tauri/src/db/repository_test.rs
+++ b/packages/desktop/src-tauri/src/db/repository_test.rs
@@ -7,6 +7,7 @@ mod session_metadata_tests {
     use crate::db::repository::SessionMetadataRepository;
     use sea_orm::{Database, DbConn};
     use sea_orm_migration::MigratorTrait;
+    use tempfile::tempdir;
 
     /// Create an in-memory SQLite database with migrations applied.
     async fn setup_test_db() -> DbConn {
@@ -561,11 +562,10 @@ mod session_metadata_tests {
                 .is_some()
         );
 
-        // Delete
-        let result = SessionMetadataRepository::delete(&db, "session-to-delete").await;
-        assert!(result.is_ok());
+        SessionMetadataRepository::delete(&db, "session-to-delete")
+            .await
+            .unwrap();
 
-        // Verify it's gone
         assert!(
             SessionMetadataRepository::get_by_id(&db, "session-to-delete")
                 .await
@@ -729,7 +729,6 @@ mod session_metadata_tests {
             "Should only insert/update 1 record (the new one)"
         );
 
-        // Verify existing wasn't modified
         let existing = SessionMetadataRepository::get_by_id(&db, "existing")
             .await
             .unwrap()
@@ -738,6 +737,74 @@ mod session_metadata_tests {
             existing.display, "Original",
             "Existing record should not be modified"
         );
+    }
+
+    #[tokio::test]
+    async fn test_upsert_preserves_base_project_for_generic_git_worktree_session() {
+        let db = setup_test_db().await;
+
+        let temp = tempdir().expect("temp dir");
+        let base_project = temp.path().join("repo");
+        let worktree = temp.path().join("feature-a");
+        std::fs::create_dir_all(base_project.join(".git/worktrees/feature-a")).unwrap();
+        std::fs::create_dir_all(&worktree).unwrap();
+        std::fs::write(
+            worktree.join(".git"),
+            format!(
+                "gitdir: {}\n",
+                base_project.join(".git/worktrees/feature-a").display()
+            ),
+        )
+        .unwrap();
+
+        let base_project_str = base_project.to_string_lossy().to_string();
+        let worktree_str = worktree.to_string_lossy().to_string();
+
+        SessionMetadataRepository::upsert(
+            &db,
+            "session-generic".to_string(),
+            "Original title".to_string(),
+            1704067200000,
+            base_project_str.clone(),
+            "claude-code".to_string(),
+            format!("{}/session-generic.jsonl", base_project_str),
+            1704067200,
+            100,
+        )
+        .await
+        .unwrap();
+
+        SessionMetadataRepository::set_worktree_path(
+            &db,
+            "session-generic",
+            &worktree_str,
+            Some(&base_project_str),
+            Some("claude-code"),
+        )
+        .await
+        .unwrap();
+
+        SessionMetadataRepository::upsert(
+            &db,
+            "session-generic".to_string(),
+            "Updated title".to_string(),
+            1704067300000,
+            worktree_str.clone(),
+            "claude-code".to_string(),
+            format!("{}/session-generic.jsonl", worktree_str),
+            1704067300,
+            200,
+        )
+        .await
+        .unwrap();
+
+        let session = SessionMetadataRepository::get_by_id(&db, "session-generic")
+            .await
+            .unwrap()
+            .unwrap();
+
+        assert_eq!(session.project_path, base_project_str);
+        assert_eq!(session.worktree_path.as_deref(), Some(worktree_str.as_str()));
     }
 
     #[tokio::test]

--- a/packages/desktop/src-tauri/src/history/commands/session_loading.rs
+++ b/packages/desktop/src-tauri/src/history/commands/session_loading.rs
@@ -1,5 +1,21 @@
 use super::*;
 
+fn canonicalize_persisted_worktree_path(worktree_path: &str) -> Result<std::path::PathBuf, String> {
+    let canonical = std::path::Path::new(worktree_path)
+        .canonicalize()
+        .map_err(|e| format!("Failed to canonicalize worktree path: {}", e))?;
+
+    if !canonical.is_dir() {
+        return Err("Worktree path is not a directory".to_string());
+    }
+
+    if !canonical.join(".git").is_file() {
+        return Err("Worktree path does not contain a git worktree .git file".to_string());
+    }
+
+    Ok(canonical)
+}
+
 fn fallback_project_path_for_history_load(
     agent: &CanonicalAgentId,
     project_path: &str,
@@ -517,7 +533,7 @@ pub async fn audit_session_load_timing(
 
 /// Set the worktree path for a session in the metadata index.
 /// Called by the frontend when a session is created within a worktree.
-/// Validates that the path is under the worktrees root before storing.
+/// Accepts any existing git worktree path, not just Acepe-managed worktrees.
 #[tauri::command]
 #[specta::specta]
 pub async fn set_session_worktree_path(
@@ -533,9 +549,7 @@ pub async fn set_session_worktree_path(
         "Persisting worktree path for session"
     );
 
-    let canonical =
-        crate::git::worktree_config::validate_worktree_path(std::path::Path::new(&worktree_path))
-            .map_err(|e| {
+    let canonical = canonicalize_persisted_worktree_path(&worktree_path).map_err(|e| {
             tracing::error!(
                 session_id = %session_id,
                 worktree_path = %worktree_path,


### PR DESCRIPTION
## Summary
Claude Code sessions launched from arbitrary git worktrees were being treated as orphaned after restart because the backend only persisted `worktree_path` values under Acepe-managed worktree roots.

This change accepts any valid git worktree by validating the `.git` pointer file and deriving the base repository from that metadata, so restored Claude sessions keep the correct worktree context. It also adds a regression test covering a generic git worktree outside `~/.acepe/worktrees`.

## Testing
- cargo test --lib db::repository_test
- cargo test --lib history::session_context
- cargo check
