### PR TITLE
fix(voice): restore editor focus after dictation overlay deactivates

### DIFF
--- a/packages/desktop/src/lib/acp/components/agent-input/agent-input-ui.svelte
+++ b/packages/desktop/src/lib/acp/components/agent-input/agent-input-ui.svelte
@@ -547,6 +547,10 @@ async function initializeVoiceState(): Promise<void> {
 		sessionId: targetSessionId,
 		getSelectedLanguage: () => voiceSettingsStore.language,
 		getSelectedModelId: () => voiceSettingsStore.selectedModelId,
+		onOverlayDeactivated: () => {
+			// Editor is re-mounted after overlay hides; focus it on next microtask
+			queueMicrotask(() => editorRef?.focus());
+		},
 		onTranscriptionReady: (text) => {
 			const normalizedText = normalizeVoiceInputText(text);
 			if (!normalizedText) {
@@ -614,6 +618,10 @@ onMount(() => {
 	const handleWindowKeyDown = (event: KeyboardEvent) => {
 		if (event.key === "Shift") {
 			isShiftPressed = true;
+		}
+		if (document.activeElement !== editorRef && voiceState && shouldUseVoiceHoldKey(event)) {
+			event.preventDefault();
+			voiceState.onKeyboardHoldStart();
 		}
 	};
 	const handleWindowKeyUp = (event: KeyboardEvent) => {

--- a/packages/desktop/src/lib/acp/components/agent-input/state/voice-input-state.svelte.ts
+++ b/packages/desktop/src/lib/acp/components/agent-input/state/voice-input-state.svelte.ts
@@ -85,6 +85,7 @@ export class VoiceInputState {
 
 	private readonly sessionId: string;
 	private readonly onTranscriptionReady: ((text: string) => void) | null;
+	private readonly onOverlayDeactivated: (() => void) | null;
 	private readonly getSelectedLanguage: () => string;
 	private readonly getSelectedModelId: () => string;
 	private isDisposed = false;
@@ -92,13 +93,15 @@ export class VoiceInputState {
 	constructor(options: {
 		sessionId: string;
 		onTranscriptionReady?: (text: string) => void;
+		onOverlayDeactivated?: () => void;
 		getSelectedLanguage?: () => string;
 		getSelectedModelId?: () => string;
 	}) {
 		this.sessionId = options.sessionId;
-		this.onTranscriptionReady = options.onTranscriptionReady ?? null;
-		this.getSelectedLanguage = options.getSelectedLanguage ?? (() => "auto");
-		this.getSelectedModelId = options.getSelectedModelId ?? (() => "small.en");
+		this.onTranscriptionReady = options.onTranscriptionReady !== undefined ? options.onTranscriptionReady : null;
+		this.onOverlayDeactivated = options.onOverlayDeactivated !== undefined ? options.onOverlayDeactivated : null;
+		this.getSelectedLanguage = options.getSelectedLanguage !== undefined ? options.getSelectedLanguage : () => "auto";
+		this.getSelectedModelId = options.getSelectedModelId !== undefined ? options.getSelectedModelId : () => "small.en";
 		log("VoiceInputState created", { sessionId: this.sessionId });
 	}
 
@@ -491,6 +494,9 @@ export class VoiceInputState {
 				this.stopRecordingElapsedTimer();
 			}
 			log(`transition: ${prev} → ${result}`);
+			if (!this.isDisposed && shouldShowVoiceOverlay(prev) && !shouldShowVoiceOverlay(result)) {
+				this.onOverlayDeactivated?.();
+			}
 		} else {
 			log(`transition BLOCKED: ${prev} → ${next}`);
 		}


### PR DESCRIPTION
## Summary
- Add `onOverlayDeactivated` callback to `VoiceInputState` that fires when voice overlay transitions from active → inactive, restoring editor focus via `queueMicrotask`
- Extend window-level `keydown` handler to start voice hold when editor isn't focused, fixing keybind asymmetry with `keyup`
- Apply review fixes: replace `??` with ternary for constructor defaults (banned operator), add `isDisposed` guard on overlay callback

## Test plan
- [x] 58/58 voice input state tests pass
- [ ] Manual: trigger voice dictation, verify editor regains focus after overlay dismisses
- [ ] Manual: press Right Option when editor is not focused, verify voice hold starts