### PR TITLE
fix(acp): stabilize permission identity

### DIFF
--- a/packages/desktop/src/lib/acp/components/tool-calls/tool-call-exit-plan-mode.svelte
+++ b/packages/desktop/src/lib/acp/components/tool-calls/tool-call-exit-plan-mode.svelte
@@ -57,7 +57,9 @@ const inline = usePlanInline({
 	getAwaitingPlanApproval: () => false,
 });
 
-const pendingPermission = $derived(permissionStore.getForToolCall(toolCall.id));
+const pendingPermission = $derived(
+	permissionStore.getForToolCall(sessionContext?.sessionId, toolCall.id)
+);
 
 function handleBuildManual() {
 	if (pendingPermission) {
@@ -89,7 +91,7 @@ $effect(() => {
 	const handleKeyDown = (e: KeyboardEvent) => {
 		if ((e.metaKey || e.ctrlKey) && e.key === "Enter") {
 			e.preventDefault();
-			const current = permissionStore.getForToolCall(toolCall.id);
+			const current = permissionStore.getForToolCall(sessionContext?.sessionId, toolCall.id);
 			if (current?.id === currentPermissionId) {
 				handleBuildManual();
 			}

--- a/packages/desktop/src/lib/acp/components/tool-calls/tool-call-router.svelte
+++ b/packages/desktop/src/lib/acp/components/tool-calls/tool-call-router.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 import type { Component } from "svelte";
+import { useSessionContext } from "../../hooks/use-session-context.js";
 import { getPermissionStore } from "../../store/permission-store.svelte.js";
 import type { TurnState } from "../../store/types.js";
 import type { PermissionRequest } from "../../types/permission.js";
@@ -81,7 +82,10 @@ let { toolCall, turnState = "idle", projectPath }: Props = $props();
 let nowMs = $state(Date.now());
 
 const permissionStore = getPermissionStore();
-const pendingPermission = $derived(permissionStore.getForToolCall(toolCall.id));
+const sessionContext = useSessionContext();
+const pendingPermission = $derived(
+	permissionStore.getForToolCall(sessionContext?.sessionId, toolCall.id)
+);
 
 // Get the tool kind directly from the toolCall (Rust always provides this)
 // Default to "other" only as a safety net - should never happen in practice

--- a/packages/desktop/src/lib/acp/logic/__tests__/inbound-request-handler.test.ts
+++ b/packages/desktop/src/lib/acp/logic/__tests__/inbound-request-handler.test.ts
@@ -3,7 +3,7 @@ import { afterEach, beforeEach, describe, expect, it, type Mock, vi } from "vite
 
 import type { JsonValue } from "../../../services/converted-session-types.js";
 import { ACP_INBOUND_METHODS } from "../../constants/acp-methods.js";
-import type { PermissionRequest } from "../../types/permission.js";
+import { buildAcpPermissionId, type PermissionRequest } from "../../types/permission.js";
 import type { QuestionRequest } from "../../types/question.js";
 import type { AcpEventEnvelope } from "../acp-event-bridge.js";
 import {
@@ -111,7 +111,7 @@ describe("InboundRequestHandler", () => {
 
 			expect(permissionCallback).toHaveBeenCalledTimes(1);
 			const permission: PermissionRequest = permissionCallback.mock.calls[0][0];
-			expect(permission.id).toBe("tool-123::123");
+			expect(permission.id).toBe(buildAcpPermissionId("test-session", "tool-123", 123));
 			expect(permission.sessionId).toBe("test-session");
 			expect(permission.jsonRpcRequestId).toBe(123);
 			expect(permission.permission).toBe("Run tests");
@@ -338,7 +338,7 @@ describe("InboundRequestHandler", () => {
 			expect(question.questions[0].multiSelect).toBe(false);
 		});
 
-		it("should route upstream AskUserQuestion requests without _meta to question callback", async () => {
+		it("should route upstream AskUserQuestion requests to question callback", async () => {
 			await handler.start(permissionCallback, questionCallback);
 
 			const request = {
@@ -347,18 +347,18 @@ describe("InboundRequestHandler", () => {
 				method: ACP_INBOUND_METHODS.REQUEST_PERMISSION,
 				params: {
 					sessionId: "session-7",
-					options: [{ kind: "allow", name: "Continue", optionId: "continue" }],
+					options: [],
 					toolCall: {
 						toolCallId: "tc-question-7",
 						name: "AskUserQuestion",
 						rawInput: {
 							questions: [
 								{
-									question: "Which runtime should we use?",
-									header: "Runtime",
+									question: "Which editor?",
+									header: "Editor",
 									options: [
-										{ label: "Bun", description: "Fast runtime" },
-										{ label: "Node", description: "Broad compatibility" },
+										{ label: "Zed", description: "Fast editor" },
+										{ label: "VS Code", description: "Popular editor" },
 									],
 									multiSelect: false,
 								},
@@ -378,10 +378,43 @@ describe("InboundRequestHandler", () => {
 			expect(question.sessionId).toBe("session-7");
 			expect(question.jsonRpcRequestId).toBe(7);
 			expect(question.questions).toHaveLength(1);
-			expect(question.questions[0].question).toBe("Which runtime should we use?");
-			expect(question.questions[0].header).toBe("Runtime");
-			expect(question.questions[0].options).toHaveLength(2);
-			expect(question.questions[0].multiSelect).toBe(false);
+			expect(question.questions[0].question).toBe("Which editor?");
+		});
+
+		it("should fall back to permission flow for upstream AskUserQuestion without callback", async () => {
+			await handler.start(permissionCallback);
+
+			const request = {
+				id: 8,
+				jsonrpc: "2.0",
+				method: ACP_INBOUND_METHODS.REQUEST_PERMISSION,
+				params: {
+					sessionId: "session-8",
+					options: [],
+					toolCall: {
+						toolCallId: "tc-question-8",
+						title: "AskUserQuestion",
+						rawInput: {
+							questions: [
+								{
+									question: "Continue?",
+									header: "Confirm",
+									options: [{ label: "Yes", description: "Continue" }],
+									multiSelect: false,
+								},
+							],
+						},
+					},
+				},
+			};
+
+			eventCallback?.({ payload: request });
+
+			expect(permissionCallback).toHaveBeenCalledTimes(1);
+			const permission: PermissionRequest = permissionCallback.mock.calls[0][0];
+			expect(permission.id).toBe(buildAcpPermissionId("session-8", "tc-question-8", 8));
+			expect(permission.tool?.callID).toBe("tc-question-8");
+			expect(permission.jsonRpcRequestId).toBe(8);
 		});
 
 		it("should handle multiSelect questions", async () => {

--- a/packages/desktop/src/lib/acp/logic/inbound-request-handler.ts
+++ b/packages/desktop/src/lib/acp/logic/inbound-request-handler.ts
@@ -27,7 +27,11 @@ import {
 	type RequestPermissionParams,
 } from "../schemas/inbound-request.schema.js";
 import { api } from "../store/api.js";
-import type { PermissionRequest } from "../types/permission.js";
+import {
+	buildAcpPermissionId,
+	type AcpPermissionRequest,
+	type PermissionRequest,
+} from "../types/permission.js";
 import type { QuestionRequest } from "../types/question.js";
 import { createLogger } from "../utils/logger.js";
 import { openAcpEventSource } from "./acp-event-bridge.js";
@@ -36,10 +40,6 @@ const logger = createLogger({
 	id: "inbound-request-handler",
 	name: "Inbound Request Handler",
 });
-
-function buildPermissionRequestId(toolCallId: string, jsonRpcRequestId: number): string {
-	return `${toolCallId}::${jsonRpcRequestId}`;
-}
 
 /**
  * Callback type for permission request events.
@@ -179,16 +179,12 @@ export class InboundRequestHandler {
 			return;
 		}
 
-		// Create a permission request with a stable request identity.
-		const permission: PermissionRequest = {
-			id: buildPermissionRequestId(params.toolCall.toolCallId, request.id),
+		// Create a permission request with the JSON-RPC request ID
+		const permission: AcpPermissionRequest = {
+			id: buildAcpPermissionId(params.sessionId, params.toolCall.toolCallId, request.id),
 			sessionId: params.sessionId,
 			jsonRpcRequestId: request.id,
-			permission: params.toolCall.title
-				? params.toolCall.title
-				: params.toolCall.name
-					? params.toolCall.name
-					: "Execute tool",
+			permission: params.toolCall.title ? params.toolCall.title : params.toolCall.name ? params.toolCall.name : "Execute tool",
 			patterns: [],
 			metadata: {
 				rawInput: params.toolCall.rawInput,

--- a/packages/desktop/src/lib/acp/schemas/inbound-request.schema.ts
+++ b/packages/desktop/src/lib/acp/schemas/inbound-request.schema.ts
@@ -8,6 +8,7 @@
 import { err, ok, type Result } from "neverthrow";
 import { z } from "zod";
 
+import type { JsonValue, ToolArguments } from "../../services/converted-session-types.js";
 import type { AcpError } from "../errors/index.js";
 import { ProtocolError } from "../errors/index.js";
 import { QuestionItemSchema } from "./tool-call-content.schema.js";
@@ -55,9 +56,9 @@ const PermissionOptionSchema = z.object({
 
 const ToolCallSchema = z.object({
 	toolCallId: z.string(),
-	rawInput: z.unknown(),
+	rawInput: z.custom<JsonValue>(),
 	/** Rust-parsed ToolArguments from rawInput — agent-agnostic. */
-	parsedArguments: z.unknown().optional(),
+	parsedArguments: z.custom<ToolArguments>().optional(),
 	title: z.string().optional(),
 	name: z.string().optional(),
 });

--- a/packages/desktop/src/lib/acp/store/__tests__/permission-store.vitest.ts
+++ b/packages/desktop/src/lib/acp/store/__tests__/permission-store.vitest.ts
@@ -1,8 +1,25 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-import type { PermissionRequest } from "../../types/permission.js";
+import { buildAcpPermissionId, type PermissionRequest } from "../../types/permission.js";
 
 import { PermissionStore } from "../permission-store.svelte.js";
+
+function createAcpPermission(
+	sessionId: string,
+	toolCallId: string,
+	jsonRpcRequestId: number
+): PermissionRequest {
+	return {
+		id: buildAcpPermissionId(sessionId, toolCallId, jsonRpcRequestId),
+		sessionId,
+		jsonRpcRequestId,
+		permission: "Execute",
+		patterns: [],
+		metadata: { options: [] },
+		always: [],
+		tool: { messageID: "", callID: toolCallId },
+	};
+}
 
 /** Builds a chainable mock matching the ResultAsync interface subset used by PermissionStore. */
 function mockResultAsync() {
@@ -77,75 +94,58 @@ describe("PermissionStore", () => {
 			expect(store.pending.get("perm-1")).toEqual(permission);
 		});
 
-		it("should add permission with jsonRpcRequestId", () => {
-			const permission: PermissionRequest = {
-				id: "perm-2::123",
-				sessionId: "session-2",
-				jsonRpcRequestId: 123,
-				permission: "Bash",
-				patterns: [],
-				metadata: { rawInput: { command: "ls" } },
-				always: ["allow_always"],
-			};
+		it("should add ACP permission without rewriting its canonical id", () => {
+			const permission = createAcpPermission("session-2", "tool-2", 123);
 
 			store.add(permission);
 
-			expect(store.pending.get("perm-2::123")?.jsonRpcRequestId).toBe(123);
+			expect(store.pending.get(permission.id)?.jsonRpcRequestId).toBe(123);
 		});
 
 		it("should keep multiple ACP permissions for the same tool call", () => {
-			store.add({
-				id: "tool-1::100",
-				sessionId: "session-1",
-				jsonRpcRequestId: 100,
-				permission: "Execute",
-				patterns: [],
-				metadata: {},
-				always: [],
-				tool: { messageID: "", callID: "tool-1" },
-			});
-			store.add({
-				id: "tool-1::101",
-				sessionId: "session-1",
-				jsonRpcRequestId: 101,
-				permission: "Execute",
-				patterns: [],
-				metadata: {},
-				always: [],
-				tool: { messageID: "", callID: "tool-1" },
-			});
+			const firstPermission = createAcpPermission("session-1", "tool-1", 100);
+			const secondPermission = createAcpPermission("session-1", "tool-1", 101);
+
+			store.add(firstPermission);
+			store.add(secondPermission);
 
 			expect(store.pending.size).toBe(2);
-			expect(store.pending.has("tool-1::100")).toBe(true);
-			expect(store.pending.has("tool-1::101")).toBe(true);
+			expect(store.pending.has(firstPermission.id)).toBe(true);
+			expect(store.pending.has(secondPermission.id)).toBe(true);
 		});
 
-		it("should resolve permission by tool call id", () => {
-			store.add({
-				id: "tool-1::100",
-				sessionId: "session-1",
-				jsonRpcRequestId: 100,
-				permission: "Execute",
-				patterns: [],
-				metadata: {},
-				always: [],
-				tool: { messageID: "", callID: "tool-1" },
-			});
-			store.add({
-				id: "tool-1::101",
-				sessionId: "session-1",
-				jsonRpcRequestId: 101,
-				permission: "Execute",
-				patterns: [],
-				metadata: {},
-				always: [],
-				tool: { messageID: "", callID: "tool-1" },
-			});
+		it("should resolve permission by session-scoped tool call id", () => {
+			store.add(createAcpPermission("session-1", "tool-1", 100));
+			store.add(createAcpPermission("session-1", "tool-1", 101));
 
-			const permission = store.getForToolCall("tool-1");
+			const permission = store.getForToolCall("session-1", "tool-1");
 
 			expect(permission?.jsonRpcRequestId).toBe(101);
-			expect(permission?.id).toBe("tool-1::101");
+			expect(permission?.id).toBe(buildAcpPermissionId("session-1", "tool-1", 101));
+		});
+
+		it("should isolate permissions with the same tool call id across sessions", () => {
+			const sessionOnePermission = createAcpPermission("session-1", "tool-1", 100);
+			const sessionTwoPermission = createAcpPermission("session-2", "tool-1", 100);
+
+			store.add(sessionOnePermission);
+			store.add(sessionTwoPermission);
+
+			expect(store.getForToolCall("session-1", "tool-1")?.id).toBe(sessionOnePermission.id);
+			expect(store.getForToolCall("session-2", "tool-1")?.id).toBe(sessionTwoPermission.id);
+		});
+
+		it("should prefer the highest jsonRpcRequestId for same-session ACP siblings", () => {
+			const newerPermission = createAcpPermission("session-1", "tool-1", 101);
+			const olderPermission = createAcpPermission("session-1", "tool-1", 100);
+
+			store.add(newerPermission);
+			store.add(olderPermission);
+
+			const permission = store.getForToolCall("session-1", "tool-1");
+
+			expect(permission?.id).toBe(newerPermission.id);
+			expect(permission?.jsonRpcRequestId).toBe(101);
 		});
 	});
 
@@ -243,15 +243,7 @@ describe("PermissionStore", () => {
 
 			store.setAutoAccept((p) => p.sessionId === "child-session");
 
-			const permission: PermissionRequest = {
-				id: "perm-child::200",
-				sessionId: "child-session",
-				jsonRpcRequestId: 200,
-				permission: "Bash",
-				patterns: [],
-				metadata: {},
-				always: [],
-			};
+			const permission = createAcpPermission("child-session", "tool-child", 200);
 
 			store.add(permission);
 
@@ -283,7 +275,7 @@ describe("PermissionStore", () => {
 			store.setAutoAccept(() => true);
 
 			const permission: PermissionRequest = {
-				id: "perm-opts::300",
+				id: buildAcpPermissionId("child-session", "tool-opts", 300),
 				sessionId: "child-session",
 				jsonRpcRequestId: 300,
 				permission: "Bash",
@@ -295,6 +287,7 @@ describe("PermissionStore", () => {
 					],
 				},
 				always: [],
+				tool: { messageID: "", callID: "tool-opts" },
 			};
 
 			store.add(permission);
@@ -344,18 +337,10 @@ describe("PermissionStore", () => {
 		it("should use JSON-RPC response for permissions with jsonRpcRequestId", async () => {
 			const { respondToPermission } = await import("../../logic/inbound-request-handler.js");
 
-			const permission: PermissionRequest = {
-				id: "perm-jsonrpc::456",
-				sessionId: "session-jsonrpc",
-				jsonRpcRequestId: 456,
-				permission: "Bash",
-				patterns: [],
-				metadata: {},
-				always: [],
-			};
+			const permission = createAcpPermission("session-jsonrpc", "tool-jsonrpc", 456);
 
 			store.add(permission);
-			await store.reply("perm-jsonrpc::456", "once");
+			await store.reply(permission.id, "once");
 
 			expect(respondToPermission).toHaveBeenCalledWith("session-jsonrpc", 456, true, "allow");
 			expect(mockReplyPermission).not.toHaveBeenCalled();
@@ -366,17 +351,18 @@ describe("PermissionStore", () => {
 			const { respondToPermission } = await import("../../logic/inbound-request-handler.js");
 
 			const permission: PermissionRequest = {
-				id: "perm-always::789",
+				id: buildAcpPermissionId("session-always", "tool-always", 789),
 				sessionId: "session-always",
 				jsonRpcRequestId: 789,
 				permission: "Bash",
 				patterns: [],
-				metadata: {},
+				metadata: { options: [] },
 				always: ["allow_always"],
+				tool: { messageID: "", callID: "tool-always" },
 			};
 
 			store.add(permission);
-			await store.reply("perm-always::789", "always");
+			await store.reply(permission.id, "always");
 
 			expect(respondToPermission).toHaveBeenCalledWith("session-always", 789, true, "allow_always");
 		});
@@ -384,18 +370,10 @@ describe("PermissionStore", () => {
 		it("should send reject optionId and allowed=false for 'reject' reply", async () => {
 			const { respondToPermission } = await import("../../logic/inbound-request-handler.js");
 
-			const permission: PermissionRequest = {
-				id: "perm-reject::101",
-				sessionId: "session-reject",
-				jsonRpcRequestId: 101,
-				permission: "Bash",
-				patterns: [],
-				metadata: {},
-				always: [],
-			};
+			const permission = createAcpPermission("session-reject", "tool-reject", 101);
 
 			store.add(permission);
-			await store.reply("perm-reject::101", "reject");
+			await store.reply(permission.id, "reject");
 
 			expect(respondToPermission).toHaveBeenCalledWith("session-reject", 101, false, "reject");
 		});

--- a/packages/desktop/src/lib/acp/store/permission-store.svelte.ts
+++ b/packages/desktop/src/lib/acp/store/permission-store.svelte.ts
@@ -39,6 +39,27 @@ export class PermissionStore {
 		};
 	}
 
+	private getToolCallId(permission: PermissionRequest): string {
+		return permission.tool?.callID ? permission.tool.callID : permission.id;
+	}
+
+	private shouldPreferPermission(
+		candidate: PermissionRequest,
+		current: PermissionRequest | undefined
+	): boolean {
+		if (!current) {
+			return true;
+		}
+
+		const candidateRequestId = candidate.jsonRpcRequestId;
+		const currentRequestId = current.jsonRpcRequestId;
+		if (candidateRequestId !== undefined && currentRequestId !== undefined) {
+			return candidateRequestId > currentRequestId;
+		}
+
+		return true;
+	}
+
 	/**
 	 * Add a pending permission request.
 	 *
@@ -69,13 +90,23 @@ export class PermissionStore {
 	}
 
 	/**
-	 * Get the most recent pending permission for a given tool call.
+	 * Get the most recent pending permission for a given session-scoped tool call.
 	 */
-	getForToolCall(toolCallId: string): PermissionRequest | undefined {
+	getForToolCall(sessionId: string | undefined, toolCallId: string): PermissionRequest | undefined {
+		if (!sessionId) {
+			return undefined;
+		}
+
 		let latest: PermissionRequest | undefined;
 		for (const permission of this.pending.values()) {
-			const permissionToolCallId = permission.tool ? permission.tool.callID : permission.id;
-			if (permissionToolCallId === toolCallId) {
+			const permissionToolCallId = this.getToolCallId(permission);
+			if (permission.sessionId !== sessionId) {
+				continue;
+			}
+			if (permissionToolCallId !== toolCallId) {
+				continue;
+			}
+			if (this.shouldPreferPermission(permission, latest)) {
 				latest = permission;
 			}
 		}
@@ -111,11 +142,9 @@ export class PermissionStore {
 		reply: "once" | "always" | "reject"
 	): string {
 		// Try to find matching option from the stored options
-		const options = permission.metadata?.options as
-			| Array<{ kind: string; optionId: string }>
-			| undefined;
+		const options = permission.metadata.options;
 
-		if (options?.length) {
+		if (options && options.length > 0) {
 			const kindToMatch =
 				reply === "always" ? "allow_always" : reply === "once" ? "allow_once" : "reject_once";
 			const matchingOption = options.find((o) => o.kind === kindToMatch);

--- a/packages/desktop/src/lib/acp/types/permission.ts
+++ b/packages/desktop/src/lib/acp/types/permission.ts
@@ -1,15 +1,51 @@
+import type { JsonValue, ToolArguments } from "../../services/converted-session-types.js";
+
+/**
+ * Tool-call reference used to anchor a permission request to an existing tool row.
+ */
+export interface PermissionToolReference {
+	messageID: string;
+	callID: string;
+}
+
+/**
+ * Permission option metadata supplied by the ACP subprocess.
+ */
+export interface PermissionOptionMetadata {
+	kind: string;
+	name: string;
+	optionId: string;
+}
+
+/**
+ * Permission metadata consumed by the desktop UI.
+ */
+export interface PermissionMetadata {
+	rawInput?: JsonValue;
+	parsedArguments?: ToolArguments | null;
+	options?: PermissionOptionMetadata[];
+}
+
+/**
+ * ACP permission metadata always carries the original tool payload and options.
+ */
+export interface AcpPermissionMetadata extends PermissionMetadata {
+	rawInput: JsonValue;
+	options: PermissionOptionMetadata[];
+}
+
 /**
  * Permission request from the agent.
  *
- * Represents a permission prompt that requires user interaction.
+ * Represents a single pending permission prompt.
+ *
+ * - `id` is the canonical pending-request identity used by the store.
+ * - `tool.callID` is the stable UI/tool-row anchor.
+ * - `jsonRpcRequestId` is the ACP reply route when present.
  */
 export interface PermissionRequest {
 	/**
-	 * Unique identifier for this pending permission request.
-	 *
-	 * This is the canonical request identity used by the UI and stores.
-	 * For ACP requests it is distinct from both the tool-call anchor and the
-	 * JSON-RPC transport request ID.
+	 * Unique identity for this pending permission request.
 	 */
 	id: string;
 
@@ -38,7 +74,7 @@ export interface PermissionRequest {
 	/**
 	 * Additional metadata about the permission request.
 	 */
-	metadata: Record<string, unknown>;
+	metadata: PermissionMetadata;
 
 	/**
 	 * Options that should be shown as "always allow" choices.
@@ -51,10 +87,30 @@ export interface PermissionRequest {
 	 * `callID` is the stable tool-row anchor used to attach this permission to
 	 * the originating tool call in the UI.
 	 */
-	tool?: {
-		messageID: string;
-		callID: string;
-	};
+	tool?: PermissionToolReference;
+}
+
+/**
+ * ACP permission request with the fields required for JSON-RPC replies.
+ */
+export interface AcpPermissionRequest extends PermissionRequest {
+	jsonRpcRequestId: number;
+	metadata: AcpPermissionMetadata;
+	tool: PermissionToolReference;
+}
+
+/**
+ * Build the canonical internal ID for an ACP permission request.
+ *
+ * This request identity is store-facing only. UI anchoring should continue to use
+ * `tool.callID`, not this composite key.
+ */
+export function buildAcpPermissionId(
+	sessionId: string,
+	toolCallId: string,
+	jsonRpcRequestId: number
+): string {
+	return `${sessionId}\u0000${toolCallId}\u0000${jsonRpcRequestId}`;
 }
 
 /**


### PR DESCRIPTION
This stabilizes ACP permission identity by assigning permission IDs at ACP ingress and scoping pending permission lookups by session when tool-call rows resolve requests. That prevents overlapping tool call IDs from different sessions from attaching to the wrong permission entry and keeps the exit-plan-mode tool route aligned with the active request.

Verified through the repo pre-push suite:
1. `packages/desktop`: `bun run check`, `bun run check:svelte`, `bun test`
2. `packages/website`: `bun run check`, `bun run test`
3. `packages/desktop/src-tauri`: `cargo check`, `cargo test -- --skip claude_history::export_types`