### PR TITLE
fix(copilot): restore replay titles and history hygiene

### DIFF
--- a/packages/desktop/src-tauri/src/copilot_history/mod.rs
+++ b/packages/desktop/src-tauri/src/copilot_history/mod.rs
@@ -207,6 +207,9 @@ pub fn convert_replay_updates_to_session(
     let mut accumulator = ReplayAccumulator::new();
 
     for (emitted_at_ms, update) in updates {
+        if matches!(update, SessionUpdate::AgentThoughtChunk { .. }) {
+            continue;
+        }
         accumulator.push(*emitted_at_ms, update);
     }
 
@@ -851,6 +854,58 @@ mod tests {
                 assert_eq!(children[0].id, "child-read-1");
             }
             other => panic!("expected tool call entry, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn replay_conversion_filters_copilot_thought_chunks_from_restored_history() {
+        let session_id = "copilot-session-thought";
+        let converted = convert_replay_updates_to_session(
+            session_id,
+            "Copilot Session",
+            &[
+                (
+                    1_710_000_020_000,
+                    crate::acp::session_update::SessionUpdate::AgentThoughtChunk {
+                        chunk: ContentChunk {
+                            content: ContentBlock::Text {
+                                text: "Investigating codebase options".to_string(),
+                            },
+                            aggregation_hint: None,
+                        },
+                        part_id: None,
+                        message_id: Some("assistant-1".to_string()),
+                        session_id: Some(session_id.to_string()),
+                    },
+                ),
+                (
+                    1_710_000_020_500,
+                    crate::acp::session_update::SessionUpdate::AgentMessageChunk {
+                        chunk: ContentChunk {
+                            content: ContentBlock::Text {
+                                text: "I found the replay path.".to_string(),
+                            },
+                            aggregation_hint: None,
+                        },
+                        part_id: None,
+                        message_id: Some("assistant-1".to_string()),
+                        session_id: Some(session_id.to_string()),
+                    },
+                ),
+            ],
+        );
+
+        assert_eq!(converted.entries.len(), 1);
+        match &converted.entries[0] {
+            StoredEntry::Assistant { message, .. } => {
+                assert_eq!(message.chunks.len(), 1);
+                assert_eq!(message.chunks[0].chunk_type, "message");
+                assert_eq!(
+                    message.chunks[0].block.text.as_deref(),
+                    Some("I found the replay path.")
+                );
+            }
+            other => panic!("expected assistant entry, got {:?}", other),
         }
     }
 

--- a/packages/desktop/src-tauri/src/copilot_history/parser.rs
+++ b/packages/desktop/src-tauri/src/copilot_history/parser.rs
@@ -812,7 +812,7 @@ mod tests {
     }
 
     #[test]
-    fn assistant_message_preserves_inline_reasoning_text() {
+    fn assistant_message_filters_inline_reasoning_text_from_restored_history() {
         let jsonl = r#"
 {"type":"assistant.message","data":{"messageId":"m1","reasoningText":"thinking","content":"world"},"timestamp":"2026-04-10T00:00:02Z"}
 "#;
@@ -825,11 +825,35 @@ mod tests {
         assert_eq!(converted.entries.len(), 1);
         match &converted.entries[0] {
             StoredEntry::Assistant { message, .. } => {
-                assert_eq!(message.chunks.len(), 2);
-                assert_eq!(message.chunks[0].chunk_type, "thought");
-                assert_eq!(message.chunks[0].block.text.as_deref(), Some("thinking"));
-                assert_eq!(message.chunks[1].chunk_type, "message");
-                assert_eq!(message.chunks[1].block.text.as_deref(), Some("world"));
+                assert_eq!(message.chunks.len(), 1);
+                assert_eq!(message.chunks[0].chunk_type, "message");
+                assert_eq!(message.chunks[0].block.text.as_deref(), Some("world"));
+            }
+            other => panic!("expected assistant entry, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn direct_transcript_parse_filters_reasoning_chunks_from_restored_history() {
+        let jsonl = r#"
+{"type":"assistant.reasoning","data":{"messageId":"m1","content":"Investigating codebase options"},"timestamp":"2026-04-10T00:00:01Z"}
+{"type":"assistant.message","data":{"messageId":"m1","content":"I found the replay path."},"timestamp":"2026-04-10T00:00:02Z"}
+"#;
+
+        let events = parse_events_from_reader(Cursor::new(jsonl)).expect("events should parse");
+        let updates = convert_events_to_updates("session-1", events);
+        let converted =
+            super::super::convert_replay_updates_to_session("session-1", "Copilot", &updates);
+
+        assert_eq!(converted.entries.len(), 1);
+        match &converted.entries[0] {
+            StoredEntry::Assistant { message, .. } => {
+                assert_eq!(message.chunks.len(), 1);
+                assert_eq!(message.chunks[0].chunk_type, "message");
+                assert_eq!(
+                    message.chunks[0].block.text.as_deref(),
+                    Some("I found the replay path.")
+                );
             }
             other => panic!("expected assistant entry, got {other:?}"),
         }

--- a/packages/desktop/src-tauri/src/db/repository.rs
+++ b/packages/desktop/src-tauri/src/db/repository.rs
@@ -989,6 +989,29 @@ impl SessionMetadataRepository {
         format!("__session_registry__/{session_id}")
     }
 
+    fn acepe_placeholder_display(session_id: &str) -> String {
+        let preview_len = 8usize.min(session_id.len());
+        format!("Session {}", &session_id[..preview_len])
+    }
+
+    pub(crate) fn is_acepe_placeholder_display(session_id: &str, display: &str) -> bool {
+        display == Self::acepe_placeholder_display(session_id)
+    }
+
+    fn should_refresh_placeholder_title_for_unchanged_metadata(
+        session_id: &str,
+        existing_display: &str,
+        title_overridden: bool,
+        incoming_display: &str,
+        incoming_agent_id: &str,
+    ) -> bool {
+        incoming_agent_id == "copilot"
+            && !title_overridden
+            && Self::is_acepe_placeholder_display(session_id, existing_display)
+            && !incoming_display.trim().is_empty()
+            && incoming_display != existing_display
+    }
+
     fn is_acepe_managed_file_path(file_path: &str) -> bool {
         let is_registry = file_path.starts_with("__session_registry__/")
             && !file_path["__session_registry__/".len()..].contains('/');
@@ -1161,7 +1184,7 @@ impl SessionMetadataRepository {
     }
 
     async fn load_state_map(
-        db: &DbConn,
+        db: &impl sea_orm::ConnectionTrait,
         session_ids: &[String],
     ) -> Result<std::collections::HashMap<String, acepe_session_state::Model>> {
         if session_ids.is_empty() {
@@ -1192,8 +1215,7 @@ impl SessionMetadataRepository {
         for _attempt in 0..5 {
             let txn = db.begin().await?;
             let now = Utc::now();
-            let preview_len = 8usize.min(session_id.len());
-            let display = format!("Session {}", &session_id[..preview_len]);
+            let display = Self::acepe_placeholder_display(session_id);
 
             let next_sequence_id = Self::next_sequence_id_for_project(&txn, project_path).await?;
 
@@ -1475,6 +1497,11 @@ impl SessionMetadataRepository {
             .await?;
 
         if let Some(existing_model) = existing {
+            let existing_state = AcepeSessionState::find_by_id(&existing_model.id).one(db).await?;
+            let title_overridden = existing_state
+                .as_ref()
+                .and_then(|state| state.title_override.as_ref())
+                .is_some();
             let project_path = Self::project_path_for_update(&existing_model, project_path);
             let (file_path, file_mtime, file_size) = Self::resolved_file_metadata_for_update(
                 &existing_model,
@@ -1485,12 +1512,21 @@ impl SessionMetadataRepository {
             let existing_is_acepe_managed = existing_model.is_acepe_managed;
             let next_is_acepe_managed =
                 Self::merged_acepe_managed_flag(existing_is_acepe_managed, &file_path);
+            let should_refresh_display =
+                Self::should_refresh_placeholder_title_for_unchanged_metadata(
+                    &existing_model.id,
+                    &existing_model.display,
+                    title_overridden,
+                    &display,
+                    &agent_id,
+                );
 
             // Check if file has changed (mtime + size comparison)
             if existing_model.file_mtime == file_mtime
                 && existing_model.file_size == file_size
                 && existing_model.project_path == project_path
                 && existing_model.file_path == file_path
+                && !should_refresh_display
             {
                 return Ok(false); // No change
             }
@@ -1514,8 +1550,7 @@ impl SessionMetadataRepository {
             active.updated_at = Set(now);
             let state_project_path = active.project_path.as_ref().clone();
             active.update(db).await?;
-            if let Some(existing_state) = AcepeSessionState::find_by_id(&session_id).one(db).await?
-            {
+            if let Some(existing_state) = existing_state {
                 let mut state_active: acepe_session_state::ActiveModel = existing_state.into();
                 state_active.project_path = Set(state_project_path);
                 state_active.updated_at = Set(now);
@@ -1585,6 +1620,11 @@ impl SessionMetadataRepository {
             )
             .all(&txn)
             .await?;
+        let existing_ids = existing_records
+            .iter()
+            .map(|model| model.id.clone())
+            .collect::<Vec<_>>();
+        let state_map = Self::load_state_map(&txn, &existing_ids).await?;
 
         // Build a HashMap for O(1) lookup during iteration
         let mut existing_map: std::collections::HashMap<String, session_metadata::Model> =
@@ -1618,6 +1658,18 @@ impl SessionMetadataRepository {
                 );
                 let next_is_acepe_managed =
                     Self::merged_acepe_managed_flag(existing_model.is_acepe_managed, &file_path);
+                let title_overridden = state_map
+                    .get(&existing_model.id)
+                    .and_then(|state| state.title_override.as_ref())
+                    .is_some();
+                let should_refresh_display =
+                    Self::should_refresh_placeholder_title_for_unchanged_metadata(
+                        &existing_model.id,
+                        &existing_model.display,
+                        title_overridden,
+                        &display,
+                        &agent_id,
+                    );
 
                 // Check if file has changed (skip if mtime+size match).
                 // Non-Claude agents use mtime=0/size=0 sentinel — always refresh those.
@@ -1625,6 +1677,7 @@ impl SessionMetadataRepository {
                     && existing_model.file_mtime == file_mtime
                     && existing_model.file_size == file_size
                     && existing_model.project_path == project_path
+                    && !should_refresh_display
                 {
                     continue; // No change
                 }
@@ -1785,8 +1838,7 @@ impl SessionMetadataRepository {
                 anyhow::anyhow!("Session not found in metadata index and agent_id was not provided")
             })?;
             let now = Utc::now();
-            let preview_len = 8usize.min(session_id.len());
-            let display = format!("Session {}", &session_id[..preview_len]);
+            let display = Self::acepe_placeholder_display(session_id);
             let model = session_metadata::ActiveModel {
                 id: Set(session_id.to_string()),
                 display: Set(display),

--- a/packages/desktop/src-tauri/src/db/repository_test.rs
+++ b/packages/desktop/src-tauri/src/db/repository_test.rs
@@ -1115,6 +1115,63 @@ mod session_metadata_tests {
     }
 
     #[tokio::test]
+    async fn test_batch_upsert_refreshes_placeholder_title_when_file_metadata_is_unchanged() {
+        let db = setup_test_db().await;
+        let session_id = "12345678-copilot-session";
+        let transcript_path = "/tmp/copilot/12345678-copilot-session/events.jsonl";
+
+        SessionMetadataRepository::ensure_exists(&db, session_id, "/project", "copilot", None)
+            .await
+            .unwrap();
+
+        let placeholder = SessionMetadataRepository::get_by_id(&db, session_id)
+            .await
+            .unwrap()
+            .unwrap()
+            .display;
+        assert_eq!(placeholder, "Session 12345678");
+
+        SessionMetadataRepository::upsert(
+            &db,
+            session_id.to_string(),
+            placeholder.clone(),
+            1704067200000,
+            "/project".to_string(),
+            "copilot".to_string(),
+            transcript_path.to_string(),
+            1704067200,
+            2048,
+        )
+        .await
+        .unwrap();
+
+        let updated = SessionMetadataRepository::batch_upsert(
+            &db,
+            vec![(
+                session_id.to_string(),
+                "Real Copilot title".to_string(),
+                1704067300000,
+                "/project".to_string(),
+                "copilot".to_string(),
+                transcript_path.to_string(),
+                1704067200,
+                2048,
+            )],
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(updated, 1, "placeholder title should refresh even when transcript metadata is unchanged");
+
+        let session = SessionMetadataRepository::get_by_id(&db, session_id)
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(session.display, "Real Copilot title");
+        assert_eq!(session.file_path, transcript_path);
+    }
+
+    #[tokio::test]
     async fn test_set_provider_session_id_allows_batch_upsert_to_update_alias_row() {
         let db = setup_test_db().await;
 

--- a/packages/desktop/src-tauri/src/history/indexer.rs
+++ b/packages/desktop/src-tauri/src/history/indexer.rs
@@ -276,11 +276,23 @@ impl SessionMetadataSource for CopilotSource {
         let sessions = copilot_history::list_workspace_sessions(project_paths)
             .await
             .map_err(|error| anyhow!(error))?;
+        let session_ids = sessions
+            .iter()
+            .map(|session| session.session_id.clone())
+            .collect::<Vec<_>>();
         let indexed_entries = SessionMetadataRepository::get_all_file_index_entries(db).await?;
         let indexed_map: HashMap<String, (String, i64, i64)> = indexed_entries
             .into_iter()
             .map(|(session_id, path, mtime, size)| (session_id, (path, mtime, size)))
             .collect();
+        let existing_rows = SessionMetadataRepository::get_for_session_ids(db, &session_ids).await?;
+        let mut existing_row_map = HashMap::new();
+        for row in existing_rows {
+            if let Some(provider_session_id) = row.provider_session_id.clone() {
+                existing_row_map.insert(provider_session_id, row.clone());
+            }
+            existing_row_map.insert(row.id.clone(), row);
+        }
 
         let mut records: Vec<SessionMetadataRecord> = Vec::with_capacity(sessions.len());
         let mut live_session_ids: HashSet<String> = HashSet::with_capacity(sessions.len());
@@ -326,9 +338,19 @@ impl SessionMetadataSource for CopilotSource {
 
             if let Some((indexed_path, indexed_mtime, indexed_size)) = indexed_map.get(&session_id)
             {
+                let title_refresh_needed = existing_row_map.get(&session_id).is_some_and(|row| {
+                    !row.title_overridden
+                        && SessionMetadataRepository::is_acepe_placeholder_display(
+                            &row.id,
+                            &row.display,
+                        )
+                        && !session.title.trim().is_empty()
+                        && session.title != row.display
+                });
                 if indexed_path == &file_path
                     && indexed_mtime == &file_mtime
                     && indexed_size == &file_size
+                    && !title_refresh_needed
                 {
                     unchanged_count += 1;
                     continue;
@@ -1261,5 +1283,147 @@ impl IndexerActor {
         };
 
         Ok(path)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{CopilotSource, SessionMetadataSource};
+    use crate::db::repository::SessionMetadataRepository;
+    use sea_orm::{Database, DbConn};
+    use sea_orm_migration::MigratorTrait;
+    use std::fs;
+    use std::path::Path;
+    use std::sync::{Mutex, OnceLock};
+    use tempfile::TempDir;
+
+    async fn setup_test_db() -> DbConn {
+        let db = Database::connect("sqlite::memory:")
+            .await
+            .expect("Failed to connect to in-memory SQLite");
+        crate::db::migrations::Migrator::up(&db, None)
+            .await
+            .expect("Failed to run migrations");
+        db
+    }
+
+    fn home_test_lock() -> &'static Mutex<()> {
+        static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+        LOCK.get_or_init(|| Mutex::new(()))
+    }
+
+    struct HomeGuard {
+        previous_value: Option<String>,
+    }
+
+    impl HomeGuard {
+        fn set(path: &Path) -> Self {
+            let previous_value = std::env::var("HOME").ok();
+            std::env::set_var("HOME", path);
+            Self { previous_value }
+        }
+    }
+
+    impl Drop for HomeGuard {
+        fn drop(&mut self) {
+            if let Some(previous_value) = &self.previous_value {
+                std::env::set_var("HOME", previous_value);
+            } else {
+                std::env::remove_var("HOME");
+            }
+        }
+    }
+
+    fn write_copilot_session(home_path: &Path, project_path: &Path, session_id: &str) -> (String, i64, i64) {
+        let session_dir = home_path
+            .join(".copilot")
+            .join("session-state")
+            .join(session_id);
+        fs::create_dir_all(&session_dir).expect("create copilot session dir");
+        let events_path = session_dir.join("events.jsonl");
+        fs::write(
+            &events_path,
+            "{\"type\":\"user.message\",\"data\":{\"content\":\"hello\"},\"timestamp\":\"2026-04-10T00:00:01Z\"}\n",
+        )
+        .expect("write events jsonl");
+        fs::write(
+            session_dir.join("workspace.yaml"),
+            format!(
+                "id: {session_id}\ncwd: {}\nsummary: Real Copilot title\nupdated_at: 2026-04-10T00:00:02Z\n",
+                project_path.display()
+            ),
+        )
+        .expect("write workspace metadata");
+
+        let metadata = fs::metadata(&events_path).expect("events metadata");
+        let modified = metadata
+            .modified()
+            .expect("modified time")
+            .duration_since(std::time::SystemTime::UNIX_EPOCH)
+            .expect("unix timestamp")
+            .as_secs() as i64;
+
+        (
+            events_path.to_string_lossy().into_owned(),
+            modified,
+            metadata.len() as i64,
+        )
+    }
+
+    #[tokio::test]
+    async fn copilot_source_fetch_emits_title_refresh_when_only_summary_changed() {
+        let _lock = home_test_lock().lock().expect("home lock");
+        let temp_dir = TempDir::new().expect("temp dir");
+        let home_dir = temp_dir.path().join("home");
+        fs::create_dir_all(&home_dir).expect("home dir");
+        let _guard = HomeGuard::set(&home_dir);
+
+        let project_dir = temp_dir.path().join("project");
+        fs::create_dir_all(&project_dir).expect("project dir");
+        git2::Repository::init(&project_dir).expect("init project repo");
+        let canonical_project = project_dir
+            .canonicalize()
+            .expect("canonical project path")
+            .to_string_lossy()
+            .into_owned();
+
+        let session_id = "12345678-copilot-session";
+        let (events_path, file_mtime, file_size) =
+            write_copilot_session(&home_dir, &project_dir, session_id);
+
+        let db = setup_test_db().await;
+        SessionMetadataRepository::ensure_exists(&db, session_id, &canonical_project, "copilot", None)
+            .await
+            .expect("seed placeholder row");
+
+        let placeholder = SessionMetadataRepository::get_by_id(&db, session_id)
+            .await
+            .expect("load placeholder row")
+            .expect("placeholder row")
+            .display;
+
+        SessionMetadataRepository::upsert(
+            &db,
+            session_id.to_string(),
+            placeholder,
+            1704067200000,
+            canonical_project.clone(),
+            "copilot".to_string(),
+            events_path,
+            file_mtime,
+            file_size,
+        )
+        .await
+        .expect("seed transcript metadata");
+
+        let source = CopilotSource;
+        let delta = source
+            .fetch(&db, &[canonical_project], None)
+            .await
+            .expect("fetch copilot delta");
+
+        assert_eq!(delta.records.len(), 1);
+        assert_eq!(delta.records[0].0, session_id);
+        assert_eq!(delta.records[0].1, "Real Copilot title");
     }
 }


### PR DESCRIPTION
## Summary

This fixes two Copilot restore regressions:

1. restarted sessions could stay stuck on Acepe placeholder titles even after Copilot had a better `workspace.yaml.summary`
2. restored Copilot history could surface internal reasoning / thought chunks as visible assistant transcript content

## What changed

- teach the session metadata repository to refresh Copilot placeholder titles even when transcript file metadata is unchanged
- let the Copilot indexer emit a metadata refresh when only the summary/title improved, while still preserving manual title overrides
- filter `AgentThoughtChunk` / reasoning-only content at the shared restored-history conversion seam so transcript parsing, journal replay, and ACP replay fallbacks stay aligned
- add targeted regression coverage for repository refresh behavior, indexer refresh behavior, and restored-history replay hygiene

## Validation

- focused `copilot_history` Rust test slice
- placeholder-title refresh regression in `repository_test`
- indexer regression for `CopilotSource::fetch()` summary-only refresh

---

[![Compound Engineering](https://img.shields.io/badge/Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
🤖 Generated with GPT-5.4 (unknown context, standard reasoning) via GitHub Copilot CLI(https://github.com/features/copilot)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restores correct Copilot session titles after restarts and cleans restored history by removing internal reasoning chunks. Keeps replays aligned and prevents placeholder titles from sticking.

- **Bug Fixes**
  - Refresh Copilot placeholder titles even when transcript mtime/size are unchanged, while preserving manual overrides.
  - Indexer emits a metadata update when only the summary/title improves to replace placeholders without unnecessary refreshes.
  - Filter reasoning-only content (`AgentThoughtChunk`, `assistant.reasoning`, inline `reasoningText`) during restored-history conversion so transcript parsing, journal replay, and ACP fallbacks stay consistent.

<sup>Written for commit 4ecd54cbe5ac5b1a7c250377c4b9f67e50f3bf19. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

