### PR TITLE
refactor(desktop): make preconnection slash provider-owned

### DIFF
--- a/docs/solutions/best-practices/provider-owned-policy-and-identity-not-ui-projections-2026-04-09.md
+++ b/docs/solutions/best-practices/provider-owned-policy-and-identity-not-ui-projections-2026-04-09.md
@@ -1,6 +1,7 @@
 ---
 title: Keep provider-owned policy and identity out of UI projections
 date: 2026-04-09
+last_updated: 2026-04-09
 category: best-practices
 module: desktop ACP runtime
 problem_type: best_practice
@@ -11,6 +12,7 @@ applies_when:
   - resume can redirect through an effective override agent
   - grouped model resolution depends on backend-projected display groups
   - provider-owned history loading must distinguish local and provider session identities
+  - preconnection slash loading differs by provider or project scope
 symptoms:
   - reconnect behavior depends on modelsDisplay presentation metadata
   - resumed capabilities cache under the wrong agent after agentOverrideId reconnects
@@ -25,6 +27,8 @@ related_components:
   - model-selector
   - session-loading
   - provider-capabilities
+  - preconnection-slash
+  - copilot-provider
 tags:
   - provider-metadata
   - agent-agnostic
@@ -32,13 +36,15 @@ tags:
   - model-selector
   - history-session-id
   - replay-identity
+  - preconnection-slash
+  - copilot
 ---
 
 # Keep provider-owned policy and identity out of UI projections
 
 ## Context
 
-Acepe’s agent-agnostic overhaul had already pushed most provider-specific logic to adapter edges, but the `/ce:review` pass exposed a last cluster of leaks. Shared runtime code was still reconstructing provider meaning from UI-facing projection data and presentation labels during reconnect, resume override handling, grouped-model resolution, selector rendering, and provider-owned replay loading.
+Acepe’s agent-agnostic overhaul had already pushed most provider-specific logic to adapter edges, but the `/ce:review` pass exposed a last cluster of leaks. Shared runtime code was still reconstructing provider meaning from UI-facing projection data and presentation labels during reconnect, resume override handling, grouped-model resolution, selector rendering, provider-owned replay loading, and preconnection slash discovery.
 
 That meant the architecture looked provider-neutral in the happy path while still depending on display metadata and local heuristics under the hood.
 
@@ -46,7 +52,7 @@ That meant the architecture looked provider-neutral in the happy path while stil
 
 Keep provider policy and provider identity in explicit provider-owned contracts. Shared frontend/runtime code should consume those contracts directly instead of inferring behavior from `modelsDisplay`, labels, or local session identifiers.
 
-In this fix, the contract boundary became explicit in three places:
+In this fix, the contract boundary became explicit in four places:
 
 1. **Provider lifecycle policy travels as typed metadata, not display projection.**
 
@@ -104,6 +110,28 @@ fn provider_owned_history_lookup_id(
 
 Provider replay paths now load history with `history_session_id`, reserving the Acepe-local id for local storage/UI identity.
 
+4. **Preconnection slash loading follows provider metadata and provider-owned loaders.**
+
+```rust
+let cwd = resolve_preconnection_cwd(
+    provider.frontend_projection().preconnection_slash_mode,
+    &cwd,
+)?;
+let commands = provider
+    .list_preconnection_commands(&app, cwd.as_deref())
+    .await?;
+```
+
+The backend preconnection command path is now a neutral dispatcher. Each provider owns whether it loads startup-global entries, project-scoped entries, or nothing at all. The frontend follows the same seam by keying warmup and on-demand loading off `providerMetadata.preconnectionSlashMode` instead of a dedicated `loadsRemotePreconnectionCommands` boolean.
+
+Copilot now owns its project-local `.agents` shape directly, including:
+
+- `.agents/skills/*/SKILL.md`
+- `.agents/*/SKILL.md`
+- `.agents/*.agent.md`
+
+For flat Copilot agent files, the invokable slash token comes from the filename, not the frontmatter `name`. `code-review.agent.md` must resolve to `code-review` even when `name` is omitted or set to a display label.
+
 The live split selector follows the same rule: use backend-projected groups first and fall back to client parsing only when the backend did not project a grouped model family.
 
 ```ts
@@ -121,7 +149,7 @@ const reasoningBaseGroups = $derived.by(() =>
 
 ## Why This Matters
 
-`modelsDisplay` is presentation data. Labels are presentation data. The Acepe local session id is local identity. None of those should become the hidden authority for provider lifecycle policy, grouped-model identity, or provider replay semantics.
+`modelsDisplay` is presentation data. Labels are presentation data. The Acepe local session id is local identity. Shared capability booleans are still shared heuristics. None of those should become the hidden authority for provider lifecycle policy, grouped-model identity, provider replay semantics, or preconnection slash support.
 
 Once shared code starts “figuring out” provider behavior from UI projection or labels, three bad things happen:
 
@@ -129,7 +157,7 @@ Once shared code starts “figuring out” provider behavior from UI projection 
 2. override and resume flows drift from the effective provider actually in use,
 3. new providers have to preserve accidental heuristics instead of implementing a clear contract.
 
-The explicit `providerMetadata` seam fixes that. The frontend can still render provider marks and grouped selectors from `modelsDisplay`, but policy now comes from typed provider metadata, grouped identity comes from model ids, and replay identity comes from `history_session_id`. That is the difference between provider-neutral styling and genuinely agent-agnostic architecture.
+The explicit `providerMetadata` seam fixes that. The frontend can still render provider marks and grouped selectors from `modelsDisplay`, but policy now comes from typed provider metadata, grouped identity comes from model ids, replay identity comes from `history_session_id`, and preconnection slash behavior comes from `preconnectionSlashMode` plus provider-owned loaders. That is the difference between provider-neutral styling and genuinely agent-agnostic architecture.
 
 ## When to Apply
 
@@ -138,6 +166,7 @@ The explicit `providerMetadata` seam fixes that. The frontend can still render p
 - When backend model projection groups variants for display
 - When shared UI components are tempted to parse provider-specific ids instead of consuming projected groups
 - When a provider stores or replays history under a provider-owned session identity that can differ from the local Acepe session id
+- When a provider exposes preconnection slash commands or project-local agent files before session connect
 
 ## Examples
 
@@ -177,6 +206,34 @@ modelsDisplay.groups.find(
 
 **Better:** derive stable group identity from backend model ids and compare against provider/base ids.
 
+**Bad:** using shared capability flags as the authority for preconnection slash behavior
+
+```ts
+if (getAgentCapabilities(agentId).loadsRemotePreconnectionCommands) {
+	await loadRemotePreconnectionCommands(projectPath, agentId);
+}
+```
+
+This forces provider-owned behavior back through shared UI policy.
+
+**Better:** drive warmup/on-demand loading from provider metadata and provider-owned dispatch
+
+```ts
+return agent.providerMetadata?.preconnectionSlashMode === "startupGlobal";
+```
+
+```rust
+provider.list_preconnection_commands(&app, cwd.as_deref()).await
+```
+
+**Copilot flat agent rule:** the slash token comes from the filename
+
+```text
+.agents/code-review.agent.md -> /code-review
+```
+
+Do not use the frontmatter `name` as the invokable token for Copilot flat agent files.
+
 Regression coverage that now guards this boundary:
 
 - `packages/desktop/src/lib/acp/store/services/session-connection-manager.test.ts`
@@ -185,6 +242,11 @@ Regression coverage that now guards this boundary:
 - `packages/desktop/src-tauri/src/history/commands/session_loading.rs` (`provider_owned_history_lookup_uses_provider_session_identity`)
 - `packages/desktop/src-tauri/src/storage/types.rs` (`user_setting_key_accepts_additional_keys`)
 - `packages/desktop/src-tauri/src/acp/parsers/provider_capabilities.rs` (`provider_capabilities_capture_plan_and_frontend_projection_contracts`)
+- `packages/desktop/src-tauri/src/acp/commands/preconnection_commands.rs` (`resolve_preconnection_cwd_*`)
+- `packages/desktop/src-tauri/src/acp/preconnection_slash.rs` (`load_preconnection_commands_from_flat_markdown_root_*`)
+- `packages/desktop/src/lib/skills/store/preconnection-agent-skills-store.vitest.ts`
+- `packages/desktop/src/lib/acp/components/agent-input/logic/preconnection-remote-commands-state.vitest.ts`
+- `packages/desktop/src/lib/acp/components/agent-input/logic/slash-command-source.vitest.ts`
 
 ## Related
 

--- a/packages/desktop/src-tauri/src/acp/commands/preconnection_commands.rs
+++ b/packages/desktop/src-tauri/src/acp/commands/preconnection_commands.rs
@@ -1,7 +1,18 @@
 use super::*;
-use crate::acp::opencode::OpenCodeHttpClient;
-use crate::acp::providers::OpenCodeProvider;
+use crate::acp::provider::PreconnectionSlashMode;
 use crate::acp::session_update::AvailableCommand;
+
+fn resolve_preconnection_cwd(
+    mode: PreconnectionSlashMode,
+    cwd: &str,
+) -> Result<Option<PathBuf>, SerializableAcpError> {
+    match mode {
+        PreconnectionSlashMode::ProjectScoped => {
+            validate_session_cwd(cwd, ProjectAccessReason::Other).map(Some)
+        }
+        PreconnectionSlashMode::StartupGlobal | PreconnectionSlashMode::Unsupported => Ok(None),
+    }
+}
 
 #[tauri::command]
 #[specta::specta]
@@ -11,29 +22,19 @@ pub async fn acp_list_preconnection_commands(
     agent_id: String,
 ) -> Result<Vec<AvailableCommand>, SerializableAcpError> {
     tracing::info!(cwd = %cwd, agent_id = %agent_id, "acp_list_preconnection_commands called");
-    let agent_id = CanonicalAgentId::parse(&agent_id);
-    if agent_id != CanonicalAgentId::OpenCode {
-        tracing::info!(requested_agent = %agent_id.as_str(), "Skipping preconnection commands for unsupported agent");
+
+    let canonical_agent_id = CanonicalAgentId::parse(&agent_id);
+    let registry = app.state::<Arc<AgentRegistry>>();
+    let Some(provider) = registry.get(&canonical_agent_id) else {
+        tracing::warn!(requested_agent = %agent_id, "Unknown agent requested preconnection commands");
         return Ok(Vec::new());
-    }
+    };
 
-    let cwd = validate_session_cwd(&cwd, ProjectAccessReason::Other)?;
-    let opencode_manager = app.state::<Arc<OpenCodeManagerRegistry>>();
-
-    let (project_key, manager) = opencode_manager.get_or_start(&cwd).await.map_err(|error| {
-        SerializableAcpError::InvalidState {
-            message: format!("Failed to get OpenCode manager: {}", error),
-        }
-    })?;
-
-    let provider = Arc::new(OpenCodeProvider);
-    let mut client = OpenCodeHttpClient::new(manager, project_key, provider)
-        .map_err(SerializableAcpError::from)?;
-
-    let commands = client
-        .list_preconnection_commands(cwd.to_string_lossy().to_string())
+    let cwd = resolve_preconnection_cwd(provider.frontend_projection().preconnection_slash_mode, &cwd)?;
+    let commands = provider
+        .list_preconnection_commands(&app, cwd.as_deref())
         .await
-        .map_err(SerializableAcpError::from)?;
+        .map_err(|message| SerializableAcpError::InvalidState { message })?;
 
     tracing::info!(
         commands_count = commands.len(),
@@ -42,4 +43,36 @@ pub async fn acp_list_preconnection_commands(
     );
 
     Ok(commands)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::tempdir;
+
+    #[test]
+    fn resolve_preconnection_cwd_allows_empty_for_startup_global_loading() {
+        let cwd = resolve_preconnection_cwd(PreconnectionSlashMode::StartupGlobal, "")
+            .expect("startup-global should not require cwd");
+
+        assert_eq!(cwd, None);
+    }
+
+    #[test]
+    fn resolve_preconnection_cwd_requires_directory_for_project_scoped_loading() {
+        let temp = tempdir().expect("temp dir");
+        let expected_cwd = std::fs::canonicalize(temp.path()).expect("canonicalize temp dir");
+
+        let cwd = resolve_preconnection_cwd(
+            PreconnectionSlashMode::ProjectScoped,
+            temp.path().to_string_lossy().as_ref(),
+        )
+        .expect("project-scoped should accept a valid cwd");
+
+        assert_eq!(cwd, Some(expected_cwd));
+        assert!(
+            resolve_preconnection_cwd(PreconnectionSlashMode::ProjectScoped, "").is_err(),
+            "project-scoped loading must reject missing cwd"
+        );
+    }
 }

--- a/packages/desktop/src-tauri/src/acp/mod.rs
+++ b/packages/desktop/src-tauri/src/acp/mod.rs
@@ -26,6 +26,7 @@ pub mod non_streaming_batcher;
 pub mod opencode;
 pub mod parsers;
 pub mod partial_json;
+pub mod preconnection_slash;
 pub mod permission_tracker;
 pub mod projections;
 pub mod provider;

--- a/packages/desktop/src-tauri/src/acp/parsers/provider_capabilities.rs
+++ b/packages/desktop/src-tauri/src/acp/parsers/provider_capabilities.rs
@@ -8,7 +8,7 @@ use crate::acp::parsers::{
 use crate::acp::provider::{
     AutonomousApplyStrategy, BackendIdentityPolicy, FrontendProviderProjection,
     FrontendVariantGroup, HistoryReplayFamily, HistoryReplayPolicy, PlanAdapterPolicy,
-    SessionLifecyclePolicy,
+    PreconnectionSlashMode, SessionLifecyclePolicy,
 };
 use crate::acp::session_update::PlanSource;
 
@@ -144,6 +144,7 @@ static PROVIDER_CAPABILITIES: [ProviderCapabilities; 5] = [
             default_alias: Some("default"),
             reasoning_effort_support: false,
             autonomous_apply_strategy: AutonomousApplyStrategy::LaunchProfile,
+            preconnection_slash_mode: PreconnectionSlashMode::StartupGlobal,
         },
         transport_family: TransportFamily::SharedChat,
         tool_vocabulary: ToolVocabulary::ClaudeCode,
@@ -171,6 +172,7 @@ static PROVIDER_CAPABILITIES: [ProviderCapabilities; 5] = [
             default_alias: None,
             reasoning_effort_support: false,
             autonomous_apply_strategy: AutonomousApplyStrategy::PostConnect,
+            preconnection_slash_mode: PreconnectionSlashMode::ProjectScoped,
         },
         transport_family: TransportFamily::SharedChat,
         tool_vocabulary: ToolVocabulary::Copilot,
@@ -198,6 +200,7 @@ static PROVIDER_CAPABILITIES: [ProviderCapabilities; 5] = [
             default_alias: None,
             reasoning_effort_support: false,
             autonomous_apply_strategy: AutonomousApplyStrategy::PostConnect,
+            preconnection_slash_mode: PreconnectionSlashMode::ProjectScoped,
         },
         transport_family: TransportFamily::OpenCodeEvents,
         tool_vocabulary: ToolVocabulary::OpenCode,
@@ -225,6 +228,7 @@ static PROVIDER_CAPABILITIES: [ProviderCapabilities; 5] = [
             default_alias: Some("auto"),
             reasoning_effort_support: false,
             autonomous_apply_strategy: AutonomousApplyStrategy::PostConnect,
+            preconnection_slash_mode: PreconnectionSlashMode::StartupGlobal,
         },
         transport_family: TransportFamily::CursorAcp,
         tool_vocabulary: ToolVocabulary::Cursor,
@@ -252,6 +256,7 @@ static PROVIDER_CAPABILITIES: [ProviderCapabilities; 5] = [
             default_alias: None,
             reasoning_effort_support: true,
             autonomous_apply_strategy: AutonomousApplyStrategy::PostConnect,
+            preconnection_slash_mode: PreconnectionSlashMode::StartupGlobal,
         },
         transport_family: TransportFamily::CodexAcp,
         tool_vocabulary: ToolVocabulary::Codex,

--- a/packages/desktop/src-tauri/src/acp/parsers/tests/future_provider_composition.rs
+++ b/packages/desktop/src-tauri/src/acp/parsers/tests/future_provider_composition.rs
@@ -8,7 +8,7 @@ use crate::acp::parsers::types::ParsedUsageTelemetry;
 use crate::acp::provider::{
     AutonomousApplyStrategy, BackendIdentityPolicy, FrontendProviderProjection,
     FrontendVariantGroup, HistoryReplayFamily, HistoryReplayPolicy, PlanAdapterPolicy,
-    SessionLifecyclePolicy,
+    PreconnectionSlashMode, SessionLifecyclePolicy,
 };
 use crate::acp::providers::CustomAgentConfig;
 use crate::acp::registry::AgentRegistry;
@@ -46,6 +46,7 @@ static FUTURE_PROVIDER_CAPABILITIES: [ProviderCapabilities; 1] = [ProviderCapabi
         default_alias: None,
         reasoning_effort_support: false,
         autonomous_apply_strategy: AutonomousApplyStrategy::PostConnect,
+        preconnection_slash_mode: PreconnectionSlashMode::Unsupported,
     },
     transport_family: TransportFamily::SharedChat,
     tool_vocabulary: ToolVocabulary::ClaudeCode,

--- a/packages/desktop/src-tauri/src/acp/preconnection_slash.rs
+++ b/packages/desktop/src-tauri/src/acp/preconnection_slash.rs
@@ -1,0 +1,498 @@
+use crate::acp::session_update::AvailableCommand;
+use crate::skills::parser::parse_skill_content;
+use std::collections::HashSet;
+use std::path::{Path, PathBuf};
+
+pub async fn load_preconnection_commands_from_root(
+    root: &Path,
+) -> Result<Vec<AvailableCommand>, String> {
+    load_preconnection_commands_from_roots(&[root.to_path_buf()]).await
+}
+
+pub async fn load_preconnection_commands_from_flat_markdown_root(
+    root: &Path,
+) -> Result<Vec<AvailableCommand>, String> {
+    let entries = load_flat_markdown_entries_from_root(root).await?;
+    Ok(dedupe_preconnection_commands(entries))
+}
+
+pub async fn load_preconnection_commands_from_roots(
+    roots: &[PathBuf],
+) -> Result<Vec<AvailableCommand>, String> {
+    let mut commands = Vec::new();
+    let mut seen_names = HashSet::new();
+
+    for root in roots {
+        let skill_entries = match load_skill_entries_from_root(root).await {
+            Ok(entries) => entries,
+            Err(error) => {
+                tracing::warn!(
+                    root = %root.display(),
+                    error = %error,
+                    "Skipping unreadable provider-owned preconnection root"
+                );
+                continue;
+            }
+        };
+        for entry in skill_entries {
+            if !seen_names.insert(entry.name.clone()) {
+                tracing::warn!(
+                    command_name = %entry.name,
+                    skill_path = %entry.path.display(),
+                    "Skipping duplicate provider-owned preconnection command"
+                );
+                continue;
+            }
+
+            commands.push(AvailableCommand {
+                name: entry.name,
+                description: entry.description,
+                input: None,
+            });
+        }
+    }
+
+    Ok(commands)
+}
+
+pub fn dedupe_preconnection_commands(
+    commands: impl IntoIterator<Item = AvailableCommand>,
+) -> Vec<AvailableCommand> {
+    let mut deduped = Vec::new();
+    let mut seen_names = HashSet::new();
+
+    for command in commands {
+        if !seen_names.insert(command.name.clone()) {
+            tracing::warn!(
+                command_name = %command.name,
+                "Skipping duplicate provider-owned preconnection command"
+            );
+            continue;
+        }
+
+        deduped.push(command);
+    }
+
+    deduped
+}
+
+#[derive(Debug, Clone)]
+struct SkillEntry {
+    name: String,
+    description: String,
+    path: PathBuf,
+}
+
+async fn load_skill_entries_from_root(root: &Path) -> Result<Vec<SkillEntry>, String> {
+    if !root.exists() {
+        return Ok(Vec::new());
+    }
+
+    let mut entries = tokio::fs::read_dir(root)
+        .await
+        .map_err(|error| format!("Failed to read preconnection slash directory: {}", error))?;
+    let mut dir_entries = Vec::new();
+
+    while let Some(entry) = entries
+        .next_entry()
+        .await
+        .map_err(|error| format!("Failed to read preconnection slash entry: {}", error))?
+    {
+        dir_entries.push(entry);
+    }
+
+    dir_entries.sort_by_key(|entry| entry.file_name());
+
+    let mut skill_entries = Vec::new();
+
+    for entry in dir_entries {
+        let folder_path = entry.path();
+        if !folder_path.is_dir() {
+            continue;
+        }
+
+        let folder_name = folder_path
+            .file_name()
+            .and_then(|segment| segment.to_str())
+            .unwrap_or("")
+            .to_string();
+        if folder_name.starts_with('.') {
+            continue;
+        }
+
+        let skill_md_path = folder_path.join("SKILL.md");
+        if !skill_md_path.exists() {
+            continue;
+        }
+
+        let content = match tokio::fs::read_to_string(&skill_md_path).await {
+            Ok(content) => content,
+            Err(error) => {
+                tracing::warn!(
+                    skill_path = %skill_md_path.display(),
+                    error = %error,
+                    "Skipping unreadable provider-owned preconnection skill"
+                );
+                continue;
+            }
+        };
+
+        let metadata = match parse_skill_content(&content) {
+            Ok((metadata, _body)) => metadata,
+            Err(error) => {
+                tracing::warn!(
+                    skill_path = %skill_md_path.display(),
+                    error = %error,
+                    "Skipping invalid provider-owned preconnection skill"
+                );
+                continue;
+            }
+        };
+
+        skill_entries.push(SkillEntry {
+            name: metadata.name,
+            description: metadata.description,
+            path: skill_md_path,
+        });
+    }
+
+    Ok(skill_entries)
+}
+
+async fn load_flat_markdown_entries_from_root(root: &Path) -> Result<Vec<AvailableCommand>, String> {
+    if !root.exists() {
+        return Ok(Vec::new());
+    }
+
+    let mut entries = tokio::fs::read_dir(root)
+        .await
+        .map_err(|error| format!("Failed to read preconnection slash directory: {}", error))?;
+    let mut dir_entries = Vec::new();
+
+    while let Some(entry) = entries
+        .next_entry()
+        .await
+        .map_err(|error| format!("Failed to read preconnection slash entry: {}", error))?
+    {
+        dir_entries.push(entry);
+    }
+
+    dir_entries.sort_by_key(|entry| entry.file_name());
+
+    let mut commands = Vec::new();
+
+    for entry in dir_entries {
+        let path = entry.path();
+        if path.is_dir() {
+            continue;
+        }
+
+        let file_name = path
+            .file_name()
+            .and_then(|segment| segment.to_str())
+            .unwrap_or("")
+            .to_string();
+        if file_name.starts_with('.') || !file_name.ends_with(".agent.md") {
+            continue;
+        }
+
+        let content = match tokio::fs::read_to_string(&path).await {
+            Ok(content) => content,
+            Err(error) => {
+                tracing::warn!(
+                    agent_path = %path.display(),
+                    error = %error,
+                    "Skipping unreadable provider-owned preconnection agent"
+                );
+                continue;
+            }
+        };
+
+        let command = match parse_flat_agent_command(&content, &path) {
+            Ok(command) => command,
+            Err(error) => {
+                tracing::warn!(
+                    agent_path = %path.display(),
+                    error = %error,
+                    "Skipping invalid provider-owned preconnection agent"
+                );
+                continue;
+            }
+        };
+
+        commands.push(command);
+    }
+
+    Ok(commands)
+}
+
+fn parse_flat_agent_command(content: &str, path: &Path) -> Result<AvailableCommand, String> {
+    let command_name = agent_name_from_path(path)?;
+
+    match parse_skill_content(content) {
+        Ok((metadata, _body)) => {
+            return Ok(AvailableCommand {
+                name: command_name,
+                description: metadata.description,
+                input: None,
+            })
+        }
+        Err(error) if error.contains("Required field 'name'") => {}
+        Err(error) => return Err(error),
+    }
+
+    let frontmatter = extract_frontmatter(content)?;
+    let mut description: Option<String> = None;
+
+    for line in frontmatter.lines() {
+        let trimmed = line.trim();
+        if trimmed.starts_with("description:") {
+            description = Some(extract_yaml_value(trimmed, "description:"));
+        }
+    }
+
+    let description =
+        description.ok_or("Required field 'description' not found in frontmatter".to_string())?;
+
+    Ok(AvailableCommand {
+        name: command_name,
+        description,
+        input: None,
+    })
+}
+
+fn extract_frontmatter(content: &str) -> Result<String, String> {
+    let lines: Vec<&str> = content.lines().collect();
+    if lines.is_empty() || lines[0] != "---" {
+        return Err("No YAML frontmatter found. Agent files must start with ---".to_string());
+    }
+
+    let end_idx = lines
+        .iter()
+        .skip(1)
+        .position(|line| *line == "---")
+        .map(|position| position + 1)
+        .ok_or("Invalid frontmatter: missing closing ---".to_string())?;
+
+    if end_idx < 2 {
+        return Err("Invalid frontmatter format".to_string());
+    }
+
+    Ok(lines[1..end_idx].join("\n"))
+}
+
+fn extract_yaml_value(line: &str, prefix: &str) -> String {
+    line.trim_start_matches(prefix)
+        .trim()
+        .trim_matches('"')
+        .trim_matches('\'')
+        .to_string()
+}
+
+fn agent_name_from_path(path: &Path) -> Result<String, String> {
+    let file_name = path
+        .file_name()
+        .and_then(|segment| segment.to_str())
+        .ok_or("Agent filename is missing".to_string())?;
+
+    if let Some(name) = file_name.strip_suffix(".agent.md") {
+        return Ok(name.to_string());
+    }
+
+    Err(format!(
+        "Agent filename must end with .agent.md: {}",
+        path.display()
+    ))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::tempdir;
+
+    fn skill_file_content(name: &str, description: &str) -> String {
+        format!(
+            "---\nname: \"{}\"\ndescription: \"{}\"\n---\n\n# {}\n",
+            name, description, name
+        )
+    }
+
+    #[tokio::test]
+    async fn load_preconnection_commands_from_root_skips_invalid_siblings() {
+        let temp = tempdir().expect("temp dir");
+        let valid_dir = temp.path().join("valid-skill");
+        let invalid_dir = temp.path().join("invalid-skill");
+        let hidden_dir = temp.path().join(".hidden-skill");
+
+        tokio::fs::create_dir_all(&valid_dir)
+            .await
+            .expect("create valid dir");
+        tokio::fs::create_dir_all(&invalid_dir)
+            .await
+            .expect("create invalid dir");
+        tokio::fs::create_dir_all(&hidden_dir)
+            .await
+            .expect("create hidden dir");
+        tokio::fs::write(
+            valid_dir.join("SKILL.md"),
+            skill_file_content("ce:review", "Review changes"),
+        )
+        .await
+        .expect("write valid skill");
+        tokio::fs::write(invalid_dir.join("SKILL.md"), "# missing frontmatter")
+            .await
+            .expect("write invalid skill");
+        tokio::fs::write(
+            hidden_dir.join("SKILL.md"),
+            skill_file_content("ce:hidden", "Hidden skill"),
+        )
+        .await
+        .expect("write hidden skill");
+
+        let commands = load_preconnection_commands_from_root(temp.path())
+            .await
+            .expect("load commands");
+
+        assert_eq!(commands.len(), 1);
+        assert_eq!(commands[0].name, "ce:review");
+        assert_eq!(commands[0].description, "Review changes");
+        assert!(commands[0].input.is_none());
+    }
+
+    #[tokio::test]
+    async fn load_preconnection_commands_from_roots_dedupes_duplicate_names() {
+        let temp = tempdir().expect("temp dir");
+        let primary_root = temp.path().join("primary");
+        let secondary_root = temp.path().join("secondary");
+        let primary_skill = primary_root.join("ce-plan");
+        let secondary_skill = secondary_root.join("ce-plan-duplicate");
+
+        tokio::fs::create_dir_all(&primary_skill)
+            .await
+            .expect("create primary skill dir");
+        tokio::fs::create_dir_all(&secondary_skill)
+            .await
+            .expect("create secondary skill dir");
+        tokio::fs::write(
+            primary_skill.join("SKILL.md"),
+            skill_file_content("ce:plan", "Plan implementation"),
+        )
+        .await
+        .expect("write primary skill");
+        tokio::fs::write(
+            secondary_skill.join("SKILL.md"),
+            skill_file_content("ce:plan", "Duplicate plan"),
+        )
+        .await
+        .expect("write secondary skill");
+
+        let commands = load_preconnection_commands_from_roots(&[primary_root, secondary_root])
+            .await
+            .expect("load commands");
+
+        assert_eq!(commands.len(), 1);
+        assert_eq!(commands[0].name, "ce:plan");
+        assert_eq!(commands[0].description, "Plan implementation");
+        assert!(commands[0].input.is_none());
+    }
+
+    #[tokio::test]
+    async fn load_preconnection_commands_from_roots_skips_unreadable_root_and_keeps_fallback() {
+        let temp = tempdir().expect("temp dir");
+        let unreadable_root = temp.path().join("not-a-directory");
+        let fallback_root = temp.path().join("fallback");
+        let fallback_skill = fallback_root.join("ce-review");
+
+        tokio::fs::write(&unreadable_root, "not a directory")
+            .await
+            .expect("write unreadable root placeholder");
+        tokio::fs::create_dir_all(&fallback_skill)
+            .await
+            .expect("create fallback skill dir");
+        tokio::fs::write(
+            fallback_skill.join("SKILL.md"),
+            skill_file_content("ce:review", "Review changes"),
+        )
+        .await
+        .expect("write fallback skill");
+
+        let commands = load_preconnection_commands_from_roots(&[unreadable_root, fallback_root])
+            .await
+            .expect("load commands");
+
+        assert_eq!(commands.len(), 1);
+        assert_eq!(commands[0].name, "ce:review");
+        assert_eq!(commands[0].description, "Review changes");
+        assert!(commands[0].input.is_none());
+    }
+
+    #[tokio::test]
+    async fn load_preconnection_commands_from_flat_markdown_root_reads_agent_files() {
+        let temp = tempdir().expect("temp dir");
+        let agent_path = temp.path().join("security-auditor.agent.md");
+        let ignored_path = temp.path().join("README.md");
+
+        tokio::fs::write(
+            &agent_path,
+            skill_file_content("security-auditor", "Review security-sensitive changes"),
+        )
+        .await
+        .expect("write agent file");
+        tokio::fs::write(&ignored_path, "# not an agent")
+            .await
+            .expect("write ignored markdown file");
+
+        let commands = load_preconnection_commands_from_flat_markdown_root(temp.path())
+            .await
+            .expect("load commands");
+
+        assert_eq!(commands.len(), 1);
+        assert_eq!(commands[0].name, "security-auditor");
+        assert_eq!(commands[0].description, "Review security-sensitive changes");
+        assert!(commands[0].input.is_none());
+    }
+
+    #[tokio::test]
+    async fn load_preconnection_commands_from_flat_markdown_root_falls_back_to_filename_when_name_missing() {
+        let temp = tempdir().expect("temp dir");
+        let agent_path = temp.path().join("security-auditor.agent.md");
+
+        tokio::fs::write(
+            &agent_path,
+            "---\ndescription: \"Review security-sensitive changes\"\n---\n\n# Security\n",
+        )
+        .await
+        .expect("write agent file");
+
+        let commands = load_preconnection_commands_from_flat_markdown_root(temp.path())
+            .await
+            .expect("load commands");
+
+        assert_eq!(commands.len(), 1);
+        assert_eq!(commands[0].name, "security-auditor");
+        assert_eq!(commands[0].description, "Review security-sensitive changes");
+        assert!(commands[0].input.is_none());
+    }
+
+    #[tokio::test]
+    async fn load_preconnection_commands_from_flat_markdown_root_uses_filename_when_name_differs() {
+        let temp = tempdir().expect("temp dir");
+        let agent_path = temp.path().join("security-auditor.agent.md");
+
+        tokio::fs::write(
+            &agent_path,
+            skill_file_content("Security Reviewer", "Review security-sensitive changes"),
+        )
+        .await
+        .expect("write agent file");
+
+        let commands = load_preconnection_commands_from_flat_markdown_root(temp.path())
+            .await
+            .expect("load commands");
+
+        assert_eq!(commands.len(), 1);
+        assert_eq!(commands[0].name, "security-auditor");
+        assert_eq!(commands[0].description, "Review security-sensitive changes");
+        assert!(commands[0].input.is_none());
+    }
+}

--- a/packages/desktop/src-tauri/src/acp/provider.rs
+++ b/packages/desktop/src-tauri/src/acp/provider.rs
@@ -17,7 +17,7 @@ use crate::acp::parsers::provider_capabilities::{
 use crate::acp::parsers::AgentType;
 use crate::acp::provider_extensions::{InboundResponseAdapter, ProviderExtensionEvent};
 use crate::acp::session_descriptor::SessionReplayContext;
-use crate::acp::session_update::{PlanConfidence, PlanSource, SessionUpdate};
+use crate::acp::session_update::{AvailableCommand, PlanConfidence, PlanSource, SessionUpdate};
 use crate::acp::task_reconciler::TaskReconciliationPolicy;
 use crate::acp::types::CanonicalAgentId;
 use crate::history::session_context::SessionContext;
@@ -163,6 +163,14 @@ pub enum AutonomousApplyStrategy {
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Type)]
 #[serde(rename_all = "camelCase")]
+pub enum PreconnectionSlashMode {
+    Unsupported,
+    StartupGlobal,
+    ProjectScoped,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Type)]
+#[serde(rename_all = "camelCase")]
 pub struct FrontendProviderProjection {
     pub provider_brand: &'static str,
     pub display_name: &'static str,
@@ -172,6 +180,7 @@ pub struct FrontendProviderProjection {
     pub default_alias: Option<&'static str>,
     pub reasoning_effort_support: bool,
     pub autonomous_apply_strategy: AutonomousApplyStrategy,
+    pub preconnection_slash_mode: PreconnectionSlashMode,
 }
 
 impl Default for FrontendProviderProjection {
@@ -185,6 +194,7 @@ impl Default for FrontendProviderProjection {
             default_alias: None,
             reasoning_effort_support: false,
             autonomous_apply_strategy: AutonomousApplyStrategy::PostConnect,
+            preconnection_slash_mode: PreconnectionSlashMode::Unsupported,
         }
     }
 }
@@ -425,6 +435,15 @@ pub trait AgentProvider: Send + Sync {
         builtin_capabilities_for_provider_id(self.id())
             .map(|capabilities| capabilities.frontend_projection)
             .unwrap_or_default()
+    }
+
+    /// Provider-owned preconnection slash entry loading before a session exists.
+    fn list_preconnection_commands<'a>(
+        &'a self,
+        _app: &'a AppHandle,
+        _cwd: Option<&'a Path>,
+    ) -> Pin<Box<dyn Future<Output = Result<Vec<AvailableCommand>, String>> + Send + 'a>> {
+        Box::pin(async { Ok(Vec::new()) })
     }
 
     /// Provider-owned hook for enriching parsed session updates before shared processing.

--- a/packages/desktop/src-tauri/src/acp/providers/claude_code.rs
+++ b/packages/desktop/src-tauri/src/acp/providers/claude_code.rs
@@ -5,12 +5,13 @@ use super::super::provider::{
 use super::claude_code_settings::resolve_claude_runtime_mode_id;
 use crate::acp::client_trait::CommunicationMode;
 use crate::acp::session_descriptor::SessionReplayContext;
+use crate::acp::session_update::AvailableCommand;
 use crate::acp::task_reconciler::TaskReconciliationPolicy;
 use crate::acp::{agent_installer, types::CanonicalAgentId};
 use crate::history::session_context::SessionContext;
 use crate::session_jsonl::types::ConvertedSession;
 use std::future::Future;
-use std::path::Path;
+use std::path::{Path, PathBuf};
 use std::pin::Pin;
 use tauri::AppHandle;
 
@@ -137,6 +138,22 @@ impl AgentProvider for ClaudeCodeProvider {
 
     fn resolve_runtime_mode_id(&self, requested_mode_id: Option<&str>, cwd: &Path) -> String {
         resolve_claude_runtime_mode_id(requested_mode_id, cwd)
+    }
+
+    fn list_preconnection_commands<'a>(
+        &'a self,
+        _app: &'a AppHandle,
+        _cwd: Option<&'a Path>,
+    ) -> Pin<Box<dyn Future<Output = Result<Vec<AvailableCommand>, String>> + Send + 'a>> {
+        Box::pin(async move {
+            match claude_skills_root() {
+                Some(root) => crate::acp::preconnection_slash::load_preconnection_commands_from_root(
+                    &root,
+                )
+                .await,
+                None => Ok(Vec::new()),
+            }
+        })
     }
 
     fn uses_task_reconciler(&self) -> bool {
@@ -274,6 +291,10 @@ fn resolve_claude_spawn_configs() -> Vec<SpawnConfig> {
 
 fn claude_env() -> std::collections::HashMap<String, String> {
     crate::shell_env::build_env(crate::shell_env::EnvStrategy::FullInherit)
+}
+
+fn claude_skills_root() -> Option<PathBuf> {
+    dirs::home_dir().map(|home| home.join(".claude").join("skills"))
 }
 
 async fn read_cwd_from_project_dir(project_dir: &std::path::Path) -> Option<String> {

--- a/packages/desktop/src-tauri/src/acp/providers/codex.rs
+++ b/packages/desktop/src-tauri/src/acp/providers/codex.rs
@@ -4,12 +4,14 @@ use super::super::provider::{
 use crate::acp::client::codex_native_config::CODEX_BUILD_FULL_ACCESS_MODE_ID;
 use crate::acp::client_trait::CommunicationMode;
 use crate::acp::session_descriptor::SessionReplayContext;
+use crate::acp::session_update::AvailableCommand;
 use crate::acp::session_update::SessionUpdate;
 use crate::acp::types::ContentBlock;
 use crate::acp::{agent_installer, types::CanonicalAgentId};
 use crate::history::session_context::SessionContext;
 use crate::session_jsonl::types::ConvertedSession;
 use std::future::Future;
+use std::path::{Path, PathBuf};
 use std::pin::Pin;
 use tauri::AppHandle;
 
@@ -60,6 +62,22 @@ impl AgentProvider for CodexProvider {
 
     fn communication_mode(&self) -> CommunicationMode {
         CommunicationMode::CodexNative
+    }
+
+    fn list_preconnection_commands<'a>(
+        &'a self,
+        _app: &'a AppHandle,
+        _cwd: Option<&'a Path>,
+    ) -> Pin<Box<dyn Future<Output = Result<Vec<AvailableCommand>, String>> + Send + 'a>> {
+        Box::pin(async move {
+            match codex_skills_root() {
+                Some(root) => crate::acp::preconnection_slash::load_preconnection_commands_from_root(
+                    &root,
+                )
+                .await,
+                None => Ok(Vec::new()),
+            }
+        })
     }
 
     fn icon(&self) -> &str {
@@ -180,6 +198,10 @@ pub(crate) fn adapt_codex_wrapper_plan_update(update: &SessionUpdate) -> Option<
 
 fn codex_env() -> std::collections::HashMap<String, String> {
     crate::shell_env::build_env(crate::shell_env::EnvStrategy::FullInherit)
+}
+
+fn codex_skills_root() -> Option<PathBuf> {
+    dirs::home_dir().map(|home| home.join(".codex").join("skills"))
 }
 
 fn push_unique_spawn_config(configs: &mut Vec<SpawnConfig>, candidate: SpawnConfig) {

--- a/packages/desktop/src-tauri/src/acp/providers/copilot.rs
+++ b/packages/desktop/src-tauri/src/acp/providers/copilot.rs
@@ -4,6 +4,7 @@ use crate::acp::client_session::{SessionModelState, SessionModes};
 use crate::acp::error::{AcpError, AcpResult};
 use crate::acp::parsers::AgentType;
 use crate::acp::session_descriptor::SessionReplayContext;
+use crate::acp::session_update::AvailableCommand;
 use crate::acp::task_reconciler::TaskReconciliationPolicy;
 use crate::acp::{agent_installer, types::CanonicalAgentId};
 use crate::db::repository::SessionMetadataRepository;
@@ -91,6 +92,39 @@ impl AgentProvider for CopilotProvider {
 
     fn task_reconciliation_policy(&self) -> TaskReconciliationPolicy {
         TaskReconciliationPolicy::ImplicitSingleActiveParent
+    }
+
+    fn list_preconnection_commands<'a>(
+        &'a self,
+        _app: &'a AppHandle,
+        cwd: Option<&'a Path>,
+    ) -> Pin<Box<dyn Future<Output = Result<Vec<AvailableCommand>, String>> + Send + 'a>> {
+        Box::pin(async move {
+            let Some(cwd) = cwd else {
+                return Ok(Vec::new());
+            };
+
+            let agents_root = cwd.join(".agents");
+            let skills_root = agents_root.join("skills");
+            let nested_skill_commands =
+                crate::acp::preconnection_slash::load_preconnection_commands_from_root(&skills_root)
+                    .await?;
+            let nested_agent_commands =
+                crate::acp::preconnection_slash::load_preconnection_commands_from_root(&agents_root)
+                    .await?;
+            let flat_agent_commands =
+                crate::acp::preconnection_slash::load_preconnection_commands_from_flat_markdown_root(
+                    &agents_root,
+                )
+                .await?;
+
+            Ok(crate::acp::preconnection_slash::dedupe_preconnection_commands(
+                nested_skill_commands
+                    .into_iter()
+                    .chain(nested_agent_commands)
+                    .chain(flat_agent_commands),
+            ))
+        })
     }
 
     fn authenticate_request_params(&self, auth_methods: &[Value]) -> AcpResult<Option<Value>> {

--- a/packages/desktop/src-tauri/src/acp/providers/cursor.rs
+++ b/packages/desktop/src-tauri/src/acp/providers/cursor.rs
@@ -14,6 +14,7 @@ use crate::acp::cursor_extensions::{
 use crate::acp::error::{AcpError, AcpResult};
 use crate::acp::provider_extensions::{InboundResponseAdapter, ProviderExtensionEvent};
 use crate::acp::session_descriptor::SessionReplayContext;
+use crate::acp::session_update::AvailableCommand;
 use crate::acp::session_update::SessionUpdate;
 use crate::acp::task_reconciler::TaskReconciliationPolicy;
 use crate::history::session_context::SessionContext;
@@ -21,6 +22,7 @@ use crate::session_jsonl::types::ConvertedSession;
 use serde_json::{json, Value};
 use std::collections::HashMap;
 use std::future::Future;
+use std::path::{Path, PathBuf};
 use std::pin::Pin;
 use tauri::AppHandle;
 
@@ -113,6 +115,22 @@ impl AgentProvider for CursorProvider {
         }
 
         Ok(Some(json!({ "methodId": "cursor_login" })))
+    }
+
+    fn list_preconnection_commands<'a>(
+        &'a self,
+        _app: &'a AppHandle,
+        _cwd: Option<&'a Path>,
+    ) -> Pin<Box<dyn Future<Output = Result<Vec<AvailableCommand>, String>> + Send + 'a>> {
+        Box::pin(async move {
+            match cursor_skills_root() {
+                Some(root) => crate::acp::preconnection_slash::load_preconnection_commands_from_root(
+                    &root,
+                )
+                .await,
+                None => Ok(Vec::new()),
+            }
+        })
     }
 
     fn normalize_mode_id(&self, id: &str) -> String {
@@ -325,6 +343,10 @@ const ALLOWED_ENV_KEYS: &[&str] = &[
 
 fn filtered_env() -> HashMap<String, String> {
     crate::shell_env::build_env(crate::shell_env::EnvStrategy::Allowlist(ALLOWED_ENV_KEYS))
+}
+
+fn cursor_skills_root() -> Option<PathBuf> {
+    dirs::home_dir().map(|home| home.join(".cursor").join("skills"))
 }
 
 async fn list_cursor_project_paths() -> Result<Vec<String>, String> {

--- a/packages/desktop/src-tauri/src/acp/providers/opencode.rs
+++ b/packages/desktop/src-tauri/src/acp/providers/opencode.rs
@@ -5,7 +5,9 @@ use super::opencode_settings::apply_opencode_session_defaults;
 use crate::acp::client_session::{SessionModelState, SessionModes};
 use crate::acp::client_trait::CommunicationMode;
 use crate::acp::error::AcpResult;
+use crate::acp::opencode::{OpenCodeHttpClient, OpenCodeManagerRegistry};
 use crate::acp::session_descriptor::SessionReplayContext;
+use crate::acp::session_update::AvailableCommand;
 use crate::acp::types::CanonicalAgentId;
 use crate::history::session_context::SessionContext;
 use crate::session_jsonl::types::ConvertedSession;
@@ -13,7 +15,9 @@ use std::collections::HashMap;
 use std::future::Future;
 use std::path::Path;
 use std::pin::Pin;
+use std::sync::Arc;
 use tauri::AppHandle;
+use tauri::Manager;
 
 /// OpenCode HTTP Agent Provider
 /// Uses HTTP REST API + SSE instead of ACP JSON-RPC
@@ -114,6 +118,32 @@ impl AgentProvider for OpenCodeProvider {
     fn communication_mode(&self) -> CommunicationMode {
         // OpenCode uses HTTP mode for full permission/question support
         CommunicationMode::Http
+    }
+
+    fn list_preconnection_commands<'a>(
+        &'a self,
+        app: &'a AppHandle,
+        cwd: Option<&'a Path>,
+    ) -> Pin<Box<dyn Future<Output = Result<Vec<AvailableCommand>, String>> + Send + 'a>> {
+        Box::pin(async move {
+            let Some(cwd) = cwd else {
+                return Ok(Vec::new());
+            };
+
+            let opencode_manager = app.state::<Arc<OpenCodeManagerRegistry>>();
+            let (project_key, manager) = opencode_manager
+                .get_or_start(cwd)
+                .await
+                .map_err(|error| error.to_string())?;
+            let provider = Arc::new(OpenCodeProvider);
+            let mut client = OpenCodeHttpClient::new(manager, project_key, provider)
+                .map_err(|error| error.to_string())?;
+
+            client
+                .list_preconnection_commands(cwd.to_string_lossy().to_string())
+                .await
+                .map_err(|error| error.to_string())
+        })
     }
 
     fn icon(&self) -> &str {

--- a/packages/desktop/src-tauri/src/acp/registry.rs
+++ b/packages/desktop/src-tauri/src/acp/registry.rs
@@ -3,7 +3,7 @@ use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::sync::{Arc, Mutex};
 
-use crate::acp::provider::{AgentProvider, AgentUiVisibility};
+use crate::acp::provider::{AgentProvider, AgentUiVisibility, FrontendProviderProjection};
 use crate::acp::providers::{
     ClaudeCodeProvider, CodexProvider, CopilotProvider, CursorProvider, CustomAgentConfig,
     ForgeProvider, OpenCodeProvider,
@@ -20,7 +20,7 @@ pub enum AgentAvailabilityKind {
 }
 
 /// Information about an available agent
-#[derive(Debug, Clone, Serialize, Deserialize, specta::Type)]
+#[derive(Debug, Clone, Serialize, specta::Type)]
 pub struct AgentInfo {
     pub id: String,
     pub name: String,
@@ -29,6 +29,8 @@ pub struct AgentInfo {
     pub availability_kind: AgentAvailabilityKind,
     /// Visible UI modes that support wrapper-managed Autonomous execution.
     pub autonomous_supported_mode_ids: Vec<String>,
+    /// Provider-owned metadata for shared frontend surfaces.
+    pub provider_metadata: FrontendProviderProjection,
     /// Registry-owned default selection precedence for UI surfaces.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub default_selection_rank: Option<u16>,
@@ -140,6 +142,7 @@ impl AgentRegistry {
                         .iter()
                         .map(|mode_id| (*mode_id).to_string())
                         .collect(),
+                    provider_metadata: provider.frontend_projection(),
                     default_selection_rank: Some(index as u16),
                 });
             }
@@ -174,6 +177,7 @@ impl AgentRegistry {
                     .iter()
                     .map(|mode_id| (*mode_id).to_string())
                     .collect(),
+                provider_metadata: provider.frontend_projection(),
                 default_selection_rank: None,
             });
         }
@@ -365,6 +369,32 @@ mod tests {
 
         assert_eq!(claude.default_selection_rank, Some(0));
         assert_eq!(custom.default_selection_rank, None);
+    }
+
+    #[test]
+    fn list_all_for_ui_exposes_provider_metadata_projection() {
+        let registry = AgentRegistry::new();
+        let agents = registry.list_all_for_ui();
+        let claude = agents
+            .iter()
+            .find(|agent| agent.id == "claude-code")
+            .expect("Claude agent should exist");
+        let copilot = agents
+            .iter()
+            .find(|agent| agent.id == "copilot")
+            .expect("Copilot agent should exist");
+
+        let claude_json = serde_json::to_value(claude).expect("serialize Claude agent");
+        let copilot_json = serde_json::to_value(copilot).expect("serialize Copilot agent");
+
+        assert_eq!(
+            claude_json["provider_metadata"]["preconnectionSlashMode"],
+            serde_json::Value::String("startupGlobal".to_string())
+        );
+        assert_eq!(
+            copilot_json["provider_metadata"]["preconnectionSlashMode"],
+            serde_json::Value::String("projectScoped".to_string())
+        );
     }
 
     #[test]

--- a/packages/desktop/src/lib/acp/components/__tests__/model-selector-logic.test.ts
+++ b/packages/desktop/src/lib/acp/components/__tests__/model-selector-logic.test.ts
@@ -508,6 +508,7 @@ describe("model-selector-logic", () => {
 						defaultAlias: undefined,
 						reasoningEffortSupport: true,
 						autonomousApplyStrategy: "postConnect",
+						preconnectionSlashMode: "startupGlobal",
 					},
 				},
 			};
@@ -531,6 +532,7 @@ describe("model-selector-logic", () => {
 					defaultAlias: "default",
 					reasoningEffortSupport: false,
 					autonomousApplyStrategy: "launchProfile",
+					preconnectionSlashMode: "startupGlobal",
 				},
 			},
 		};
@@ -554,6 +556,7 @@ describe("model-selector-logic", () => {
 				defaultAlias: "default",
 				reasoningEffortSupport: false,
 				autonomousApplyStrategy: "launchProfile",
+				preconnectionSlashMode: "startupGlobal",
 			});
 		});
 	});

--- a/packages/desktop/src/lib/acp/components/agent-input/agent-input-ui.svelte
+++ b/packages/desktop/src/lib/acp/components/agent-input/agent-input-ui.svelte
@@ -175,6 +175,30 @@ const capabilitiesAgentId = $derived.by(() => {
 const sessionCapabilities = $derived(
 	props.sessionId ? sessionStore.getCapabilities(props.sessionId) : null
 );
+const capabilitiesAgent = $derived.by(() => {
+	if (!capabilitiesAgentId) {
+		return null;
+	}
+
+	for (const agent of agentStore.agents) {
+		if (agent.id === capabilitiesAgentId) {
+			return agent;
+		}
+	}
+
+	return null;
+});
+const capabilitiesProviderMetadata = $derived.by(() => {
+	if (sessionCapabilities?.providerMetadata) {
+		return sessionCapabilities.providerMetadata;
+	}
+
+	if (capabilitiesAgent) {
+		return capabilitiesAgent.providerMetadata;
+	}
+
+	return null;
+});
 
 // Get hot state for current mode/model
 const sessionHotState = $derived(
@@ -301,6 +325,7 @@ const preconnectionAvailableCommands = $derived.by(() => {
 	return preconnectionRemoteCommandsState.getCommands({
 		agentId: capabilitiesAgentId,
 		projectPath: filePickerProjectPath,
+		preconnectionSlashMode: capabilitiesProviderMetadata?.preconnectionSlashMode ?? "unsupported",
 		skillCommands: preconnectionAgentSkillsStore.getCommandsForAgent(capabilitiesAgentId),
 	});
 });
@@ -646,10 +671,11 @@ function handleEditorInput(options?: { suppressAutocomplete?: boolean }): void {
 			if (
 				capabilitiesAgentId &&
 				!hasConnectedSession &&
+				capabilitiesProviderMetadata?.preconnectionSlashMode === "startupGlobal" &&
 				!preconnectionAgentSkillsStore.loaded &&
 				!preconnectionAgentSkillsStore.loading
 			) {
-				preconnectionAgentSkillsStore.ensureLoaded().mapErr((error) => {
+				preconnectionAgentSkillsStore.ensureLoaded(agentStore.agents).mapErr((error) => {
 					logger.error("Failed to warm preconnection skills", {
 						agentId: capabilitiesAgentId,
 						projectPath: filePickerProjectPath,
@@ -664,6 +690,8 @@ function handleEditorInput(options?: { suppressAutocomplete?: boolean }): void {
 					agentId: capabilitiesAgentId,
 					hasConnectedSession,
 					projectPath: filePickerProjectPath,
+					preconnectionSlashMode:
+						capabilitiesProviderMetadata?.preconnectionSlashMode ?? "unsupported",
 				})
 				.mapErr((error) => {
 					logger.error("Failed to warm remote preconnection commands", {

--- a/packages/desktop/src/lib/acp/components/agent-input/logic/preconnection-remote-commands-state.svelte.ts
+++ b/packages/desktop/src/lib/acp/components/agent-input/logic/preconnection-remote-commands-state.svelte.ts
@@ -1,19 +1,22 @@
+import { SvelteMap } from "svelte/reactivity";
 import { okAsync, type ResultAsync } from "neverthrow";
-import { getAgentCapabilities } from "$lib/acp/constants/agent-capabilities.js";
 import { tauriClient } from "$lib/utils/tauri-client.js";
 import type { AppError } from "$lib/acp/errors/app-error.js";
 import type { AvailableCommand } from "$lib/acp/types/available-command.js";
+import type { ProviderMetadataProjection } from "$lib/services/acp-types.js";
 import { createLogger } from "$lib/acp/utils/logger.js";
 
 interface EnsureLoadedInput {
 	agentId: string | null;
 	hasConnectedSession: boolean;
 	projectPath: string | null;
+	preconnectionSlashMode: ProviderMetadataProjection["preconnectionSlashMode"];
 }
 
 interface GetCommandsInput {
 	agentId: string | null;
 	projectPath: string | null;
+	preconnectionSlashMode: ProviderMetadataProjection["preconnectionSlashMode"];
 	skillCommands: ReadonlyArray<AvailableCommand>;
 }
 
@@ -27,30 +30,34 @@ const logger = createLogger({
 	name: "PreconnectionRemoteCommands",
 });
 
+function buildProjectScopedCacheKey(
+	agentId: string | null,
+	projectPath: string | null
+): string | null {
+	if (!agentId || !projectPath) {
+		return null;
+	}
+
+	return `${agentId}::${projectPath}`;
+}
+
 export function shouldLoadRemotePreconnectionCommands(input: {
 	agentId: string | null;
 	hasConnectedSession: boolean;
 	projectPath: string | null;
-	loadedProjectPath: string | null;
-	loadingProjectPath: string | null;
+	preconnectionSlashMode: ProviderMetadataProjection["preconnectionSlashMode"];
+	alreadyLoaded: boolean;
+	alreadyLoading: boolean;
 }): boolean {
-	if (!getAgentCapabilities(input.agentId).loadsRemotePreconnectionCommands) {
+	if (input.preconnectionSlashMode !== "projectScoped") {
 		return false;
 	}
 
-	if (input.hasConnectedSession) {
+	if (!input.agentId || input.hasConnectedSession || !input.projectPath) {
 		return false;
 	}
 
-	if (!input.projectPath) {
-		return false;
-	}
-
-	if (input.loadedProjectPath === input.projectPath) {
-		return false;
-	}
-
-	if (input.loadingProjectPath === input.projectPath) {
+	if (input.alreadyLoaded || input.alreadyLoading) {
 		return false;
 	}
 
@@ -58,9 +65,8 @@ export function shouldLoadRemotePreconnectionCommands(input: {
 }
 
 export class PreconnectionRemoteCommandsState {
-	loadedProjectPath = $state<string | null>(null);
-	loadingProjectPath = $state<string | null>(null);
-	private remoteCommands = $state<AvailableCommand[]>([]);
+	loadingCacheKey = $state<string | null>(null);
+	private readonly remoteCommandsByKey = new SvelteMap<string, AvailableCommand[]>();
 	private readonly fetchRemoteCommands: FetchRemoteCommands;
 
 	constructor(fetchRemoteCommands?: FetchRemoteCommands) {
@@ -69,20 +75,25 @@ export class PreconnectionRemoteCommandsState {
 	}
 
 	ensureLoaded(input: EnsureLoadedInput): ResultAsync<void, AppError> {
+		const cacheKey = buildProjectScopedCacheKey(input.agentId, input.projectPath);
+		const alreadyLoaded = cacheKey ? this.remoteCommandsByKey.has(cacheKey) : false;
+		const alreadyLoading = cacheKey !== null && this.loadingCacheKey === cacheKey;
+
 		if (
 			!shouldLoadRemotePreconnectionCommands({
 				agentId: input.agentId,
 				hasConnectedSession: input.hasConnectedSession,
 				projectPath: input.projectPath,
-				loadedProjectPath: this.loadedProjectPath,
-				loadingProjectPath: this.loadingProjectPath,
+				preconnectionSlashMode: input.preconnectionSlashMode,
+				alreadyLoaded,
+				alreadyLoading,
 			})
 		) {
 			return okAsync(undefined);
 		}
 
 		const projectPath = input.projectPath;
-		if (!projectPath) {
+		if (!projectPath || !cacheKey) {
 			return okAsync(undefined);
 		}
 
@@ -91,48 +102,53 @@ export class PreconnectionRemoteCommandsState {
 			return okAsync(undefined);
 		}
 
-		logger.info("Loading remote preconnection commands", {
+		logger.info("Loading project-scoped preconnection commands", {
 			agentId,
 			projectPath,
 		});
-		this.loadingProjectPath = projectPath;
+		this.loadingCacheKey = cacheKey;
 
 		return this.fetchRemoteCommands(projectPath, agentId)
 			.map((commands) => {
-				logger.info("Loaded remote preconnection commands", {
+				logger.info("Loaded project-scoped preconnection commands", {
 					agentId,
 					projectPath,
 					count: commands.length,
 					commandNames: commands.map((command) => command.name),
 				});
-				this.remoteCommands = commands;
-				this.loadedProjectPath = projectPath;
-				if (this.loadingProjectPath === projectPath) {
-					this.loadingProjectPath = null;
+				this.remoteCommandsByKey.set(cacheKey, commands);
+				if (this.loadingCacheKey === cacheKey) {
+					this.loadingCacheKey = null;
 				}
 			})
 			.mapErr((error) => {
-				logger.error("Failed to load remote preconnection commands", {
+				logger.error("Failed to load project-scoped preconnection commands", {
 					agentId,
 					projectPath,
 					error: error.message,
 				});
-				if (this.loadingProjectPath === projectPath) {
-					this.loadingProjectPath = null;
+				if (this.loadingCacheKey === cacheKey) {
+					this.loadingCacheKey = null;
 				}
 				return error;
 			});
 	}
 
 	getCommands(input: GetCommandsInput): AvailableCommand[] {
-		if (
-			getAgentCapabilities(input.agentId).loadsRemotePreconnectionCommands &&
-			input.projectPath &&
-			input.projectPath === this.loadedProjectPath
-		) {
-			return Array.from(this.remoteCommands);
+		if (input.preconnectionSlashMode !== "projectScoped") {
+			return Array.from(input.skillCommands);
 		}
 
-		return Array.from(input.skillCommands);
+		const cacheKey = buildProjectScopedCacheKey(input.agentId, input.projectPath);
+		if (!cacheKey) {
+			return Array.from(input.skillCommands);
+		}
+
+		const remoteCommands = this.remoteCommandsByKey.get(cacheKey);
+		if (!remoteCommands) {
+			return Array.from(input.skillCommands);
+		}
+
+		return Array.from(remoteCommands);
 	}
 }

--- a/packages/desktop/src/lib/acp/components/agent-input/logic/preconnection-remote-commands-state.vitest.ts
+++ b/packages/desktop/src/lib/acp/components/agent-input/logic/preconnection-remote-commands-state.vitest.ts
@@ -22,16 +22,15 @@ describe("PreconnectionRemoteCommandsState", () => {
 		fetchFn.mockReset();
 	});
 
-	it("loads OpenCode commands for a project before a session exists", async () => {
-		fetchFn.mockReturnValueOnce(
-			okAsync([makeCommand("compact", "compact the session")])
-		);
+	it("loads project-scoped commands before a session exists", async () => {
+		fetchFn.mockReturnValueOnce(okAsync([makeCommand("compact", "compact the session")]));
 
 		const state = new PreconnectionRemoteCommandsState(fetchFn);
 		const result = await state.ensureLoaded({
 			agentId: "opencode",
 			hasConnectedSession: false,
 			projectPath: "/repo",
+			preconnectionSlashMode: "projectScoped",
 		});
 
 		expect(result.isOk()).toBe(true);
@@ -40,12 +39,13 @@ describe("PreconnectionRemoteCommandsState", () => {
 			state.getCommands({
 				agentId: "opencode",
 				projectPath: "/repo",
+				preconnectionSlashMode: "projectScoped",
 				skillCommands: [makeCommand("ce:brainstorm", "Brainstorm")],
 			})
 		).toEqual([makeCommand("compact", "compact the session")]);
 	});
 
-	it("falls back to skill commands for non-OpenCode agents", async () => {
+	it("falls back to startup-global commands for non-project-scoped providers", async () => {
 		const state = new PreconnectionRemoteCommandsState(fetchFn);
 		const skillCommands = [makeCommand("ce:brainstorm", "Brainstorm")];
 
@@ -53,6 +53,7 @@ describe("PreconnectionRemoteCommandsState", () => {
 			agentId: "claude-code",
 			hasConnectedSession: false,
 			projectPath: "/repo",
+			preconnectionSlashMode: "startupGlobal",
 		});
 
 		expect(result.isOk()).toBe(true);
@@ -61,27 +62,28 @@ describe("PreconnectionRemoteCommandsState", () => {
 			state.getCommands({
 				agentId: "claude-code",
 				projectPath: "/repo",
+				preconnectionSlashMode: "startupGlobal",
 				skillCommands,
 			})
 		).toEqual(skillCommands);
 	});
 
-	it("does not refetch OpenCode commands when the same project is already loaded", async () => {
-		fetchFn.mockReturnValue(
-			okAsync([makeCommand("compact", "compact the session")])
-		);
+	it("does not refetch commands when the same agent and project are already loaded", async () => {
+		fetchFn.mockReturnValue(okAsync([makeCommand("compact", "compact the session")]));
 
 		const state = new PreconnectionRemoteCommandsState(fetchFn);
 		await state.ensureLoaded({
-			agentId: "opencode",
+			agentId: "copilot",
 			hasConnectedSession: false,
 			projectPath: "/repo",
+			preconnectionSlashMode: "projectScoped",
 		});
 
 		const second = await state.ensureLoaded({
-			agentId: "opencode",
+			agentId: "copilot",
 			hasConnectedSession: false,
 			projectPath: "/repo",
+			preconnectionSlashMode: "projectScoped",
 		});
 
 		expect(second.isOk()).toBe(true);
@@ -98,22 +100,24 @@ describe("PreconnectionRemoteCommandsState", () => {
 			agentId: "opencode",
 			hasConnectedSession: false,
 			projectPath: "/repo",
+			preconnectionSlashMode: "projectScoped",
 		});
 
 		expect(result.isErr()).toBe(true);
-		expect(state.loadingProjectPath).toBeNull();
+		expect(state.loadingCacheKey).toBeNull();
 	});
 });
 
 describe("shouldLoadRemotePreconnectionCommands", () => {
-	it("only loads for OpenCode before connection when a project path is present", () => {
+	it("only loads for project-scoped providers before connection when a project path is present", () => {
 		expect(
 			shouldLoadRemotePreconnectionCommands({
 				agentId: "opencode",
 				hasConnectedSession: false,
 				projectPath: "/repo",
-				loadedProjectPath: null,
-				loadingProjectPath: null,
+				preconnectionSlashMode: "projectScoped",
+				alreadyLoaded: false,
+				alreadyLoading: false,
 			})
 		).toBe(true);
 
@@ -122,8 +126,9 @@ describe("shouldLoadRemotePreconnectionCommands", () => {
 				agentId: "opencode",
 				hasConnectedSession: true,
 				projectPath: "/repo",
-				loadedProjectPath: null,
-				loadingProjectPath: null,
+				preconnectionSlashMode: "projectScoped",
+				alreadyLoaded: false,
+				alreadyLoading: false,
 			})
 		).toBe(false);
 
@@ -132,8 +137,9 @@ describe("shouldLoadRemotePreconnectionCommands", () => {
 				agentId: "claude-code",
 				hasConnectedSession: false,
 				projectPath: "/repo",
-				loadedProjectPath: null,
-				loadingProjectPath: null,
+				preconnectionSlashMode: "startupGlobal",
+				alreadyLoaded: false,
+				alreadyLoading: false,
 			})
 		).toBe(false);
 	});

--- a/packages/desktop/src/lib/acp/components/agent-input/logic/slash-command-source.ts
+++ b/packages/desktop/src/lib/acp/components/agent-input/logic/slash-command-source.ts
@@ -15,11 +15,7 @@ export function shouldShowSlashCommandDropdown(input: {
 		return false;
 	}
 
-	if (input.source.source !== "none") {
-		return true;
-	}
-
-	return input.capabilitiesAgentId ? true : false;
+	return input.source.source !== "none" && input.capabilitiesAgentId !== null;
 }
 
 export function resolveSlashCommandSource(input: {
@@ -28,10 +24,18 @@ export function resolveSlashCommandSource(input: {
 	selectedAgentId: string | null;
 	preconnectionCommands: ReadonlyArray<AvailableCommand>;
 }): SlashCommandSource {
-	if (input.hasConnectedSession && input.liveCommands.length > 0) {
+	if (input.hasConnectedSession) {
+		if (input.liveCommands.length > 0) {
+			return {
+				source: "live",
+				commands: Array.from(input.liveCommands),
+				tokenType: "command",
+			};
+		}
+
 		return {
-			source: "live",
-			commands: Array.from(input.liveCommands),
+			source: "none",
+			commands: [],
 			tokenType: "command",
 		};
 	}

--- a/packages/desktop/src/lib/acp/components/agent-input/logic/slash-command-source.vitest.ts
+++ b/packages/desktop/src/lib/acp/components/agent-input/logic/slash-command-source.vitest.ts
@@ -5,57 +5,12 @@ import {
 } from "./slash-command-source.js";
 
 describe("resolveSlashCommandSource", () => {
-	it("prefers live commands when they exist", () => {
+	it("does not fall back to preconnection commands once a session is connected", () => {
 		const source = resolveSlashCommandSource({
-			liveCommands: [{ name: "review", description: "Review code" }],
+			liveCommands: [],
 			hasConnectedSession: true,
-			selectedAgentId: "claude-code",
-			preconnectionCommands: [{ name: "ce:brainstorm", description: "Brainstorm" }],
-		});
-
-		expect(source).toEqual({
-			source: "live",
-			commands: [{ name: "review", description: "Review code" }],
-			tokenType: "command",
-		});
-	});
-
-	it("ignores stale live commands before connection and uses preconnection skills", () => {
-		const source = resolveSlashCommandSource({
-			liveCommands: [{ name: "review", description: "Review code" }],
-			hasConnectedSession: false,
-			selectedAgentId: "claude-code",
-			preconnectionCommands: [{ name: "ce:brainstorm", description: "Brainstorm" }],
-		});
-
-		expect(source).toEqual({
-			source: "preconnection",
-			commands: [{ name: "ce:brainstorm", description: "Brainstorm" }],
-			tokenType: "skill",
-		});
-	});
-
-	it("uses preconnection commands when live commands are absent", () => {
-		const source = resolveSlashCommandSource({
-			liveCommands: [],
-			hasConnectedSession: false,
-			selectedAgentId: "claude-code",
-			preconnectionCommands: [{ name: "ce:brainstorm", description: "Brainstorm" }],
-		});
-
-		expect(source).toEqual({
-			source: "preconnection",
-			commands: [{ name: "ce:brainstorm", description: "Brainstorm" }],
-			tokenType: "skill",
-		});
-	});
-
-	it("returns none when no selected agent or no commands exist", () => {
-		const source = resolveSlashCommandSource({
-			liveCommands: [],
-			hasConnectedSession: false,
-			selectedAgentId: null,
-			preconnectionCommands: [],
+			selectedAgentId: "copilot",
+			preconnectionCommands: [{ name: "ce:review", description: "Review changes" }],
 		});
 
 		expect(source).toEqual({
@@ -65,65 +20,33 @@ describe("resolveSlashCommandSource", () => {
 		});
 	});
 
-	it("falls back to preconnection skills after connection when live commands are empty", () => {
+	it("uses preconnection commands before connection when they exist", () => {
 		const source = resolveSlashCommandSource({
 			liveCommands: [],
-			hasConnectedSession: true,
+			hasConnectedSession: false,
 			selectedAgentId: "claude-code",
-			preconnectionCommands: [{ name: "ce:brainstorm", description: "Brainstorm" }],
+			preconnectionCommands: [{ name: "ce:plan", description: "Plan work" }],
 		});
 
 		expect(source).toEqual({
 			source: "preconnection",
-			commands: [{ name: "ce:brainstorm", description: "Brainstorm" }],
+			commands: [{ name: "ce:plan", description: "Plan work" }],
 			tokenType: "skill",
 		});
 	});
+});
 
-	it("shows the dropdown empty state when an agent is selected but no slash commands exist", () => {
-		const source = resolveSlashCommandSource({
-			liveCommands: [],
-			hasConnectedSession: false,
-			selectedAgentId: "opencode",
-			preconnectionCommands: [],
-		});
-
+describe("shouldShowSlashCommandDropdown", () => {
+	it("hides the dropdown when no slash source exists", () => {
 		expect(
 			shouldShowSlashCommandDropdown({
 				isTriggerActive: true,
-				source,
-				capabilitiesAgentId: "opencode",
-			})
-		).toBe(true);
-	});
-
-	it("keeps the dropdown hidden when no agent context exists", () => {
-		const source = resolveSlashCommandSource({
-			liveCommands: [],
-			hasConnectedSession: false,
-			selectedAgentId: null,
-			preconnectionCommands: [],
-		});
-
-		expect(
-			shouldShowSlashCommandDropdown({
-				isTriggerActive: true,
-				source,
-				capabilitiesAgentId: null,
-			})
-		).toBe(false);
-	});
-
-	it("keeps the dropdown hidden when the slash trigger is inactive", () => {
-		expect(
-			shouldShowSlashCommandDropdown({
-				isTriggerActive: false,
 				source: {
-					source: "preconnection",
-					commands: [{ name: "ce:brainstorm", description: "Brainstorm" }],
-					tokenType: "skill",
+					source: "none",
+					commands: [],
+					tokenType: "command",
 				},
-				capabilitiesAgentId: "opencode",
+				capabilitiesAgentId: "copilot",
 			})
 		).toBe(false);
 	});

--- a/packages/desktop/src/lib/acp/constants/__tests__/agent-capabilities.test.ts
+++ b/packages/desktop/src/lib/acp/constants/__tests__/agent-capabilities.test.ts
@@ -7,21 +7,18 @@ describe("getAgentCapabilities", () => {
 	it("returns Claude Code's open-in-finder capability", () => {
 		expect(getAgentCapabilities(AGENT_IDS.CLAUDE_CODE)).toEqual({
 			openInFinderTarget: "claude-session",
-			loadsRemotePreconnectionCommands: false,
 		});
 	});
 
-	it("returns OpenCode's remote preconnection capability", () => {
+	it("returns OpenCode's project-path capability", () => {
 		expect(getAgentCapabilities(AGENT_IDS.OPENCODE)).toEqual({
 			openInFinderTarget: "project-path",
-			loadsRemotePreconnectionCommands: true,
 		});
 	});
 
 	it("falls back to default capabilities for other agents", () => {
 		expect(getAgentCapabilities(AGENT_IDS.CURSOR)).toEqual({
 			openInFinderTarget: "project-path",
-			loadsRemotePreconnectionCommands: false,
 		});
 	});
 });

--- a/packages/desktop/src/lib/acp/constants/agent-capabilities.ts
+++ b/packages/desktop/src/lib/acp/constants/agent-capabilities.ts
@@ -4,12 +4,10 @@ export type OpenInFinderTargetCapability = "project-path" | "claude-session";
 
 export interface AgentCapabilities {
 	openInFinderTarget: OpenInFinderTargetCapability;
-	loadsRemotePreconnectionCommands: boolean;
 }
 
 const DEFAULT_AGENT_CAPABILITIES = {
 	openInFinderTarget: "project-path",
-	loadsRemotePreconnectionCommands: false,
 } as const satisfies AgentCapabilities;
 
 const AGENT_CAPABILITY_OVERRIDES: Readonly<
@@ -17,9 +15,6 @@ const AGENT_CAPABILITY_OVERRIDES: Readonly<
 > = {
 	[AGENT_IDS.CLAUDE_CODE]: {
 		openInFinderTarget: "claude-session",
-	},
-	[AGENT_IDS.OPENCODE]: {
-		loadsRemotePreconnectionCommands: true,
 	},
 };
 
@@ -34,8 +29,5 @@ export function getAgentCapabilities(
 	return {
 		openInFinderTarget:
 			overrides?.openInFinderTarget ?? DEFAULT_AGENT_CAPABILITIES.openInFinderTarget,
-		loadsRemotePreconnectionCommands:
-			overrides?.loadsRemotePreconnectionCommands ??
-			DEFAULT_AGENT_CAPABILITIES.loadsRemotePreconnectionCommands,
 	};
 }

--- a/packages/desktop/src/lib/acp/store/provider-metadata.contract.test.ts
+++ b/packages/desktop/src/lib/acp/store/provider-metadata.contract.test.ts
@@ -18,7 +18,7 @@ describe("provider metadata projection contract", () => {
 		for (const [agentId, metadata] of Object.entries(BUILTIN_PROVIDER_METADATA_BY_AGENT_ID)) {
 			expect(rustSource).toMatch(
 				new RegExp(
-					`provider_id:\\s*"${agentId}"[\\s\\S]*?frontend_projection:\\s*FrontendProviderProjection\\s*\\{[\\s\\S]*?provider_brand:\\s*"${metadata.providerBrand}"[\\s\\S]*?display_name:\\s*"${metadata.displayName}"[\\s\\S]*?display_order:\\s*${metadata.displayOrder}[\\s\\S]*?supports_model_defaults:\\s*${metadata.supportsModelDefaults}[\\s\\S]*?variant_group:\\s*FrontendVariantGroup::${metadata.variantGroup === "reasoningEffort" ? "ReasoningEffort" : "Plain"}[\\s\\S]*?default_alias:\\s*${metadata.defaultAlias ? `Some\\("${metadata.defaultAlias}"\\)` : "None"}[\\s\\S]*?reasoning_effort_support:\\s*${metadata.reasoningEffortSupport}[\\s\\S]*?autonomous_apply_strategy:\\s*AutonomousApplyStrategy::${metadata.autonomousApplyStrategy === "launchProfile" ? "LaunchProfile" : "PostConnect"}`,
+					`provider_id:\\s*"${agentId}"[\\s\\S]*?frontend_projection:\\s*FrontendProviderProjection\\s*\\{[\\s\\S]*?provider_brand:\\s*"${metadata.providerBrand}"[\\s\\S]*?display_name:\\s*"${metadata.displayName}"[\\s\\S]*?display_order:\\s*${metadata.displayOrder}[\\s\\S]*?supports_model_defaults:\\s*${metadata.supportsModelDefaults}[\\s\\S]*?variant_group:\\s*FrontendVariantGroup::${metadata.variantGroup === "reasoningEffort" ? "ReasoningEffort" : "Plain"}[\\s\\S]*?default_alias:\\s*${metadata.defaultAlias ? `Some\\("${metadata.defaultAlias}"\\)` : "None"}[\\s\\S]*?reasoning_effort_support:\\s*${metadata.reasoningEffortSupport}[\\s\\S]*?autonomous_apply_strategy:\\s*AutonomousApplyStrategy::${metadata.autonomousApplyStrategy === "launchProfile" ? "LaunchProfile" : "PostConnect"}[\\s\\S]*?preconnection_slash_mode:\\s*PreconnectionSlashMode::${metadata.preconnectionSlashMode === "startupGlobal" ? "StartupGlobal" : metadata.preconnectionSlashMode === "projectScoped" ? "ProjectScoped" : "Unsupported"}`,
 					"m"
 				)
 			);
@@ -35,6 +35,7 @@ describe("provider metadata projection contract", () => {
 			defaultAlias: undefined,
 			reasoningEffortSupport: false,
 			autonomousApplyStrategy: "postConnect",
+			preconnectionSlashMode: "unsupported",
 		});
 	});
 

--- a/packages/desktop/src/lib/components/main-app-view/logic/managers/initialization-manager.ts
+++ b/packages/desktop/src/lib/components/main-app-view/logic/managers/initialization-manager.ts
@@ -287,6 +287,24 @@ export class InitializationManager {
 	 * @returns ResultAsync indicating success or error
 	 */
 	private loadBasicMetadata(): ResultAsync<void, MainAppViewError> {
+		const loadAgentsAndWarmPreconnectionCommands = this.agentStore
+			.loadAvailableAgents()
+			.mapErr(
+				(error) =>
+					new InitializationError(
+						"loadAvailableAgents",
+						error instanceof Error ? error : undefined
+					)
+			)
+			.andThen((agents) =>
+				this.preconnectionAgentSkillsStore.initialize(agents).orElse((error) => {
+					logger.warn("Failed to warm preconnection agent skills; continuing startup", {
+						error,
+					});
+					return okAsync(undefined);
+				})
+			);
+
 		return NeverthrowResultAsync.combine([
 			this.keybindingsService
 				.loadUserKeybindings()
@@ -301,15 +319,7 @@ export class InitializationManager {
 							error instanceof Error ? error : undefined
 						)
 				),
-			this.agentStore
-				.loadAvailableAgents()
-				.mapErr(
-					(error) =>
-						new InitializationError(
-							"loadAvailableAgents",
-							error instanceof Error ? error : undefined
-						)
-				),
+			loadAgentsAndWarmPreconnectionCommands,
 			this.projectManager
 				.loadProjects()
 				.mapErr(
@@ -322,12 +332,6 @@ export class InitializationManager {
 					(error) =>
 						new InitializationError("initializeZoom", error instanceof Error ? error : undefined)
 				),
-			this.preconnectionAgentSkillsStore.initialize().orElse((error) => {
-				logger.warn("Failed to warm preconnection agent skills; continuing startup", {
-					error,
-				});
-				return okAsync(undefined);
-			}),
 		]).map(() => undefined);
 	}
 

--- a/packages/desktop/src/lib/components/settings-page/sections/agents-models-section.logic.test.ts
+++ b/packages/desktop/src/lib/components/settings-page/sections/agents-models-section.logic.test.ts
@@ -63,6 +63,7 @@ describe("getAgentModelDefaultsEntries", () => {
 		defaultAlias: "default",
 		reasoningEffortSupport: false,
 		autonomousApplyStrategy: "launchProfile",
+		preconnectionSlashMode: "startupGlobal",
 	};
 
 	const cursorProviderMetadata: ProviderMetadataProjection = {
@@ -74,6 +75,7 @@ describe("getAgentModelDefaultsEntries", () => {
 		defaultAlias: "auto",
 		reasoningEffortSupport: false,
 		autonomousApplyStrategy: "postConnect",
+		preconnectionSlashMode: "startupGlobal",
 	};
 
 	const copilotProviderMetadata: ProviderMetadataProjection = {
@@ -85,6 +87,7 @@ describe("getAgentModelDefaultsEntries", () => {
 		defaultAlias: undefined,
 		reasoningEffortSupport: false,
 		autonomousApplyStrategy: "postConnect",
+		preconnectionSlashMode: "projectScoped",
 	};
 
 	const agents: Agent[] = [
@@ -141,6 +144,7 @@ describe("getAgentModelDefaultsEntries", () => {
 					defaultAlias: "auto",
 					reasoningEffortSupport: false,
 					autonomousApplyStrategy: "postConnect",
+					preconnectionSlashMode: "startupGlobal",
 				},
 			},
 		};
@@ -183,6 +187,7 @@ describe("getAgentsByProviderOrder", () => {
 						defaultAlias: "auto",
 						reasoningEffortSupport: false,
 						autonomousApplyStrategy: "postConnect",
+						preconnectionSlashMode: "startupGlobal",
 					},
 				},
 				{
@@ -202,6 +207,7 @@ describe("getAgentsByProviderOrder", () => {
 						defaultAlias: "default",
 						reasoningEffortSupport: false,
 						autonomousApplyStrategy: "launchProfile",
+						preconnectionSlashMode: "startupGlobal",
 					},
 				},
 			],
@@ -224,6 +230,7 @@ describe("getProviderDefaultLabel", () => {
 				defaultAlias: "auto",
 				reasoningEffortSupport: false,
 				autonomousApplyStrategy: "postConnect",
+				preconnectionSlashMode: "startupGlobal",
 			})
 		).toBe("Auto");
 	});
@@ -239,6 +246,7 @@ describe("getProviderDefaultLabel", () => {
 				defaultAlias: undefined,
 				reasoningEffortSupport: false,
 				autonomousApplyStrategy: "postConnect",
+				preconnectionSlashMode: "projectScoped",
 			})
 		).toBe("Agent default");
 	});

--- a/packages/desktop/src/lib/services/acp-types.ts
+++ b/packages/desktop/src/lib/services/acp-types.ts
@@ -35,14 +35,187 @@ export type ModelDisplayFamily = "claudeLike" | "codexReasoningEffort" | "provid
 
 export type UsageMetricsPresentation = "contextWindowOnly" | "spendAndContext"
 
-export type ModelPresentationMetadata = { displayFamily: ModelDisplayFamily; usageMetrics: UsageMetricsPresentation }
+export type ProviderBrand =
+	| "claude-code"
+	| "copilot"
+	| "cursor"
+	| "opencode"
+	| "codex"
+	| "custom"
+
+export type ProviderVariantGroup = "plain" | "reasoningEffort"
+
+export type AutonomousApplyStrategy = "postConnect" | "launchProfile"
+
+export type PreconnectionSlashMode = "unsupported" | "startupGlobal" | "projectScoped"
+
+export type ProviderMetadataProjection = {
+	providerBrand: ProviderBrand
+	displayName: string
+	displayOrder: number
+	supportsModelDefaults: boolean
+	variantGroup: ProviderVariantGroup
+	defaultAlias?: string
+	reasoningEffortSupport: boolean
+	autonomousApplyStrategy: AutonomousApplyStrategy
+	preconnectionSlashMode: PreconnectionSlashMode
+}
+
+export type ModelPresentationMetadata = {
+	displayFamily: ModelDisplayFamily
+	usageMetrics: UsageMetricsPresentation
+	provider?: ProviderMetadataProjection
+}
 
 /**
  * Display-ready model structure. Single representation—flat = one group.
  */
 export type ModelsForDisplay = { groups: DisplayModelGroup[]; presentation?: ModelPresentationMetadata }
 
-export type SessionModelState = { availableModels?: AvailableModel[]; currentModelId?: string; modelsDisplay?: ModelsForDisplay }
+export type SessionModelState = {
+	availableModels?: AvailableModel[]
+	currentModelId?: string
+	modelsDisplay?: ModelsForDisplay
+	providerMetadata?: ProviderMetadataProjection
+}
+
+export const BUILTIN_PROVIDER_METADATA_BY_AGENT_ID: Record<string, ProviderMetadataProjection> = {
+	"claude-code": {
+		providerBrand: "claude-code",
+		displayName: "Claude Code",
+		displayOrder: 10,
+		supportsModelDefaults: true,
+		variantGroup: "plain",
+		defaultAlias: "default",
+		reasoningEffortSupport: false,
+		autonomousApplyStrategy: "launchProfile",
+		preconnectionSlashMode: "startupGlobal",
+	},
+	copilot: {
+		providerBrand: "copilot",
+		displayName: "GitHub Copilot",
+		displayOrder: 30,
+		supportsModelDefaults: false,
+		variantGroup: "plain",
+		defaultAlias: undefined,
+		reasoningEffortSupport: false,
+		autonomousApplyStrategy: "postConnect",
+		preconnectionSlashMode: "projectScoped",
+	},
+	cursor: {
+		providerBrand: "cursor",
+		displayName: "Cursor",
+		displayOrder: 20,
+		supportsModelDefaults: true,
+		variantGroup: "plain",
+		defaultAlias: "auto",
+		reasoningEffortSupport: false,
+		autonomousApplyStrategy: "postConnect",
+		preconnectionSlashMode: "startupGlobal",
+	},
+	opencode: {
+		providerBrand: "opencode",
+		displayName: "OpenCode",
+		displayOrder: 40,
+		supportsModelDefaults: true,
+		variantGroup: "plain",
+		defaultAlias: undefined,
+		reasoningEffortSupport: false,
+		autonomousApplyStrategy: "postConnect",
+		preconnectionSlashMode: "projectScoped",
+	},
+	codex: {
+		providerBrand: "codex",
+		displayName: "Codex",
+		displayOrder: 50,
+		supportsModelDefaults: true,
+		variantGroup: "reasoningEffort",
+		defaultAlias: undefined,
+		reasoningEffortSupport: true,
+		autonomousApplyStrategy: "postConnect",
+		preconnectionSlashMode: "startupGlobal",
+	},
+}
+
+function cloneProviderMetadataProjection(
+	providerMetadata: ProviderMetadataProjection
+): ProviderMetadataProjection {
+	return {
+		providerBrand: providerMetadata.providerBrand,
+		displayName: providerMetadata.displayName,
+		displayOrder: providerMetadata.displayOrder,
+		supportsModelDefaults: providerMetadata.supportsModelDefaults,
+		variantGroup: providerMetadata.variantGroup,
+		defaultAlias: providerMetadata.defaultAlias,
+		reasoningEffortSupport: providerMetadata.reasoningEffortSupport,
+		autonomousApplyStrategy: providerMetadata.autonomousApplyStrategy,
+		preconnectionSlashMode: providerMetadata.preconnectionSlashMode,
+	}
+}
+
+export function resolveProviderMetadataProjection(
+	agentId: string,
+	providerMetadata: ProviderMetadataProjection | null | undefined,
+	fallbackDisplayName?: string
+): ProviderMetadataProjection {
+	if (providerMetadata) {
+		return cloneProviderMetadataProjection(providerMetadata)
+	}
+
+	const builtInProviderMetadata = BUILTIN_PROVIDER_METADATA_BY_AGENT_ID[agentId]
+	if (builtInProviderMetadata) {
+		return cloneProviderMetadataProjection(builtInProviderMetadata)
+	}
+
+	return {
+		providerBrand: "custom",
+		displayName: fallbackDisplayName ?? agentId,
+		displayOrder: 65535,
+		supportsModelDefaults: false,
+		variantGroup: "plain",
+		defaultAlias: undefined,
+		reasoningEffortSupport: false,
+		autonomousApplyStrategy: "postConnect",
+		preconnectionSlashMode: "unsupported",
+	}
+}
+
+export function getProviderMetadataFromModelsDisplay(
+	modelsDisplay: ModelsForDisplay | null | undefined
+): ProviderMetadataProjection | null {
+	return modelsDisplay?.presentation?.provider ?? null
+}
+
+export function normalizeModelsForDisplay(
+	agentId: string,
+	modelsDisplay: ModelsForDisplay | null | undefined,
+	fallbackDisplayName?: string,
+	providerMetadataOverride?: ProviderMetadataProjection | null
+): ModelsForDisplay | null {
+	if (!modelsDisplay) {
+		return null
+	}
+
+	const presentation = modelsDisplay.presentation
+	const providerMetadata = resolveProviderMetadataProjection(
+		agentId,
+		providerMetadataOverride ?? presentation?.provider,
+		fallbackDisplayName
+	)
+	const displayFamily =
+		presentation?.displayFamily ??
+		(providerMetadata.variantGroup === "reasoningEffort"
+			? "codexReasoningEffort"
+			: "providerGrouped")
+	return {
+		groups: modelsDisplay.groups,
+		presentation: {
+			displayFamily,
+			usageMetrics: presentation?.usageMetrics ?? "spendAndContext",
+			provider: providerMetadata,
+		},
+	}
+}
 
 export type SessionModes = { currentModeId?: string; availableModes?: AvailableMode[] }
 
@@ -183,4 +356,3 @@ export type InteractionResponse = { kind: "permission"; accepted: boolean; optio
 export type InteractionSnapshot = { id: string; session_id: string; kind: InteractionKind; state: InteractionState; json_rpc_request_id: number | null; reply_handler: InteractionReplyHandler | null; tool_reference: ToolReference | null; responded_at_event_seq: number | null; response: InteractionResponse | null; payload: InteractionPayload }
 
 export type SessionProjectionSnapshot = { session: SessionSnapshot | null; operations: OperationSnapshot[]; interactions: InteractionSnapshot[] }
-

--- a/packages/desktop/src/lib/skills/store/preconnection-agent-skills-store.svelte.ts
+++ b/packages/desktop/src/lib/skills/store/preconnection-agent-skills-store.svelte.ts
@@ -1,11 +1,11 @@
-import { okAsync, type ResultAsync } from "neverthrow";
+import { ResultAsync, okAsync } from "neverthrow";
 import { getContext, setContext } from "svelte";
 import { SvelteMap } from "svelte/reactivity";
 import type { AvailableCommand } from "$lib/acp/types/available-command.js";
 import type { AppError } from "$lib/acp/errors/app-error.js";
 import { createLogger } from "$lib/acp/utils/logger.js";
-import { skillsApi } from "../api/skills-api.js";
-import type { AgentSkills } from "../types/index.js";
+import type { ProviderMetadataProjection } from "$lib/services/acp-types.js";
+import { tauriClient } from "$lib/utils/tauri-client.js";
 
 const PRECONNECTION_AGENT_SKILLS_STORE_KEY = Symbol("preconnection-agent-skills-store");
 const logger = createLogger({
@@ -13,31 +13,45 @@ const logger = createLogger({
 	name: "PreconnectionAgentSkillsStore",
 });
 
-export function normalizeAgentSkillsToCommands(
-	agentSkills: AgentSkills
+interface WarmablePreconnectionAgent {
+	readonly id: string;
+	readonly providerMetadata?: ProviderMetadataProjection;
+}
+
+type FetchPreconnectionCommands = (
+	cwd: string,
+	agentId: string
+) => ResultAsync<AvailableCommand[], AppError>;
+
+export function normalizePreconnectionCommands(
+	commands: ReadonlyArray<AvailableCommand>,
+	agentId: string
 ): AvailableCommand[] {
-	const commands: AvailableCommand[] = [];
+	const normalized: AvailableCommand[] = [];
 	const seenNames = new Set<string>();
 
-	for (const skill of agentSkills.skills) {
-		const commandName = skill.name;
-		if (seenNames.has(commandName)) {
-			logger.warn("Skipping duplicate preconnection skill command", {
-				agentId: agentSkills.agentId,
-				commandName,
-				skillId: skill.id,
+	for (const command of commands) {
+		if (seenNames.has(command.name)) {
+			logger.warn("Skipping duplicate provider-owned preconnection command", {
+				agentId,
+				commandName: command.name,
 			});
 			continue;
 		}
 
-		seenNames.add(commandName);
-		commands.push({
-			name: commandName,
-			description: skill.description,
+		seenNames.add(command.name);
+		normalized.push({
+			name: command.name,
+			description: command.description,
+			input: command.input,
 		});
 	}
 
-	return commands;
+	return normalized;
+}
+
+function isStartupGlobalPreconnectionAgent(agent: WarmablePreconnectionAgent): boolean {
+	return agent.providerMetadata?.preconnectionSlashMode === "startupGlobal";
 }
 
 export class PreconnectionAgentSkillsStore {
@@ -45,24 +59,31 @@ export class PreconnectionAgentSkillsStore {
 	loaded = $state(false);
 	error = $state<string | null>(null);
 	private readonly commandsByAgent = new SvelteMap<string, AvailableCommand[]>();
+	private readonly fetchPreconnectionCommands: FetchPreconnectionCommands;
 
-	initialize(): ResultAsync<void, AppError> {
+	constructor(fetchPreconnectionCommands?: FetchPreconnectionCommands) {
+		this.fetchPreconnectionCommands = fetchPreconnectionCommands
+			? fetchPreconnectionCommands
+			: tauriClient.acp.listPreconnectionCommands;
+	}
+
+	initialize(agents: ReadonlyArray<WarmablePreconnectionAgent>): ResultAsync<void, AppError> {
 		if (this.loading || this.loaded) {
 			return okAsync(undefined);
 		}
 
-		return this.refresh();
+		return this.refresh(agents);
 	}
 
-	ensureLoaded(): ResultAsync<void, AppError> {
+	ensureLoaded(agents: ReadonlyArray<WarmablePreconnectionAgent>): ResultAsync<void, AppError> {
 		if (this.loading || this.loaded) {
 			return okAsync(undefined);
 		}
 
-		return this.refresh();
+		return this.refresh(agents);
 	}
 
-	refresh(): ResultAsync<void, AppError> {
+	refresh(agents: ReadonlyArray<WarmablePreconnectionAgent>): ResultAsync<void, AppError> {
 		if (this.loading) {
 			return okAsync(undefined);
 		}
@@ -70,10 +91,24 @@ export class PreconnectionAgentSkillsStore {
 		this.loading = true;
 		this.error = null;
 
-		return skillsApi
-			.listAgentSkills()
-			.map((agentSkills) => {
-				this.replaceCommands(agentSkills);
+		const warmableAgents = agents.filter((agent) => isStartupGlobalPreconnectionAgent(agent));
+		if (warmableAgents.length === 0) {
+			this.commandsByAgent.clear();
+			this.loading = false;
+			this.loaded = true;
+			return okAsync(undefined);
+		}
+
+		return ResultAsync.combine(
+			warmableAgents.map((agent) =>
+				this.fetchPreconnectionCommands("", agent.id).map((commands) => ({
+					agentId: agent.id,
+					commands: normalizePreconnectionCommands(commands, agent.id),
+				}))
+			)
+		)
+			.map((commandsByAgent) => {
+				this.replaceCommands(commandsByAgent);
 				this.loading = false;
 				this.loaded = true;
 			})
@@ -95,11 +130,16 @@ export class PreconnectionAgentSkillsStore {
 		return commands ? commands : [];
 	}
 
-	private replaceCommands(agentSkills: AgentSkills[]): void {
+	private replaceCommands(
+		commandsByAgent: ReadonlyArray<{
+			readonly agentId: string;
+			readonly commands: ReadonlyArray<AvailableCommand>;
+		}>
+	): void {
 		this.commandsByAgent.clear();
 
-		for (const group of agentSkills) {
-			this.commandsByAgent.set(group.agentId, normalizeAgentSkillsToCommands(group));
+		for (const group of commandsByAgent) {
+			this.commandsByAgent.set(group.agentId, Array.from(group.commands));
 		}
 	}
 }

--- a/packages/desktop/src/lib/skills/store/preconnection-agent-skills-store.vitest.ts
+++ b/packages/desktop/src/lib/skills/store/preconnection-agent-skills-store.vitest.ts
@@ -1,178 +1,114 @@
-import { mock } from "bun:test";
 import { errAsync, okAsync } from "neverthrow";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { AgentError } from "../../acp/errors/app-error";
-import type { AgentSkills, Skill } from "../types/index.js";
-
-const listAgentSkillsMock = vi.fn();
+import type { ProviderMetadataProjection } from "../../services/acp-types.js";
 
 let PreconnectionAgentSkillsStore: typeof import("./preconnection-agent-skills-store.svelte.js").PreconnectionAgentSkillsStore;
-let normalizeAgentSkillsToCommands: typeof import("./preconnection-agent-skills-store.svelte.js").normalizeAgentSkillsToCommands;
+let normalizePreconnectionCommands: typeof import("./preconnection-agent-skills-store.svelte.js").normalizePreconnectionCommands;
 
-function buildSkill(options: {
-	id: string;
-	agentId: string;
-	folderName: string;
-	name: string;
-	description: string;
-}): Skill {
+function providerMetadata(preconnectionSlashMode: ProviderMetadataProjection["preconnectionSlashMode"]): ProviderMetadataProjection {
 	return {
-		id: options.id,
-		agentId: options.agentId,
-		folderName: options.folderName,
-		path: `/tmp/${options.agentId}/${options.folderName}/SKILL.md`,
-		name: options.name,
-		description: options.description,
-		content: "",
-		modifiedAt: 1,
+		providerBrand: "custom",
+		displayName: "Test",
+		displayOrder: 1,
+		supportsModelDefaults: false,
+		variantGroup: "plain",
+		defaultAlias: undefined,
+		reasoningEffortSupport: false,
+		autonomousApplyStrategy: "postConnect",
+		preconnectionSlashMode,
 	};
 }
 
-function buildAgentSkills(agentId: string, skills: Skill[]): AgentSkills {
+function buildAgent(
+	id: string,
+	preconnectionSlashMode: ProviderMetadataProjection["preconnectionSlashMode"]
+): {
+	readonly id: string;
+	readonly providerMetadata: ProviderMetadataProjection;
+} {
 	return {
-		agentId,
-		skills,
+		id,
+		providerMetadata: providerMetadata(preconnectionSlashMode),
 	};
 }
 
 describe("PreconnectionAgentSkillsStore", () => {
 	beforeEach(async () => {
-		listAgentSkillsMock.mockReset();
-
-		mock.module("../api/skills-api.js", () => ({
-			skillsApi: {
-				listAgentSkills: listAgentSkillsMock,
-			},
-		}));
-
-		({ PreconnectionAgentSkillsStore, normalizeAgentSkillsToCommands } = await import(
+		({ PreconnectionAgentSkillsStore, normalizePreconnectionCommands } = await import(
 			"./preconnection-agent-skills-store.svelte.js"
 		));
 	});
 
-	it("normalizes on-disk skills by agent using frontmatter name and description", async () => {
-		listAgentSkillsMock.mockReturnValue(
-			okAsync([
-				buildAgentSkills("claude-code", [
-					buildSkill({
-						id: "skill-1",
-						agentId: "claude-code",
-						folderName: "brainstorm-feature",
-						name: "ce:brainstorm",
-						description: "Brainstorm a feature",
-					}),
-				]),
-				buildAgentSkills("cursor", []),
-			])
-		);
+	it("warms startup-global providers through the shared ACP preconnection command", async () => {
+		const fetchPreconnectionCommands = vi
+			.fn()
+			.mockReturnValueOnce(okAsync([{ name: "ce:brainstorm", description: "Brainstorm" }]));
 
-		const store = new PreconnectionAgentSkillsStore();
-		const result = await store.initialize();
+		const store = new PreconnectionAgentSkillsStore(fetchPreconnectionCommands);
+		const result = await store.initialize([
+			buildAgent("claude-code", "startupGlobal"),
+			buildAgent("copilot", "projectScoped"),
+		]);
 
 		expect(result.isOk()).toBe(true);
-		expect(store.loaded).toBe(true);
+		expect(fetchPreconnectionCommands).toHaveBeenCalledTimes(1);
+		expect(fetchPreconnectionCommands).toHaveBeenCalledWith("", "claude-code");
 		expect(store.getCommandsForAgent("claude-code")).toEqual([
 			{
 				name: "ce:brainstorm",
-				description: "Brainstorm a feature",
+				description: "Brainstorm",
+				input: undefined,
 			},
 		]);
-		expect(store.getCommandsForAgent("cursor")).toEqual([]);
+		expect(store.getCommandsForAgent("copilot")).toEqual([]);
 	});
 
-	it("drops later duplicate names within one agent deterministically", () => {
-		const commands = normalizeAgentSkillsToCommands(
-			buildAgentSkills("claude-code", [
-				buildSkill({
-					id: "skill-1",
-					agentId: "claude-code",
-					folderName: "brainstorm-first",
-					name: "ce:brainstorm",
-					description: "First description",
-				}),
-				buildSkill({
-					id: "skill-2",
-					agentId: "claude-code",
-					folderName: "brainstorm-second",
-					name: "ce:brainstorm",
-					description: "Second description",
-				}),
-			])
+	it("drops later duplicate command names deterministically", () => {
+		const commands = normalizePreconnectionCommands(
+			[
+				{ name: "ce:plan", description: "First description" },
+				{ name: "ce:plan", description: "Second description" },
+			],
+			"claude-code"
 		);
 
 		expect(commands).toEqual([
 			{
-				name: "ce:brainstorm",
+				name: "ce:plan",
 				description: "First description",
+				input: undefined,
 			},
 		]);
 	});
 
-	it("keeps the store retryable when initialization fails", async () => {
-		listAgentSkillsMock.mockReturnValue(
-			errAsync(new AgentError("skills_list_agent_skills", new Error("boom")))
-		);
+	it("keeps the store retryable when warmup fails", async () => {
+		const fetchPreconnectionCommands = vi
+			.fn()
+			.mockReturnValue(
+				errAsync(new AgentError("acp_list_preconnection_commands", new Error("boom")))
+			);
 
-		const store = new PreconnectionAgentSkillsStore();
-		const result = await store.initialize();
+		const store = new PreconnectionAgentSkillsStore(fetchPreconnectionCommands);
+		const result = await store.initialize([buildAgent("claude-code", "startupGlobal")]);
 
 		expect(result.isErr()).toBe(true);
 		expect(store.loaded).toBe(false);
-		expect(store.error).toBe("Agent operation failed: skills_list_agent_skills");
+		expect(store.error).toBe("Agent operation failed: acp_list_preconnection_commands");
 		expect(store.getCommandsForAgent("claude-code")).toEqual([]);
 	});
 
 	it("can retry successfully after an initialization failure", async () => {
-		listAgentSkillsMock
-			.mockReturnValueOnce(errAsync(new AgentError("skills_list_agent_skills", new Error("boom"))))
+		const fetchPreconnectionCommands = vi
+			.fn()
 			.mockReturnValueOnce(
-				okAsync([
-					buildAgentSkills("claude-code", [
-						buildSkill({
-							id: "skill-1",
-							agentId: "claude-code",
-							folderName: "plan-implementation",
-							name: "ce:plan",
-							description: "Plan implementation",
-						}),
-					]),
-				])
-			);
+				errAsync(new AgentError("acp_list_preconnection_commands", new Error("boom")))
+			)
+			.mockReturnValueOnce(okAsync([{ name: "ce:review", description: "Review changes" }]));
 
-		const store = new PreconnectionAgentSkillsStore();
-		const firstResult = await store.initialize();
-		const secondResult = await store.initialize();
-
-		expect(firstResult.isErr()).toBe(true);
-		expect(secondResult.isOk()).toBe(true);
-		expect(store.getCommandsForAgent("claude-code")).toEqual([
-			{
-				name: "ce:plan",
-				description: "Plan implementation",
-			},
-		]);
-	});
-
-	it("ensureLoaded retries after a failed startup warmup", async () => {
-		listAgentSkillsMock
-			.mockReturnValueOnce(errAsync(new AgentError("skills_list_agent_skills", new Error("boom"))))
-			.mockReturnValueOnce(
-				okAsync([
-					buildAgentSkills("claude-code", [
-						buildSkill({
-							id: "skill-1",
-							agentId: "claude-code",
-							folderName: "review-changes",
-							name: "ce:review",
-							description: "Review changes",
-						}),
-					]),
-				])
-			);
-
-		const store = new PreconnectionAgentSkillsStore();
-		const firstResult = await store.initialize();
-		const secondResult = await store.ensureLoaded();
+		const store = new PreconnectionAgentSkillsStore(fetchPreconnectionCommands);
+		const firstResult = await store.initialize([buildAgent("claude-code", "startupGlobal")]);
+		const secondResult = await store.initialize([buildAgent("claude-code", "startupGlobal")]);
 
 		expect(firstResult.isErr()).toBe(true);
 		expect(secondResult.isOk()).toBe(true);
@@ -180,7 +116,18 @@ describe("PreconnectionAgentSkillsStore", () => {
 			{
 				name: "ce:review",
 				description: "Review changes",
+				input: undefined,
 			},
 		]);
+	});
+
+	it("marks warmup complete when no startup-global providers exist", async () => {
+		const fetchPreconnectionCommands = vi.fn();
+		const store = new PreconnectionAgentSkillsStore(fetchPreconnectionCommands);
+		const result = await store.initialize([buildAgent("copilot", "projectScoped")]);
+
+		expect(result.isOk()).toBe(true);
+		expect(store.loaded).toBe(true);
+		expect(fetchPreconnectionCommands).not.toHaveBeenCalled();
 	});
 });


### PR DESCRIPTION
## Summary

Moves preconnection slash discovery behind provider-owned ACP contracts so shared runtime and UI code stop deciding which providers support preconnection commands or how those commands are loaded. Copilot now owns project-local `.agents` discovery, including flat `*.agent.md` files whose invokable slash token always comes from the filename.

## What changed

1. Added `preconnectionSlashMode` to provider metadata and routed `acp_list_preconnection_commands` through `AgentProvider::list_preconnection_commands(...)` so shared backend code only validates scope and dispatches.
2. Added neutral parsing and dedupe helpers in `acp/preconnection_slash.rs`, then implemented provider-owned preconnection loading for Claude Code, Cursor, Codex, OpenCode, and Copilot.
3. Reworked the frontend warmup/composer flow to key off provider metadata instead of `loadsRemotePreconnectionCommands`, and stopped falling back to empty preconnection slash sources after connection.
4. Refreshed the provider-owned architecture solution doc with the preconnection boundary and the Copilot filename-derived flat-agent token rule.

## Provider modes

| Provider shape | Mode |
|--------|--------|
| Claude Code / Cursor / Codex | `startupGlobal` |
| OpenCode / Copilot | `projectScoped` |
| Shared runtime fallback | `unsupported` |

## Verification

- `bun run i18n:generate && bun run check`
- `bun test ./src/lib/skills/store/preconnection-agent-skills-store.vitest.ts ./src/lib/acp/components/agent-input/logic/preconnection-remote-commands-state.vitest.ts ./src/lib/acp/components/agent-input/logic/slash-command-source.vitest.ts`
- `cargo test preconnection --lib`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Moves preconnection slash discovery into provider-owned ACP contracts and adds a provider metadata flag to drive UI/runtime behavior. Copilot now owns project-local `.agents` discovery (including flat `*.agent.md` files where the slash token is the filename).

- **Refactors**
  - Added `preconnectionSlashMode` to provider metadata and routed `acp_list_preconnection_commands` through `AgentProvider::list_preconnection_commands(...)`, with per-mode CWD resolution and tests.
  - Implemented provider loaders: Claude Code/Cursor/Codex as startup-global (`~/.{provider}/skills`), OpenCode as project-scoped (HTTP), Copilot as project-scoped (`.agents/skills`, `.agents/*/SKILL.md`, and flat `.agents/*.agent.md` with filename-derived token).
  - Introduced neutral loading/dedupe helpers in `acp/preconnection_slash.rs` (supports nested skills and flat agent files).
  - Registry now exposes `provider_metadata` to the UI; session state and model presentation can carry the same projection. Added TS types (`ProviderMetadataProjection`), built-in defaults, and normalization helpers.
  - Frontend keys warmup and on-demand loading off `providerMetadata.preconnectionSlashMode`, removes `loadsRemotePreconnectionCommands`, warms startup-global commands via ACP in `preconnectionAgentSkillsStore`, caches project-scoped results by `agentId::projectPath`, and stops falling back to preconnection commands after connect.

- **Migration**
  - Copilot projects: put agents under `.agents` and use `.agent.md` filenames to define the slash token (e.g., `.agents/code-review.agent.md` ➜ `/code-review`).
  - No changes required for other providers.

<sup>Written for commit 35f572ca3818e8ba1792e1a46bd1688ab2478f82. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

