### PR TITLE
fix(ui): only show active agents in chat bubble

### DIFF
--- a/packages/desktop/src/lib/components/main-app-view/components/sidebar/app-sidebar-agents.test.ts
+++ b/packages/desktop/src/lib/components/main-app-view/components/sidebar/app-sidebar-agents.test.ts
@@ -3,7 +3,7 @@ import { describe, expect, it } from "bun:test";
 import { ensureProjectHeaderAgentSelected, getProjectHeaderAgents } from "./app-sidebar-agents.js";
 
 describe("getProjectHeaderAgents", () => {
-	it("includes selected agents and installable agents that are not installed", () => {
+	it("returns only selected agents", () => {
 		const result = getProjectHeaderAgents(
 			[
 				{
@@ -16,7 +16,7 @@ describe("getProjectHeaderAgents", () => {
 					id: "cursor",
 					name: "Cursor",
 					icon: "cursor",
-					availability_kind: { kind: "installable", installed: false },
+					availability_kind: { kind: "installable", installed: true },
 				},
 				{
 					id: "codex",
@@ -25,13 +25,35 @@ describe("getProjectHeaderAgents", () => {
 					availability_kind: { kind: "installable", installed: true },
 				},
 			],
-			["claude-code"]
+			["claude-code", "cursor"]
 		);
 
 		expect(result.map((agent) => agent.id)).toEqual(["claude-code", "cursor"]);
 	});
 
-	it("does not add already installed agents that are not selected", () => {
+	it("excludes installable-but-not-installed agents that are not selected", () => {
+		const result = getProjectHeaderAgents(
+			[
+				{
+					id: "claude-code",
+					name: "Claude Code",
+					icon: "claude-code",
+					availability_kind: { kind: "installable", installed: false },
+				},
+				{
+					id: "opencode",
+					name: "OpenCode",
+					icon: "opencode",
+					availability_kind: { kind: "installable", installed: true },
+				},
+			],
+			["opencode"]
+		);
+
+		expect(result.map((agent) => agent.id)).toEqual(["opencode"]);
+	});
+
+	it("returns empty list when no agents are selected", () => {
 		const result = getProjectHeaderAgents(
 			[
 				{
@@ -50,29 +72,7 @@ describe("getProjectHeaderAgents", () => {
 			[]
 		);
 
-		expect(result.map((agent) => agent.id)).toEqual(["cursor"]);
-	});
-
-	it("does not auto-include already installed PATH-backed agents that are not selected", () => {
-		const result = getProjectHeaderAgents(
-			[
-				{
-					id: "forge",
-					name: "Forge",
-					icon: "forge",
-					availability_kind: { kind: "installable", installed: true },
-				},
-				{
-					id: "cursor",
-					name: "Cursor",
-					icon: "cursor",
-					availability_kind: { kind: "installable", installed: false },
-				},
-			],
-			[]
-		);
-
-		expect(result.map((agent) => agent.id)).toEqual(["cursor"]);
+		expect(result.map((agent) => agent.id)).toEqual([]);
 	});
 });
 

--- a/packages/desktop/src/lib/components/main-app-view/logic/spawnable-agents.test.ts
+++ b/packages/desktop/src/lib/components/main-app-view/logic/spawnable-agents.test.ts
@@ -3,7 +3,57 @@ import { describe, expect, it } from "bun:test";
 import { ensureSpawnableAgentSelected, getSpawnableSessionAgents } from "./spawnable-agents.js";
 
 describe("getSpawnableSessionAgents", () => {
-	it("includes selected agents and installable agents that are not installed", () => {
+	it("returns only selected agents", () => {
+		const result = getSpawnableSessionAgents(
+			[
+				{
+					id: "claude-code",
+					name: "Claude Code",
+					icon: "claude-code",
+					availability_kind: { kind: "installable", installed: true },
+				},
+				{
+					id: "cursor",
+					name: "Cursor",
+					icon: "cursor",
+					availability_kind: { kind: "installable", installed: true },
+				},
+				{
+					id: "codex",
+					name: "Codex",
+					icon: "codex",
+					availability_kind: { kind: "installable", installed: true },
+				},
+			],
+			["claude-code", "cursor"]
+		);
+
+		expect(result.map((agent) => agent.id)).toEqual(["claude-code", "cursor"]);
+	});
+
+	it("excludes installable-but-not-installed agents that are not selected", () => {
+		const result = getSpawnableSessionAgents(
+			[
+				{
+					id: "claude-code",
+					name: "Claude Code",
+					icon: "claude-code",
+					availability_kind: { kind: "installable", installed: false },
+				},
+				{
+					id: "opencode",
+					name: "OpenCode",
+					icon: "opencode",
+					availability_kind: { kind: "installable", installed: true },
+				},
+			],
+			["opencode"]
+		);
+
+		expect(result.map((agent) => agent.id)).toEqual(["opencode"]);
+	});
+
+	it("returns empty list when no agents are selected", () => {
 		const result = getSpawnableSessionAgents(
 			[
 				{
@@ -18,61 +68,33 @@ describe("getSpawnableSessionAgents", () => {
 					icon: "cursor",
 					availability_kind: { kind: "installable", installed: false },
 				},
-				{
-					id: "codex",
-					name: "Codex",
-					icon: "codex",
-					availability_kind: { kind: "installable", installed: true },
-				},
 			],
-			["claude-code"]
+			[]
 		);
 
-		expect(result.map((agent) => agent.id)).toEqual(["claude-code", "cursor"]);
+		expect(result.map((agent) => agent.id)).toEqual([]);
 	});
 
-	it("does not add already installed agents that are not selected", () => {
+	it("preserves selection order from agents array", () => {
 		const result = getSpawnableSessionAgents(
 			[
 				{
-					id: "custom-agent",
-					name: "Custom Agent",
-					icon: "custom-agent",
+					id: "opencode",
+					name: "OpenCode",
+					icon: "opencode",
 					availability_kind: { kind: "installable", installed: true },
 				},
 				{
 					id: "cursor",
 					name: "Cursor",
 					icon: "cursor",
-					availability_kind: { kind: "installable", installed: false },
-				},
-			],
-			[]
-		);
-
-		expect(result.map((agent) => agent.id)).toEqual(["cursor"]);
-	});
-
-	it("does not auto-include already installed PATH-backed agents that are not selected", () => {
-		const result = getSpawnableSessionAgents(
-			[
-				{
-					id: "forge",
-					name: "Forge",
-					icon: "forge",
 					availability_kind: { kind: "installable", installed: true },
 				},
-				{
-					id: "cursor",
-					name: "Cursor",
-					icon: "cursor",
-					availability_kind: { kind: "installable", installed: false },
-				},
 			],
-			[]
+			["cursor", "opencode"]
 		);
 
-		expect(result.map((agent) => agent.id)).toEqual(["cursor"]);
+		expect(result.map((agent) => agent.id)).toEqual(["opencode", "cursor"]);
 	});
 });
 

--- a/packages/desktop/src/lib/components/main-app-view/logic/spawnable-agents.ts
+++ b/packages/desktop/src/lib/components/main-app-view/logic/spawnable-agents.ts
@@ -1,11 +1,10 @@
-import type { Agent, AgentAvailabilityKind } from "$lib/acp/store/types.js";
+import type { Agent } from "$lib/acp/store/types.js";
 
-function isInstallableButNotInstalled(
-	availabilityKind: AgentAvailabilityKind | undefined
-): boolean {
-	return availabilityKind ? availabilityKind.installed === false : false;
-}
-
+/**
+ * Returns only the agents the user has explicitly selected/enabled.
+ * Unselected agents (including installable-but-not-installed ones) are excluded
+ * so the chat bubble and session creation flows only show active agents.
+ */
 export function getSpawnableSessionAgents(
 	agents: readonly Agent[],
 	selectedAgentIds: readonly string[]
@@ -18,11 +17,6 @@ export function getSpawnableSessionAgents(
 	const visibleAgents: Agent[] = [];
 	for (const agent of agents) {
 		if (selectedAgentIdSet.has(agent.id)) {
-			visibleAgents.push(agent);
-			continue;
-		}
-
-		if (isInstallableButNotInstalled(agent.availability_kind)) {
 			visibleAgents.push(agent);
 		}
 	}


### PR DESCRIPTION
## Summary

- Chat bubble / agent selector now filters to user-selected (toggled) agents only
- Previously, agents marked as "installable but not installed" leaked into the list — e.g. Claude Code appeared even when the user only had Opencode and Cursor enabled
- Removed the `isInstallableButNotInstalled` fallback from `getSpawnableSessionAgents`; agents can still be discovered and installed from Settings → Agents

Closes #101

## Test plan

- [x] All 2453 existing tests pass (0 regressions)
- [x] Updated `spawnable-agents.test.ts` and `app-sidebar-agents.test.ts` to match new behavior
- [x] TypeScript check passes
- [ ] Manual: toggle off an agent in Settings → verify it no longer appears in the chat bubble
- [ ] Manual: with only one agent enabled, verify it auto-selects as default

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Show only enabled agents in the chat bubble, project header, and session creation. Removes installable-but-not-installed agents from these lists.

- **Bug Fixes**
  - Filter to selected/enabled agents only; exclude installable-but-not-installed.
  - Preserve agents list order; return an empty list when none are selected.
  - Update sidebar and session creation tests to match the new behavior.

<sup>Written for commit 4f7e98622a5b6cca28fbde017475a4edde59c2ec. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

