### PR TITLE
feat(ui): allow users to pick a default agent

### DIFF
--- a/packages/desktop/src-tauri/src/storage/types.rs
+++ b/packages/desktop/src-tauri/src/storage/types.rs
@@ -80,6 +80,8 @@ pub enum UserSettingKey {
     DismissedTooltips,
     /// Whether the attention queue panel is shown in the sidebar (boolean)
     AttentionQueueEnabled,
+    /// User's preferred default agent ID for new sessions
+    DefaultAgentId,
 }
 
 impl UserSettingKey {
@@ -126,6 +128,7 @@ impl UserSettingKey {
             UserSettingKey::GitMergeStrategyPreference => "git_merge_strategy_preference",
             UserSettingKey::DismissedTooltips => "dismissed_tooltips",
             UserSettingKey::AttentionQueueEnabled => "attention_queue_enabled",
+            UserSettingKey::DefaultAgentId => "default_agent_id",
         }
     }
 }
@@ -171,6 +174,7 @@ mod tests {
             "git_text_generation_agent",
             "dismissed_tooltips",
             "attention_queue_enabled",
+            "default_agent_id",
         ];
 
         for key in keys {

--- a/packages/desktop/src/lib/acp/components/agent-selector.svelte
+++ b/packages/desktop/src/lib/acp/components/agent-selector.svelte
@@ -4,8 +4,10 @@ import * as DropdownMenu from "@acepe/ui/dropdown-menu";
 import { useTheme } from "$lib/components/theme/context.svelte.js";
 import { Skeleton } from "$lib/components/ui/skeleton/index.js";
 import * as m from "$lib/paraglide/messages.js";
+import { Star } from "phosphor-svelte";
 import { getAgentIcon } from "../constants/thread-list-constants.js";
 import type { AgentInfo } from "../logic/agent-manager.js";
+import { getAgentPreferencesStore } from "../store/index.js";
 import { capitalizeName } from "../utils/index.js";
 import { createLogger } from "../utils/logger.js";
 import SelectorCheck from "./selector-check.svelte";
@@ -35,6 +37,8 @@ const logger = createLogger({
 });
 
 const themeState = useTheme();
+const agentPreferencesStore = getAgentPreferencesStore();
+const defaultAgentId = $derived(agentPreferencesStore.defaultAgentId);
 
 function handleAgentSelect(agentId: string) {
 	logger.debug("handleAgentSelect() called", {
@@ -103,6 +107,17 @@ const currentAgent = $derived(
 						<img src={icon} alt={agent.name} class="h-4 w-4 shrink-0" />
 					{/if}
 					<span class="flex-1 text-sm truncate">{capitalizeName(agent.name)}</span>
+					<button
+						type="button"
+						class="shrink-0 {agent.id === defaultAgentId ? 'text-primary' : 'opacity-0 group-hover/item:opacity-100 text-muted-foreground hover:text-primary'} transition-opacity"
+						onclick={(event: MouseEvent) => {
+							event.stopPropagation();
+							event.preventDefault();
+							void agentPreferencesStore.setDefaultAgentId(agent.id === defaultAgentId ? null : agent.id);
+						}}
+					>
+						<Star size={14} weight={agent.id === defaultAgentId ? "fill" : "regular"} />
+					</button>
 					<SelectorCheck visible={isSelected} />
 				</div>
 			</DropdownMenu.Item>

--- a/packages/desktop/src/lib/acp/store/agent-preferences-store.svelte.ts
+++ b/packages/desktop/src/lib/acp/store/agent-preferences-store.svelte.ts
@@ -13,6 +13,7 @@ const HAS_COMPLETED_ONBOARDING_KEY: UserSettingKey = "has_completed_onboarding";
 const SELECTED_AGENT_IDS_KEY: UserSettingKey = "selected_agent_ids";
 const CUSTOM_AGENT_CONFIGS_KEY: UserSettingKey = "custom_agent_configs";
 const AGENT_ENV_OVERRIDES_KEY = "agent_env_overrides";
+const DEFAULT_AGENT_ID_KEY: UserSettingKey = "default_agent_id";
 
 export type AgentEnvOverrides = Record<string, Record<string, string>>;
 
@@ -205,6 +206,7 @@ function chainPersistOperations(operations: ReadonlyArray<ResultAsync<void, AppE
 
 export class AgentPreferencesStore {
 	selectedAgentIds = $state<string[]>([]);
+	defaultAgentId = $state<string | null>(null);
 	onboardingCompleted = $state<boolean>(false);
 	customAgentConfigs = $state<CustomAgentConfig[]>([]);
 	agentEnvOverrides = $state<AgentEnvOverrides>({});
@@ -218,6 +220,7 @@ export class AgentPreferencesStore {
 			tauriClient.settings.get<string[]>(SELECTED_AGENT_IDS_KEY),
 			tauriClient.settings.get<CustomAgentConfig[]>(CUSTOM_AGENT_CONFIGS_KEY),
 			tauriClient.settings.get<AgentEnvOverrides>(AGENT_ENV_OVERRIDES_KEY),
+			tauriClient.settings.get<string>(DEFAULT_AGENT_ID_KEY),
 		])
 			.andThen(
 				([
@@ -225,6 +228,7 @@ export class AgentPreferencesStore {
 					persistedSelectedAgentIds,
 					persistedCustom,
 					persistedAgentEnvOverrides,
+					persistedDefaultAgentId,
 				]) => {
 					const initState = deriveAgentPreferencesInitializationState({
 						persistedOnboardingCompleted,
@@ -237,6 +241,10 @@ export class AgentPreferencesStore {
 					this.selectedAgentIds = initState.selectedAgentIds;
 					this.customAgentConfigs = persistedCustom ?? [];
 					this.agentEnvOverrides = persistedAgentEnvOverrides ?? {};
+					this.defaultAgentId =
+						persistedDefaultAgentId && initState.selectedAgentIds.includes(persistedDefaultAgentId)
+							? persistedDefaultAgentId
+							: null;
 
 					const persistOperations: ResultAsync<void, AppError>[] = [];
 					if (initState.shouldPersistOnboardingCompleted) {
@@ -269,9 +277,31 @@ export class AgentPreferencesStore {
 
 		const normalized = validation.value;
 		this.selectedAgentIds = normalized;
+
+		// Clear default agent if it was removed from the selected list
+		if (this.defaultAgentId && !normalized.includes(this.defaultAgentId)) {
+			this.defaultAgentId = null;
+			return tauriClient.settings
+				.set(SELECTED_AGENT_IDS_KEY, normalized)
+				.andThen(() => tauriClient.settings.set(DEFAULT_AGENT_ID_KEY, null))
+				.mapErr((error) => new Error(`Failed to persist selected agents: ${error.message}`));
+		}
+
 		return tauriClient.settings
 			.set(SELECTED_AGENT_IDS_KEY, normalized)
 			.mapErr((error) => new Error(`Failed to persist selected agents: ${error.message}`));
+	}
+
+	setDefaultAgentId(agentId: string | null): ResultAsync<void, Error> {
+		// Validate that the agent is in the selected list (or null to clear)
+		if (agentId !== null && !this.selectedAgentIds.includes(agentId)) {
+			return okAsync(undefined);
+		}
+
+		this.defaultAgentId = agentId;
+		return tauriClient.settings
+			.set(DEFAULT_AGENT_ID_KEY, agentId)
+			.mapErr((error) => new Error(`Failed to persist default agent: ${error.message}`));
 	}
 
 	completeOnboarding(agentIds: readonly string[]): ResultAsync<void, Error> {
@@ -332,4 +362,9 @@ export function getAgentPreferencesStore(): AgentPreferencesStore {
 	return getContext<AgentPreferencesStore>(AGENT_PREFERENCES_STORE_KEY);
 }
 
-export { CUSTOM_AGENT_CONFIGS_KEY, HAS_COMPLETED_ONBOARDING_KEY, SELECTED_AGENT_IDS_KEY };
+export {
+	CUSTOM_AGENT_CONFIGS_KEY,
+	DEFAULT_AGENT_ID_KEY,
+	HAS_COMPLETED_ONBOARDING_KEY,
+	SELECTED_AGENT_IDS_KEY,
+};

--- a/packages/desktop/src/lib/components/main-app-view/components/content/empty-states.svelte
+++ b/packages/desktop/src/lib/components/main-app-view/components/content/empty-states.svelte
@@ -57,10 +57,11 @@ const availableAgents = $derived(
 const projects = $derived(projectManager.projects);
 const availableAgentIds = $derived(availableAgents.map((agent) => agent.id));
 
-// Resolve effective agent: explicit selection if still available, otherwise first available
+// Resolve effective agent: explicit selection → user default → first available
 const effectiveAgentId = $derived(
 	resolveEmptyStateAgentId({
 		selectedAgentId,
+		defaultAgentId: agentPreferencesStore.defaultAgentId,
 		availableAgentIds,
 	})
 );

--- a/packages/desktop/src/lib/components/main-app-view/components/content/kanban-new-session-dialog-state.ts
+++ b/packages/desktop/src/lib/components/main-app-view/components/content/kanban-new-session-dialog-state.ts
@@ -6,6 +6,7 @@ interface ResolveKanbanNewSessionDefaultsInput {
 	readonly focusedProjectPath: string | null;
 	readonly availableAgents: readonly AgentInfo[];
 	readonly selectedAgentIds: readonly string[];
+	readonly defaultAgentId?: string | null;
 	readonly requestedProjectPath?: string | null;
 	readonly requestedAgentId?: string | null;
 }
@@ -42,6 +43,7 @@ function resolveDefaultProjectPath(input: ResolveKanbanNewSessionDefaultsInput):
 }
 
 function resolveDefaultAgentId(input: ResolveKanbanNewSessionDefaultsInput): string | null {
+	// 1. Explicit request wins
 	if (input.requestedAgentId) {
 		for (const agent of input.availableAgents) {
 			if (agent.id === input.requestedAgentId) {
@@ -50,6 +52,16 @@ function resolveDefaultAgentId(input: ResolveKanbanNewSessionDefaultsInput): str
 		}
 	}
 
+	// 2. User's persisted default agent preference
+	if (input.defaultAgentId) {
+		for (const agent of input.availableAgents) {
+			if (agent.id === input.defaultAgentId) {
+				return agent.id;
+			}
+		}
+	}
+
+	// 3. First selected agent
 	for (const selectedAgentId of input.selectedAgentIds) {
 		for (const agent of input.availableAgents) {
 			if (agent.id === selectedAgentId) {
@@ -58,6 +70,7 @@ function resolveDefaultAgentId(input: ResolveKanbanNewSessionDefaultsInput): str
 		}
 	}
 
+	// 4. First available agent
 	const firstAgent = input.availableAgents[0];
 	return firstAgent ? firstAgent.id : null;
 }

--- a/packages/desktop/src/lib/components/main-app-view/components/content/kanban-view.svelte
+++ b/packages/desktop/src/lib/components/main-app-view/components/content/kanban-view.svelte
@@ -175,6 +175,7 @@ const availableAgentIds = $derived(availableAgents.map((agent) => agent.id));
 const effectiveAgentId = $derived(
 	resolveEmptyStateAgentId({
 		selectedAgentId,
+		defaultAgentId: agentPreferencesStore.defaultAgentId,
 		availableAgentIds,
 	})
 );
@@ -818,6 +819,7 @@ function resetNewSessionState(request?: KanbanNewSessionRequest): void {
 		focusedProjectPath: panelStore.focusedViewProjectPath,
 		availableAgents,
 		selectedAgentIds: agentPreferencesStore.selectedAgentIds,
+		defaultAgentId: agentPreferencesStore.defaultAgentId,
 		requestedProjectPath: request?.projectPath ?? null,
 		requestedAgentId: request?.agentId ?? null,
 	});

--- a/packages/desktop/src/lib/components/main-app-view/components/content/logic/__tests__/empty-state-send-state.test.ts
+++ b/packages/desktop/src/lib/components/main-app-view/components/content/logic/__tests__/empty-state-send-state.test.ts
@@ -151,6 +151,46 @@ describe("empty-state send state", () => {
 		).toBe("cursor");
 	});
 
+	it("prefers default agent when no explicit selection exists", () => {
+		expect(
+			resolveEmptyStateAgentId({
+				selectedAgentId: null,
+				defaultAgentId: "opencode",
+				availableAgentIds: ["cursor", "opencode", "claude-code"],
+			})
+		).toBe("opencode");
+	});
+
+	it("explicit selection wins over default agent", () => {
+		expect(
+			resolveEmptyStateAgentId({
+				selectedAgentId: "cursor",
+				defaultAgentId: "opencode",
+				availableAgentIds: ["cursor", "opencode"],
+			})
+		).toBe("cursor");
+	});
+
+	it("falls back to first available when default agent is not in available list", () => {
+		expect(
+			resolveEmptyStateAgentId({
+				selectedAgentId: null,
+				defaultAgentId: "opencode",
+				availableAgentIds: ["cursor", "claude-code"],
+			})
+		).toBe("cursor");
+	});
+
+	it("falls back to first available when default agent is null", () => {
+		expect(
+			resolveEmptyStateAgentId({
+				selectedAgentId: null,
+				defaultAgentId: null,
+				availableAgentIds: ["cursor", "claude-code"],
+			})
+		).toBe("cursor");
+	});
+
 	it("blocks first send when no agent is selected", () => {
 		expect(
 			canSendWithoutSession({

--- a/packages/desktop/src/lib/components/main-app-view/components/content/logic/empty-state-send-state.ts
+++ b/packages/desktop/src/lib/components/main-app-view/components/content/logic/empty-state-send-state.ts
@@ -2,12 +2,20 @@ export const EMPTY_STATE_PANEL_ID = "empty-state-panel";
 
 export function resolveEmptyStateAgentId(options: {
 	selectedAgentId: string | null;
+	defaultAgentId?: string | null;
 	availableAgentIds: readonly string[];
 }): string | null {
+	// 1. Explicit user selection in current session wins
 	if (options.selectedAgentId && options.availableAgentIds.includes(options.selectedAgentId)) {
 		return options.selectedAgentId;
 	}
 
+	// 2. User's persisted default agent preference
+	if (options.defaultAgentId && options.availableAgentIds.includes(options.defaultAgentId)) {
+		return options.defaultAgentId;
+	}
+
+	// 3. First available agent
 	const firstAvailableAgentId = options.availableAgentIds[0];
 	return firstAvailableAgentId ? firstAvailableAgentId : null;
 }

--- a/packages/desktop/src/lib/components/settings-page/sections/agents-models-section.svelte
+++ b/packages/desktop/src/lib/components/settings-page/sections/agents-models-section.svelte
@@ -39,6 +39,14 @@ const sortedAgents = $derived.by(() =>
 	getAgentsByProviderOrder(agentStore.agents, preferencesStore.getCachedModelsDisplay)
 );
 
+const defaultAgentId = $derived(agentPreferencesStore.defaultAgentId);
+const defaultAgent = $derived(
+	defaultAgentId ? agentStore.agents.find((a) => a.id === defaultAgentId) ?? null : null
+);
+const selectableAgents = $derived(
+	agentStore.agents.filter((a) => agentPreferencesStore.selectedAgentIds.includes(a.id))
+);
+
 function setAgentChecked(agentId: string, checked: boolean): void {
 	const result = applyAgentSelectionChange(
 		agentPreferencesStore.selectedAgentIds,
@@ -109,6 +117,62 @@ function getModelDescription(
 title="Agents & Models"
 description="Choose which agents are enabled and set their default models."
 />
+
+<AgentToolCard variant="muted">
+<div class="flex items-center justify-between h-8 px-2.5">
+	<div class="flex flex-col gap-0">
+		<span class="text-[13px] font-medium text-foreground/80">Default agent</span>
+	</div>
+	<DropdownMenu.Root>
+		<DropdownMenu.Trigger>
+			{#snippet child({ props })}
+			<button
+				{...props}
+				type="button"
+				class="flex items-center gap-1.5 h-7 px-2 rounded-md text-muted-foreground transition-colors hover:bg-accent/50"
+			>
+				{#if defaultAgent}
+				<AgentIcon agentId={defaultAgent.id} class="size-3.5 shrink-0" size={14} />
+				<span class="text-[13px] font-medium text-foreground/70">{defaultAgent.name}</span>
+				{:else}
+				<span class="text-[13px] font-medium text-foreground/70">First available</span>
+				{/if}
+				<CaretDown class="size-2.5 shrink-0 opacity-40 ml-1" weight="bold" />
+			</button>
+			{/snippet}
+		</DropdownMenu.Trigger>
+		<DropdownMenu.Content align="end" class="w-[220px]">
+			<DropdownMenu.Item onclick={() => void agentPreferencesStore.setDefaultAgentId(null)}>
+				<div class="flex items-center gap-2">
+					<Check
+						class={defaultAgentId === null
+							? "size-3 text-foreground"
+							: "size-3 text-transparent"}
+						weight="bold"
+					/>
+					<span class="text-[13px]">First available</span>
+				</div>
+			</DropdownMenu.Item>
+			<DropdownMenu.Separator />
+			{#each selectableAgents as agent (agent.id)}
+			<DropdownMenu.Item onclick={() => void agentPreferencesStore.setDefaultAgentId(agent.id)}>
+				<div class="flex items-center gap-2">
+					<Check
+						class={agent.id === defaultAgentId
+							? "size-3 text-foreground"
+							: "size-3 text-transparent"}
+						weight="bold"
+					/>
+					<AgentIcon agentId={agent.id} class="size-3.5 shrink-0" size={14} />
+					<span class="text-[13px]">{agent.name}</span>
+				</div>
+			</DropdownMenu.Item>
+			{/each}
+		</DropdownMenu.Content>
+	</DropdownMenu.Root>
+</div>
+</AgentToolCard>
+
 	{#each sortedAgents as agent (agent.id)}
 {@const entry = modelDefaultEntries.find((candidate) => candidate.agent.id === agent.id) ?? null}
 {@const providerMetadata = entry?.providerMetadata ?? agent.providerMetadata ?? null}

--- a/packages/desktop/src/lib/services/converted-session-types.ts
+++ b/packages/desktop/src/lib/services/converted-session-types.ts
@@ -3,9 +3,6 @@
 // JsonValue represents any valid JSON value
 export type JsonValue = null | boolean | number | string | JsonValue[] | { [key: string]: JsonValue };
 
-// Types referenced by ConnectionComplete lifecycle event
-import type { SessionModelState, SessionModes } from "./acp-types.js";
-
 /**
  * Token counts for usage telemetry (generic, adapter-agnostic).
  */
@@ -53,7 +50,7 @@ export type SessionUpdate = { type: "userMessageChunk"; chunk: ContentChunk; ses
  * Emitted by the async resume task when session connection completes successfully.
  * Carries the session capabilities so the frontend can populate hot state.
  */
-{ type: "connectionComplete"; session_id: string; attempt_id: number; models: SessionModelState; modes: SessionModes; available_commands: AvailableCommand[]; config_options: ConfigOptionData[]; autonomous_enabled: boolean } | 
+{ type: "connectionComplete"; session_id: string; attempt_id: number; models: SessionModelState; modes: SessionModes; available_commands?: AvailableCommand[]; config_options?: ConfigOptionData[]; autonomous_enabled: boolean } | 
 /**
  * Emitted by the async resume task when session connection fails.
  */
@@ -678,9 +675,13 @@ export type UserSettingKey =
  */
 "dismissed_tooltips" | 
 /**
- * Whether the attention queue panel is shown in the sidebar (boolean, default false)
+ * Whether the attention queue panel is shown in the sidebar (boolean)
  */
-"attention_queue_enabled"
+"attention_queue_enabled" | 
+/**
+ * User's preferred default agent ID for new sessions
+ */
+"default_agent_id"
 
 /**
  * Information about a single indexed file.


### PR DESCRIPTION
## Summary

- Adds a `default_agent_id` user setting so users can choose which agent is pre-selected in the chat bubble / new session creation flow
- The default agent can be set from two surfaces:
  - **Agent selector dropdown**: star icon on each agent (filled = default, outline on hover = set as default)
  - **Settings → Agents & Models**: new "Default agent" dropdown at the top of the section
- Resolution order: explicit session selection → user default → first available
- If the default agent is deselected/uninstalled, silently falls back to first available

Addresses the remaining part of #101 (the "pick default agent" request).

## Changes

**Rust** (`storage/types.rs`):
- Added `DefaultAgentId` variant to `UserSettingKey` enum

**Store** (`agent-preferences-store.svelte.ts`):
- New `defaultAgentId` state field, loaded on init, persisted via settings
- `setDefaultAgentId()` method with validation (agent must be in selected list)
- `setSelectedAgentIds()` auto-clears default when its agent is removed

**Resolution** (`empty-state-send-state.ts`, `kanban-new-session-dialog-state.ts`):
- `resolveEmptyStateAgentId` and kanban's `resolveDefaultAgentId` now accept optional `defaultAgentId` parameter
- Wired through `empty-states.svelte` and `kanban-view.svelte`

**UI** (`agent-selector.svelte`, `agents-models-section.svelte`):
- Star icon in agent selector dropdown (hover-reveal for non-default, always visible for default)
- "Default agent" dropdown card in settings page

## Test plan

- [x] 2477 tests pass (0 new failures, 2 pre-existing unrelated)
- [x] Added 4 new test cases for `resolveEmptyStateAgentId` with `defaultAgentId`
- [x] Rust `UserSettingKey` acceptance test updated
- [ ] Manual: set default agent via star icon in selector → new chats pre-select it
- [ ] Manual: set default agent via settings dropdown → same effect
- [ ] Manual: disable the default agent → graceful fallback to first available

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Let users pick a default agent for new chats and sessions. Adds a persisted `default_agent_id` and uses it when no explicit selection exists. Completes Linear #101.

- **New Features**
  - Set default via star in the agent selector or the Settings → Agents & Models “Default agent” dropdown.
  - Selection order: explicit session choice → user default → first available.
  - Default must be among enabled agents; it clears automatically if removed/unavailable.
  - Persists `default_agent_id`, wires resolution through empty states and kanban new-session flow, and adds tests.

<sup>Written for commit fa431943c50a4a95ebfdc75ea72e85221c926662. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

