### PR TITLE
fix(agent-input): align stream controls and voice start state

### DIFF
--- a/packages/desktop/src/app.css
+++ b/packages/desktop/src/app.css
@@ -38,6 +38,8 @@
 	--destructive-foreground: hsl(0 0% 100%);
 	--success: var(--token-success-light);
 	--success-foreground: hsl(0 0% 100%);
+	--build-icon: var(--success);
+	--plan-icon: var(--token-plan-icon-light);
 	--border: #BDB6A6;
 	--input: #E0DBD0;
 	--ring: #D97757;
@@ -101,8 +103,11 @@
 	--accent: #303030; /* hover/selected item background */
 	--accent-foreground: #ffffff; /* list.hoverForeground */
 	--destructive: #bf616a; /* editorError.foreground */
-	--success: var(--token-success-dark);
+	/* Dark: semantic success matches build accent (Colors.green) */
+	--success: var(--token-build-icon-dark);
 	--success-foreground: #ffffff;
+	--build-icon: var(--success);
+	--plan-icon: var(--token-plan-icon-dark);
 	--border: #2a2a2a; /* input.border, dropdown.border */
 	--input: #313131; /* input.background */
 	--ring: #30373a; /* focusBorder */

--- a/packages/desktop/src/lib/acp/components/agent-input/agent-input-ui.svelte
+++ b/packages/desktop/src/lib/acp/components/agent-input/agent-input-ui.svelte
@@ -18,7 +18,6 @@ import * as agentModelPrefs from "../../store/agent-model-preferences-store.svel
 import { getMessageQueueStore, getPanelStore, getSessionStore } from "../../store/index.js";
 import type { AvailableCommand } from "../../types/available-command.js";
 import { CanonicalModeId } from "../../types/canonical-mode-id.js";
-import { Colors } from "../../utils/colors.js";
 import { createLogger } from "../../utils/logger.js";
 import { filterVisibleModes } from "../../utils/mode-filter.js";
 import { ArtefactBadge } from "../artefact/index.js";
@@ -33,7 +32,7 @@ import VoiceModelMenu from "./components/voice-model-menu.svelte";
 import PastedTextOverlay from "./components/pasted-text-overlay.svelte";
 import VoiceRecordingOverlay from "./components/voice-recording-overlay.svelte";
 import { VoiceInputState } from "./state/voice-input-state.svelte.js";
-import { shouldShowVoiceOverlay } from "./logic/voice-ui-state.js";
+import { canStartVoiceInteraction, shouldShowVoiceOverlay } from "./logic/voice-ui-state.js";
 import { createImageAttachment, isImageMimeType } from "./logic/image-attachment.js";
 import {
 	findInlineArtefactRangeAtPosition,
@@ -157,15 +156,15 @@ const effectiveCurrentModeId = $derived.by(() =>
 	})
 );
 
-// Derive button color based on current mode
+// Derive submit button fill from the same tokens as mode icons (plan / build mint in dark)
 const buttonColor = $derived.by(() => {
 	switch (effectiveCurrentModeId) {
 		case CanonicalModeId.PLAN:
-			return Colors.orange;
+			return "var(--plan-icon)";
 		case CanonicalModeId.BUILD:
-			return "var(--success)";
+			return "var(--build-icon)";
 		default:
-			return "var(--success)";
+			return "var(--build-icon)";
 	}
 });
 
@@ -1015,6 +1014,10 @@ function handlePrimaryButtonClick(): void {
 		handleSteer();
 		return;
 	}
+	if (primaryButtonIntent === "cancel") {
+		void handleCancel();
+		return;
+	}
 	if (primaryButtonIntent === "send") {
 		void handleSend();
 		return;
@@ -1063,10 +1066,10 @@ function shouldUseVoiceHoldKey(event: KeyboardEvent): boolean {
 	if (!shouldStartVoiceHold(event)) {
 		return false;
 	}
-	if (!voiceEnabled || currentVoiceState === null || isSending || isStreaming) {
+	if (!voiceEnabled || currentVoiceState === null) {
 		return false;
 	}
-	return currentVoiceState.phase === "idle";
+	return canStartVoiceInteraction(currentVoiceState.phase, isSending);
 }
 
 function handleEditorKeyDown(event: KeyboardEvent): void {
@@ -1713,7 +1716,7 @@ async function handleCancel() {
 							{/if}
 							<MicButton
 								voiceState={currentVoiceState}
-								disabled={isStreaming || isSending}
+								disabled={!canStartVoiceInteraction(currentVoiceState.phase, isSending) && currentVoiceState.phase !== "recording"}
 							/>
 						</div>
 					{:else}
@@ -1745,10 +1748,10 @@ async function handleCancel() {
 							{/if}
 							<div class="voice-controls flex items-center">
 								<VoiceModelMenu {voiceSettingsStore} />
-								<MicButton
-									voiceState={currentVoiceState}
-									disabled={isStreaming || isSending}
-								/>
+							<MicButton
+								voiceState={currentVoiceState}
+								disabled={!canStartVoiceInteraction(currentVoiceState.phase, isSending) && currentVoiceState.phase !== "recording"}
+							/>
 							</div>
 						{/if}
 					{/if}

--- a/packages/desktop/src/lib/acp/components/agent-input/components/mic-button.svelte
+++ b/packages/desktop/src/lib/acp/components/agent-input/components/mic-button.svelte
@@ -174,10 +174,6 @@ const STOP_RED = "#FF5D5A";
 	}
 	.mic-idle:hover {
 		color: #f9c396;
-		transform: scale(1.08);
-	}
-	.mic-idle:active {
-		transform: scale(0.95);
 	}
 
 	.mic-idle :global(svg) {

--- a/packages/desktop/src/lib/acp/components/agent-input/logic/__tests__/voice-ui-state.test.ts
+++ b/packages/desktop/src/lib/acp/components/agent-input/logic/__tests__/voice-ui-state.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { canCancelVoiceInteraction, shouldShowVoiceOverlay } from "../voice-ui-state.js";
+import { canCancelVoiceInteraction, canStartVoiceInteraction, shouldShowVoiceOverlay } from "../voice-ui-state.js";
 import type { VoiceInputPhase } from "../../../../types/voice-input.js";
 
 describe("voice-ui-state", () => {
@@ -28,6 +28,23 @@ describe("voice-ui-state", () => {
 		)("returns false for %s", (phase) => {
 			expect(canCancelVoiceInteraction(phase)).toBe(false);
 		});
+	});
+
+	describe("canStartVoiceInteraction", () => {
+		it("allows idle voice input while agent is streaming elsewhere", () => {
+			expect(canStartVoiceInteraction("idle", false)).toBe(true);
+		});
+
+		it("blocks voice input while the input is currently sending", () => {
+			expect(canStartVoiceInteraction("idle", true)).toBe(false);
+		});
+
+		it.each(ALL_PHASES.filter((phase) => phase !== "idle"))(
+			"blocks voice start when phase is %s",
+			(phase) => {
+				expect(canStartVoiceInteraction(phase, false)).toBe(false);
+			}
+		);
 	});
 
 	describe("shouldShowVoiceOverlay", () => {

--- a/packages/desktop/src/lib/acp/components/agent-input/logic/submit-intent.test.ts
+++ b/packages/desktop/src/lib/acp/components/agent-input/logic/submit-intent.test.ts
@@ -50,6 +50,17 @@ describe("submit intent", () => {
 		).toBe("send");
 	});
 
+	it("uses cancel when streaming without a draft", () => {
+		expect(
+			resolvePrimaryButtonIntent({
+				hasDraftInput: false,
+				isAgentBusy: true,
+				isStreaming: true,
+				isShiftPressed: false,
+			})
+		).toBe("cancel");
+	});
+
 	it("switches button to steer while Shift is held", () => {
 		expect(
 			resolvePrimaryButtonIntent({

--- a/packages/desktop/src/lib/acp/components/agent-input/logic/submit-intent.ts
+++ b/packages/desktop/src/lib/acp/components/agent-input/logic/submit-intent.ts
@@ -1,4 +1,4 @@
-export type SubmitIntent = "none" | "send" | "steer";
+export type SubmitIntent = "none" | "send" | "steer" | "cancel";
 
 interface EnterKeyIntentInput {
 	hasDraftInput: boolean;
@@ -33,7 +33,7 @@ export function resolveEnterKeyIntent(input: EnterKeyIntentInput): SubmitIntent 
 
 export function resolvePrimaryButtonIntent(input: PrimaryButtonIntentInput): SubmitIntent {
 	if (input.isStreaming && !input.hasDraftInput) {
-		return "steer";
+		return "cancel";
 	}
 
 	if (!input.hasDraftInput) {

--- a/packages/desktop/src/lib/acp/components/agent-input/logic/voice-ui-state.ts
+++ b/packages/desktop/src/lib/acp/components/agent-input/logic/voice-ui-state.ts
@@ -1,5 +1,13 @@
 import type { VoiceInputPhase } from "$lib/acp/types/voice-input.js";
 
+export function canStartVoiceInteraction(phase: VoiceInputPhase, isSending: boolean): boolean {
+	if (isSending) {
+		return false;
+	}
+
+	return phase === "idle";
+}
+
 export function canCancelVoiceInteraction(phase: VoiceInputPhase): boolean {
 	return (
 		phase === "checking_permission" ||


### PR DESCRIPTION
Keep the primary action and mic availability aligned with the actual input state during streaming.

This switches the empty-draft streaming action to cancel, gates voice start on the local voice phase instead of unrelated stream state, and keeps the desktop input button on explicit build and plan tokens.

## Verification
1. Editor diagnostics on all changed files are clean in the isolated branch worktree.
2. `bun run check` could not run in the isolated worktree because the workspace toolchain is not bootstrapped there (`svelte-kit` was unavailable).

---

[![Compound Engineering v2.54.1](https://img.shields.io/badge/Compound_Engineering-v2.54.1-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
🤖 Generated with GPT-5.4 (unknown context, standard reasoning) via [GitHub Copilot](https://github.com/features/copilot)