### PR TITLE
fix(website): use normal flow for header nav + optimize Railway build

### DIFF
--- a/.railwayignore
+++ b/.railwayignore
@@ -1,0 +1,14 @@
+# Only packages/website + shared packages are needed for the Railway build.
+# Exclude heavy desktop/Tauri/Rust code and other irrelevant packages.
+packages/desktop/src-tauri/
+packages/desktop/src/
+packages/desktop/static/
+packages/acps/
+packages/analytics/
+packages/changelog/
+docs/
+todos/
+assets/
+nested/
+.worktrees/
+.git/

--- a/packages/website/src/lib/components/header.svelte
+++ b/packages/website/src/lib/components/header.svelte
@@ -55,9 +55,9 @@
 
 <header class="fixed top-4 left-1/2 z-50 w-[calc(100%-3rem)] max-w-4xl -translate-x-1/2">
 	<div
-		class="relative flex items-center justify-between rounded-full bg-card/45 px-4 py-2.5 backdrop-blur-[30px]"
+		class="flex items-center justify-between rounded-full bg-card/45 px-4 py-2.5 backdrop-blur-[30px]"
 	>
-		<div class="flex items-center">
+		<div class="flex shrink-0 items-center">
 			<a
 				href="/"
 				class="flex items-center gap-2 rounded-full px-2 py-1 transition-colors hover:bg-card/70"
@@ -68,7 +68,7 @@
 		</div>
 
 		<!-- Desktop nav: centered links -->
-		<div class="absolute left-1/2 -translate-x-1/2 hidden items-center gap-1 md:flex">
+		<nav class="hidden items-center justify-center gap-1 md:flex">
 			<a href="/blog" class={desktopNavLinkClass}>
 				{m.nav_blog()}
 			</a>
@@ -86,10 +86,10 @@
 			<a href="/compare" class={desktopNavLinkClass}>
 				{m.nav_compare()}
 			</a>
-		</div>
+		</nav>
 
 		<!-- Desktop nav: right-side icons -->
-		<div class="hidden items-center gap-3 md:flex">
+		<div class="hidden shrink-0 items-center gap-3 md:flex">
 			<a
 				href="https://github.com/flazouh/acepe"
 				target="_blank"

--- a/railway.json
+++ b/railway.json
@@ -1,7 +1,8 @@
 {
 	"build": {
 		"builder": "NIXPACKS",
-		"buildCommand": "bun install --frozen-lockfile && NODE_OPTIONS=--max-old-space-size=6144 bun run --cwd packages/website build"
+		"installCommand": "bun install --frozen-lockfile",
+		"buildCommand": "NODE_OPTIONS=--max-old-space-size=6144 bun run --cwd packages/website build"
 	},
 	"deploy": {
 		"startCommand": "cd packages/website && node build",


### PR DESCRIPTION
**Header fix:** Removes `absolute left-1/2 -translate-x-1/2` from the centered nav and puts it in normal flexbox flow with `justify-between`. The three sections (logo, links, icons) now share space naturally without overlap.

**Railway optimization:**
- Added `.railwayignore` to exclude desktop/Tauri/Rust/docs from Railway snapshot (~25MB → ~5MB)
- Split `installCommand` from `buildCommand` in `railway.json` to eliminate double `bun install`