### PR TITLE
feat(projects): persist sidebar metadata and icons

### DIFF
--- a/packages/desktop/src-tauri/src/commands/names.rs
+++ b/packages/desktop/src-tauri/src/commands/names.rs
@@ -2,6 +2,25 @@
 /// These are exported to TypeScript via specta to ensure type safety.
 use serde::Serialize;
 
+#[macro_export]
+macro_rules! project_storage_command_idents {
+    ($callback:ident) => {
+        $callback!(
+            get_projects,
+            get_recent_projects,
+            get_project_count,
+            get_missing_project_paths,
+            import_project,
+            add_project,
+            update_project_color,
+            update_project_icon,
+            update_project_order,
+            remove_project,
+            browse_project
+        )
+    };
+}
+
 /// ACP (Agent Client Protocol) command names
 #[derive(Debug, Clone, Serialize, specta::Type)]
 #[serde(rename_all = "snake_case")]
@@ -65,6 +84,22 @@ pub const SESSION_HISTORY_COMMANDS: SessionHistoryCommands = SessionHistoryComma
 };
 
 /// Storage command names
+macro_rules! storage_command_project_fields {
+    ($($command:ident),* $(,)?) => {
+        $(
+            pub $command: &'static str,
+        )*
+    };
+}
+
+macro_rules! storage_command_project_values {
+    ($($command:ident),* $(,)?) => {
+        $(
+            $command: stringify!($command),
+        )*
+    };
+}
+
 #[derive(Debug, Clone, Serialize, specta::Type)]
 #[serde(rename_all = "snake_case")]
 #[allow(dead_code)]
@@ -77,14 +112,7 @@ pub struct StorageCommands {
     pub delete_conversation: &'static str,
     pub open_in_finder: &'static str,
     pub open_streaming_log: &'static str,
-    pub get_projects: &'static str,
-    pub get_recent_projects: &'static str,
-    pub get_project_count: &'static str,
-    pub get_missing_project_paths: &'static str,
-    pub import_project: &'static str,
-    pub add_project: &'static str,
-    pub remove_project: &'static str,
-    pub browse_project: &'static str,
+    project_storage_command_idents!(storage_command_project_fields)
     pub get_all_conversations: &'static str,
     pub upsert_conversation: &'static str,
     pub get_user_setting: &'static str,
@@ -113,14 +141,7 @@ pub const STORAGE_COMMANDS: StorageCommands = StorageCommands {
     delete_conversation: "delete_conversation",
     open_in_finder: "open_in_finder",
     open_streaming_log: "open_streaming_log",
-    get_projects: "get_projects",
-    get_recent_projects: "get_recent_projects",
-    get_project_count: "get_project_count",
-    get_missing_project_paths: "get_missing_project_paths",
-    import_project: "import_project",
-    add_project: "add_project",
-    remove_project: "remove_project",
-    browse_project: "browse_project",
+    project_storage_command_idents!(storage_command_project_values)
     get_all_conversations: "get_all_conversations",
     upsert_conversation: "upsert_conversation",
     get_user_setting: "get_user_setting",

--- a/packages/desktop/src-tauri/src/db/entities/project.rs
+++ b/packages/desktop/src-tauri/src/db/entities/project.rs
@@ -13,6 +13,8 @@ pub struct Model {
     pub last_opened: DateTime<Utc>,
     pub created_at: DateTime<Utc>,
     pub color: String,
+    pub sort_order: i32,
+    pub icon_path: Option<String>,
 }
 
 #[derive(Copy, Clone, Debug, EnumIter, DeriveRelation)]

--- a/packages/desktop/src-tauri/src/db/migrations/m20260413_000001_add_project_sidebar_metadata.rs
+++ b/packages/desktop/src-tauri/src/db/migrations/m20260413_000001_add_project_sidebar_metadata.rs
@@ -1,0 +1,72 @@
+use sea_orm_migration::prelude::*;
+
+#[derive(DeriveMigrationName)]
+pub struct Migration;
+
+#[async_trait::async_trait]
+impl MigrationTrait for Migration {
+    async fn up(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        manager
+            .alter_table(
+                Table::alter()
+                    .table(Projects::Table)
+                    .add_column(
+                        ColumnDef::new(Projects::SortOrder)
+                            .integer()
+                            .not_null()
+                            .default(0),
+                    )
+                    .to_owned(),
+            )
+            .await?;
+
+        manager
+            .alter_table(
+                Table::alter()
+                    .table(Projects::Table)
+                    .add_column(ColumnDef::new(Projects::IconPath).string().null())
+                    .to_owned(),
+            )
+            .await?;
+
+        manager
+            .get_connection()
+            .execute_unprepared(
+                r#"
+                UPDATE projects
+                SET sort_order = (
+                    SELECT COUNT(*)
+                    FROM projects AS newer
+                    WHERE newer.created_at > projects.created_at
+                        OR (newer.created_at = projects.created_at AND newer.id < projects.id)
+                );
+                "#,
+            )
+            .await?;
+
+        manager
+            .create_index(
+                Index::create()
+                    .if_not_exists()
+                    .name("idx_projects_sort_order")
+                    .table(Projects::Table)
+                    .col(Projects::SortOrder)
+                    .to_owned(),
+            )
+            .await?;
+
+        Ok(())
+    }
+
+    async fn down(&self, _manager: &SchemaManager) -> Result<(), DbErr> {
+        // SQLite doesn't support DROP COLUMN — leave in place
+        Ok(())
+    }
+}
+
+#[derive(DeriveIden)]
+enum Projects {
+    Table,
+    SortOrder,
+    IconPath,
+}

--- a/packages/desktop/src-tauri/src/db/migrations/mod.rs
+++ b/packages/desktop/src-tauri/src/db/migrations/mod.rs
@@ -20,6 +20,7 @@ mod m20260405_000002_add_acepe_managed_to_session_metadata;
 mod m20260406_000001_create_acepe_session_state;
 mod m20260408_000001_create_session_projection_snapshots;
 mod m20260408_000002_create_session_journal_events;
+mod m20260413_000001_add_project_sidebar_metadata;
 
 pub struct Migrator;
 
@@ -47,6 +48,7 @@ impl MigratorTrait for Migrator {
             Box::new(m20260406_000001_create_acepe_session_state::Migration),
             Box::new(m20260408_000001_create_session_projection_snapshots::Migration),
             Box::new(m20260408_000002_create_session_journal_events::Migration),
+            Box::new(m20260413_000001_add_project_sidebar_metadata::Migration),
         ]
     }
 }

--- a/packages/desktop/src-tauri/src/db/repository.rs
+++ b/packages/desktop/src-tauri/src/db/repository.rs
@@ -259,7 +259,8 @@ impl ProjectRepository {
     }
 
     pub async fn reorder(db: &DbConn, ordered_paths: &[String]) -> Result<Vec<ProjectRow>> {
-        let existing = Project::find().all(db).await?;
+        let txn = db.begin().await?;
+        let existing = Project::find().all(&txn).await?;
         if existing.len() != ordered_paths.len() {
             anyhow::bail!("Project order update requires all projects");
         }
@@ -277,7 +278,6 @@ impl ProjectRepository {
             anyhow::bail!("Project order update paths do not match stored projects");
         }
 
-        let txn = db.begin().await?;
         for (index, path) in ordered_paths.iter().enumerate() {
             let project = Project::find()
                 .filter(crate::db::entities::project::Column::Path.eq(path))
@@ -304,9 +304,10 @@ impl ProjectRepository {
             "Deleting project"
         );
 
+        let txn = db.begin().await?;
         let existing = Project::find()
             .filter(crate::db::entities::project::Column::Path.eq(path))
-            .one(db)
+            .one(&txn)
             .await?;
 
         let Some(existing_model) = existing else {
@@ -314,7 +315,6 @@ impl ProjectRepository {
         };
 
         let deleted_sort_order = existing_model.sort_order;
-        let txn = db.begin().await?;
 
         Project::delete_many()
             .filter(crate::db::entities::project::Column::Path.eq(path))

--- a/packages/desktop/src-tauri/src/db/repository.rs
+++ b/packages/desktop/src-tauri/src/db/repository.rs
@@ -36,11 +36,37 @@ pub struct ProjectRow {
     pub last_opened: String,
     pub created_at: String,
     pub color: String,
+    pub sort_order: i32,
+    pub icon_path: Option<String>,
 }
 
 pub struct ProjectRepository;
 
 impl ProjectRepository {
+    fn display_name(path: &str, stored_name: &str) -> String {
+        std::path::Path::new(path)
+            .file_name()
+            .and_then(|name| name.to_str())
+            .filter(|name| !name.is_empty())
+            .map(std::borrow::ToOwned::to_owned)
+            .unwrap_or_else(|| stored_name.to_string())
+    }
+
+    fn row_from_model(model: crate::db::entities::project::Model) -> ProjectRow {
+        let name = Self::display_name(&model.path, &model.name);
+
+        ProjectRow {
+            id: model.id,
+            path: model.path,
+            name,
+            last_opened: model.last_opened.to_rfc3339(),
+            created_at: model.created_at.to_rfc3339(),
+            color: model.color,
+            sort_order: model.sort_order,
+            icon_path: model.icon_path,
+        }
+    }
+
     /// Create or update a project.
     /// If project exists, updates last_opened timestamp.
     /// If project doesn't exist, creates it.
@@ -71,6 +97,8 @@ impl ProjectRepository {
             let id = active.id.as_ref().clone();
             let created_at = *active.created_at.as_ref();
             let existing_color = active.color.as_ref().clone();
+            let sort_order = *active.sort_order.as_ref();
+            let icon_path = active.icon_path.as_ref().clone();
             active.name = Set(name.clone());
             active.last_opened = Set(now);
             // Update color if provided, otherwise keep existing
@@ -90,6 +118,8 @@ impl ProjectRepository {
                 last_opened: now.to_rfc3339(),
                 created_at: created_at.to_rfc3339(),
                 color: final_color,
+                sort_order,
+                icon_path,
             }
         } else {
             // Create new project - assign random color if not provided
@@ -99,6 +129,10 @@ impl ProjectRepository {
                 colors[rng.gen_range(0..colors.len())].to_string()
             });
 
+            let txn = db.begin().await?;
+            txn.execute_unprepared("UPDATE projects SET sort_order = sort_order + 1")
+                .await?;
+
             let id = Uuid::new_v4().to_string();
             let project = crate::db::entities::project::ActiveModel {
                 id: Set(id.clone()),
@@ -107,9 +141,12 @@ impl ProjectRepository {
                 last_opened: Set(now),
                 created_at: Set(now),
                 color: Set(assigned_color.clone()),
+                sort_order: Set(0),
+                icon_path: Set(None),
             };
 
-            Project::insert(project).exec(db).await?;
+            Project::insert(project).exec(&txn).await?;
+            txn.commit().await?;
 
             tracing::info!(
                 id = %id,
@@ -125,6 +162,8 @@ impl ProjectRepository {
                 last_opened: now.to_rfc3339(),
                 created_at: now.to_rfc3339(),
                 color: assigned_color,
+                sort_order: 0,
+                icon_path: None,
             }
         };
 
@@ -154,21 +193,15 @@ impl ProjectRepository {
             ),
         }
 
-        Ok(model.map(|m| ProjectRow {
-            id: m.id,
-            path: m.path,
-            name: m.name,
-            last_opened: m.last_opened.to_rfc3339(),
-            created_at: m.created_at.to_rfc3339(),
-            color: m.color,
-        }))
+        Ok(model.map(Self::row_from_model))
     }
 
-    /// Get all projects, ordered by last_opened descending.
+    /// Get all projects, ordered by persisted sidebar order.
     pub async fn get_all(db: &DbConn) -> Result<Vec<ProjectRow>> {
         tracing::debug!("Loading all projects");
 
         let models = Project::find()
+            .order_by_asc(crate::db::entities::project::Column::SortOrder)
             .order_by_desc(crate::db::entities::project::Column::CreatedAt)
             .all(db)
             .await?;
@@ -179,17 +212,7 @@ impl ProjectRepository {
             "Loaded projects"
         );
 
-        Ok(models
-            .into_iter()
-            .map(|m| ProjectRow {
-                id: m.id,
-                path: m.path,
-                name: m.name,
-                last_opened: m.last_opened.to_rfc3339(),
-                created_at: m.created_at.to_rfc3339(),
-                color: m.color,
-            })
-            .collect())
+        Ok(models.into_iter().map(Self::row_from_model).collect())
     }
 
     /// Get recent projects (limit to N, ordered by last_opened).
@@ -211,17 +234,67 @@ impl ProjectRepository {
             "Loaded recent projects"
         );
 
-        Ok(models
-            .into_iter()
-            .map(|m| ProjectRow {
-                id: m.id,
-                path: m.path,
-                name: m.name,
-                last_opened: m.last_opened.to_rfc3339(),
-                created_at: m.created_at.to_rfc3339(),
-                color: m.color,
-            })
-            .collect())
+        Ok(models.into_iter().map(Self::row_from_model).collect())
+    }
+
+    pub async fn update_icon_path(
+        db: &DbConn,
+        path: &str,
+        icon_path: Option<String>,
+    ) -> Result<ProjectRow> {
+        let existing = Project::find()
+            .filter(crate::db::entities::project::Column::Path.eq(path))
+            .one(db)
+            .await?;
+
+        let Some(existing_model) = existing else {
+            anyhow::bail!("Project not found: {}", path);
+        };
+
+        let mut active: crate::db::entities::project::ActiveModel = existing_model.into();
+        active.icon_path = Set(icon_path);
+
+        let updated = active.update(db).await?;
+        Ok(Self::row_from_model(updated))
+    }
+
+    pub async fn reorder(db: &DbConn, ordered_paths: &[String]) -> Result<Vec<ProjectRow>> {
+        let existing = Project::find().all(db).await?;
+        if existing.len() != ordered_paths.len() {
+            anyhow::bail!("Project order update requires all projects");
+        }
+
+        let existing_paths = existing
+            .iter()
+            .map(|project| project.path.clone())
+            .collect::<std::collections::BTreeSet<_>>();
+        let requested_paths = ordered_paths
+            .iter()
+            .cloned()
+            .collect::<std::collections::BTreeSet<_>>();
+
+        if existing_paths != requested_paths {
+            anyhow::bail!("Project order update paths do not match stored projects");
+        }
+
+        let txn = db.begin().await?;
+        for (index, path) in ordered_paths.iter().enumerate() {
+            let project = Project::find()
+                .filter(crate::db::entities::project::Column::Path.eq(path))
+                .one(&txn)
+                .await?;
+
+            let Some(project_model) = project else {
+                anyhow::bail!("Project not found during reorder: {}", path);
+            };
+
+            let mut active: crate::db::entities::project::ActiveModel = project_model.into();
+            active.sort_order = Set(index as i32);
+            active.update(&txn).await?;
+        }
+        txn.commit().await?;
+
+        Self::get_all(db).await
     }
 
     /// Delete a project by path.
@@ -231,10 +304,29 @@ impl ProjectRepository {
             "Deleting project"
         );
 
+        let existing = Project::find()
+            .filter(crate::db::entities::project::Column::Path.eq(path))
+            .one(db)
+            .await?;
+
+        let Some(existing_model) = existing else {
+            return Ok(());
+        };
+
+        let deleted_sort_order = existing_model.sort_order;
+        let txn = db.begin().await?;
+
         Project::delete_many()
             .filter(crate::db::entities::project::Column::Path.eq(path))
-            .exec(db)
+            .exec(&txn)
             .await?;
+
+        let shift_statement = format!(
+            "UPDATE projects SET sort_order = sort_order - 1 WHERE sort_order > {}",
+            deleted_sort_order
+        );
+        txn.execute_unprepared(&shift_statement).await?;
+        txn.commit().await?;
 
         tracing::info!(
             path = %path,

--- a/packages/desktop/src-tauri/src/db/repository_test.rs
+++ b/packages/desktop/src-tauri/src/db/repository_test.rs
@@ -16,7 +16,7 @@ mod session_metadata_tests {
     use crate::acp::session_update::{PermissionData, QuestionData, SessionUpdate};
     use crate::db::entities::prelude::AcepeSessionState;
     use crate::db::repository::{
-        SessionJournalEventRepository, SessionMetadataRepository,
+        ProjectRepository, SessionJournalEventRepository, SessionMetadataRepository,
         SessionProjectionSnapshotRepository,
     };
     use sea_orm::{ConnectionTrait, Database, DbConn, EntityTrait, Statement};
@@ -83,6 +83,67 @@ mod session_metadata_tests {
         // Verify insertion
         let is_empty = SessionMetadataRepository::is_empty(&db).await.unwrap();
         assert!(!is_empty, "Database should not be empty after insert");
+    }
+
+    #[tokio::test]
+    async fn project_repository_preserves_path_casing_in_display_name() {
+        let db = setup_test_db().await;
+
+        ProjectRepository::create_or_update(
+            &db,
+            "/Users/test/MyAPIService".to_string(),
+            "myapiservice".to_string(),
+            Some("cyan".to_string()),
+        )
+        .await
+        .expect("create project");
+
+        let projects = ProjectRepository::get_all(&db).await.expect("load projects");
+
+        assert_eq!(projects.len(), 1);
+        assert_eq!(projects[0].name, "MyAPIService");
+        assert_eq!(projects[0].sort_order, 0);
+    }
+
+    #[tokio::test]
+    async fn project_repository_reorders_projects_and_persists_icon_path() {
+        let db = setup_test_db().await;
+
+        let first = ProjectRepository::create_or_update(
+            &db,
+            "/Users/test/Alpha".to_string(),
+            "Alpha".to_string(),
+            Some("cyan".to_string()),
+        )
+        .await
+        .expect("create first project");
+        let second = ProjectRepository::create_or_update(
+            &db,
+            "/Users/test/Beta".to_string(),
+            "Beta".to_string(),
+            Some("purple".to_string()),
+        )
+        .await
+        .expect("create second project");
+
+        let updated_second = ProjectRepository::update_icon_path(
+            &db,
+            &second.path,
+            Some("/tmp/beta-icon.png".to_string()),
+        )
+        .await
+        .expect("update icon");
+        assert_eq!(updated_second.icon_path.as_deref(), Some("/tmp/beta-icon.png"));
+
+        let reordered = ProjectRepository::reorder(&db, &[second.path.clone(), first.path.clone()])
+            .await
+            .expect("reorder projects");
+
+        assert_eq!(reordered.len(), 2);
+        assert_eq!(reordered[0].path, second.path);
+        assert_eq!(reordered[0].sort_order, 0);
+        assert_eq!(reordered[1].path, first.path);
+        assert_eq!(reordered[1].sort_order, 1);
     }
 
     #[tokio::test]

--- a/packages/desktop/src-tauri/src/lib.rs
+++ b/packages/desktop/src-tauri/src/lib.rs
@@ -142,6 +142,7 @@ use storage::commands::{
     get_thread_list_settings, get_user_setting, import_project, open_in_finder, open_streaming_log,
     remove_project, reset_database, save_api_key, save_custom_keybindings,
     save_session_review_state, save_thread_list_settings, save_user_setting, update_project_color,
+    update_project_icon, update_project_order,
 };
 use tauri::Manager;
 use terminal::commands::{
@@ -1082,6 +1083,8 @@ pub fn run() {
             import_project,
             add_project,
             update_project_color,
+            update_project_icon,
+            update_project_order,
             remove_project,
             browse_project,
             get_api_key,

--- a/packages/desktop/src-tauri/src/lib.rs
+++ b/packages/desktop/src-tauri/src/lib.rs
@@ -159,6 +159,14 @@ use voice::{
     voice_stop_recording, VoiceState,
 };
 
+macro_rules! registered_project_storage_handlers {
+    ($($command:ident),* $(,)?) => {
+        $(
+            $command,
+        )*
+    };
+}
+
 struct NoSpanEventFormatter;
 
 struct PrettyDevEventFormatter {
@@ -1076,17 +1084,7 @@ pub fn run() {
             get_opencode_session,
             get_opencode_converted_session,
             get_opencode_sessions_for_project,
-            get_projects,
-            get_recent_projects,
-            get_project_count,
-            get_missing_project_paths,
-            import_project,
-            add_project,
-            update_project_color,
-            update_project_icon,
-            update_project_order,
-            remove_project,
-            browse_project,
+            crate::project_storage_command_idents!(registered_project_storage_handlers)
             get_api_key,
             save_api_key,
             delete_api_key,

--- a/packages/desktop/src-tauri/src/storage/commands/projects.rs
+++ b/packages/desktop/src-tauri/src/storage/commands/projects.rs
@@ -4,7 +4,7 @@ use rand::Rng;
 use sea_orm::DatabaseConnection;
 use tauri::{AppHandle, State};
 
-use super::shared::{capitalize_name, get_db, validate_project_path_for_storage, Project};
+use super::shared::{get_db, project_name_from_path, validate_project_path_for_storage, Project};
 
 fn classify_missing_project_paths(paths: &[String]) -> Vec<String> {
     paths
@@ -43,6 +43,8 @@ pub async fn get_projects(app: AppHandle) -> Result<Vec<Project>, String> {
             last_opened: Some(row.last_opened),
             created_at: row.created_at,
             color: row.color,
+            sort_order: row.sort_order,
+            icon_path: row.icon_path,
         })
         .collect();
 
@@ -76,6 +78,8 @@ pub async fn get_recent_projects(
             last_opened: Some(row.last_opened),
             created_at: row.created_at,
             color: row.color,
+            sort_order: row.sort_order,
+            icon_path: row.icon_path,
         })
         .collect();
 
@@ -128,14 +132,9 @@ pub async fn import_project(
     let canonical_path = validate_project_path_for_storage(&path)?;
     let canonical_path_str = canonical_path.to_string_lossy().to_string();
 
-    // Extract name from path if not provided, and capitalize it
+    // Extract name from path if not provided, preserving the path's original casing.
     let project_name = name.unwrap_or_else(|| {
-        let raw_name = canonical_path
-            .file_name()
-            .and_then(|n| n.to_str())
-            .unwrap_or(&canonical_path_str)
-            .to_string();
-        capitalize_name(&raw_name)
+        project_name_from_path(&canonical_path, &canonical_path_str)
     });
 
     // Create or update project (color will be randomly assigned if new)
@@ -179,6 +178,8 @@ pub async fn import_project(
         last_opened: Some(project_row.last_opened),
         created_at: project_row.created_at,
         color: project_row.color,
+        sort_order: project_row.sort_order,
+        icon_path: project_row.icon_path,
     })
 }
 
@@ -191,14 +192,9 @@ pub async fn add_project(app: AppHandle, path: String, name: Option<String>) -> 
     let canonical_path = validate_project_path_for_storage(&path)?;
     let canonical_path_str = canonical_path.to_string_lossy().to_string();
 
-    // Extract name from path if not provided, and capitalize it
+    // Extract name from path if not provided, preserving the path's original casing.
     let project_name = name.unwrap_or_else(|| {
-        let raw_name = canonical_path
-            .file_name()
-            .and_then(|n| n.to_str())
-            .unwrap_or(&canonical_path_str)
-            .to_string();
-        capitalize_name(&raw_name)
+        project_name_from_path(&canonical_path, &canonical_path_str)
     });
 
     // Create or update project (color will be randomly assigned if new)
@@ -249,7 +245,67 @@ pub async fn update_project_color(
         last_opened: Some(row.last_opened),
         created_at: row.created_at,
         color: row.color,
+        sort_order: row.sort_order,
+        icon_path: row.icon_path,
     })
+}
+
+#[tauri::command]
+#[specta::specta]
+pub async fn update_project_icon(
+    app: AppHandle,
+    path: String,
+    icon_path: Option<String>,
+) -> Result<Project, String> {
+    tracing::info!(path = %path, icon_path = ?icon_path, "Updating project icon");
+
+    let db = get_db(&app);
+    let row = ProjectRepository::update_icon_path(&db, &path, icon_path)
+        .await
+        .map_err(|e| {
+            tracing::error!(error = %e, "Failed to update project icon");
+            e.to_string()
+        })?;
+
+    Ok(Project {
+        path: row.path,
+        name: row.name,
+        last_opened: Some(row.last_opened),
+        created_at: row.created_at,
+        color: row.color,
+        sort_order: row.sort_order,
+        icon_path: row.icon_path,
+    })
+}
+
+#[tauri::command]
+#[specta::specta]
+pub async fn update_project_order(
+    app: AppHandle,
+    ordered_paths: Vec<String>,
+) -> Result<Vec<Project>, String> {
+    tracing::info!(count = ordered_paths.len(), "Updating project order");
+
+    let db = get_db(&app);
+    let rows = ProjectRepository::reorder(&db, &ordered_paths)
+        .await
+        .map_err(|e| {
+            tracing::error!(error = %e, "Failed to update project order");
+            e.to_string()
+        })?;
+
+    Ok(rows
+        .into_iter()
+        .map(|row| Project {
+            path: row.path,
+            name: row.name,
+            last_opened: Some(row.last_opened),
+            created_at: row.created_at,
+            color: row.color,
+            sort_order: row.sort_order,
+            icon_path: row.icon_path,
+        })
+        .collect())
 }
 
 #[tauri::command]
@@ -286,10 +342,8 @@ pub async fn browse_project(_app: AppHandle) -> Result<Option<Project>, String> 
             let path_str = folder_path.path().to_string_lossy().to_string();
             let project_name = folder_path
                 .path()
-                .file_name()
-                .and_then(|n| n.to_str())
-                .map(capitalize_name)
-                .unwrap_or_else(|| capitalize_name(&path_str));
+                .to_path_buf();
+            let project_name = project_name_from_path(&project_name, &path_str);
 
             tracing::info!(path = %path_str, name = %project_name, "Project selected");
 
@@ -304,6 +358,8 @@ pub async fn browse_project(_app: AppHandle) -> Result<Option<Project>, String> 
                 last_opened: Some(chrono::Utc::now().to_rfc3339()),
                 created_at: chrono::Utc::now().to_rfc3339(),
                 color: assigned_color,
+                sort_order: 0,
+                icon_path: None,
             }))
         }
         None => {
@@ -315,7 +371,7 @@ pub async fn browse_project(_app: AppHandle) -> Result<Option<Project>, String> 
 
 #[cfg(test)]
 mod tests {
-    use super::classify_missing_project_paths;
+    use super::{classify_missing_project_paths, project_name_from_path};
     use tempfile::tempdir;
 
     #[test]
@@ -341,5 +397,14 @@ mod tests {
                 missing_path.to_string_lossy().to_string(),
             ]
         );
+    }
+
+    #[test]
+    fn preserves_original_project_name_casing() {
+        let project_path = std::path::PathBuf::from("/Users/test/MyAPIService");
+
+        let name = project_name_from_path(&project_path, "/Users/test/MyAPIService");
+
+        assert_eq!(name, "MyAPIService");
     }
 }

--- a/packages/desktop/src-tauri/src/storage/commands/shared.rs
+++ b/packages/desktop/src-tauri/src/storage/commands/shared.rs
@@ -2,22 +2,12 @@ use crate::path_safety::validate_project_directory_from_str;
 use sea_orm::DbConn;
 use tauri::{AppHandle, Manager, State};
 
-/// Capitalize the first letter of each word in a string.
-/// Handles spaces, underscores, and hyphens as word separators.
-pub(super) fn capitalize_name(name: &str) -> String {
-    name.split(&[' ', '_', '-'][..])
-        .map(|word| {
-            let mut chars = word.chars();
-            match chars.next() {
-                None => String::new(),
-                Some(first) => {
-                    first.to_uppercase().collect::<String>()
-                        + chars.as_str().to_lowercase().as_str()
-                }
-            }
-        })
-        .collect::<Vec<String>>()
-        .join(" ")
+pub(super) fn project_name_from_path(path: &std::path::Path, fallback: &str) -> String {
+    path.file_name()
+        .and_then(|name| name.to_str())
+        .filter(|name| !name.is_empty())
+        .map(std::borrow::ToOwned::to_owned)
+        .unwrap_or_else(|| fallback.to_string())
 }
 
 /// Get database connection from app state
@@ -44,4 +34,7 @@ pub struct Project {
     pub last_opened: Option<String>,
     pub created_at: String,
     pub color: String,
+    pub sort_order: i32,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub icon_path: Option<String>,
 }

--- a/packages/desktop/src/lib/acp/components/project-card.svelte
+++ b/packages/desktop/src/lib/acp/components/project-card.svelte
@@ -157,7 +157,7 @@ function handleAgentClick(e: MouseEvent, agentId: string) {
 					<button
 						class="inline-flex items-center justify-center h-7 w-7 border-r border-border/30 last:border-r-0
 							text-muted-foreground hover:bg-accent/50 hover:text-foreground transition-colors cursor-pointer"
-						title="{capitalizeName(agent.name)}{agentKey <= 9 ? ` (${modifierSymbol}${agentKey})` : ''}"
+						title="{agent.name}{agentKey <= 9 ? ` (${modifierSymbol}${agentKey})` : ''}"
 						onclick={(e) => handleAgentClick(e, agent.id)}
 					>
 						<img src={iconSrc} alt={agent.name} class="h-4 w-4 shrink-0" />

--- a/packages/desktop/src/lib/acp/components/project-card.svelte
+++ b/packages/desktop/src/lib/acp/components/project-card.svelte
@@ -6,7 +6,6 @@ import { GitBranch } from "phosphor-svelte";
 import { Kbd, KbdGroup } from "$lib/components/ui/kbd/index.js";
 import { getAgentIcon } from "../constants/thread-list-constants.js";
 import type { AgentInfo } from "../logic/agent-manager.js";
-import { capitalizeName } from "../utils/index.js";
 import type { ProjectCardData } from "./project-card-data.js";
 
 interface Props {
@@ -66,7 +65,7 @@ function handleAgentClick(e: MouseEvent, agentId: string) {
 		<div class="flex items-center gap-2 px-2.5 h-8">
 			<span class="h-2 w-2 rounded-full shrink-0 bg-destructive/40"></span>
 			<span class="text-[11px] font-semibold text-muted-foreground truncate flex-1 line-through">
-				{capitalizeName(data.project.name)}
+				{data.project.name}
 			</span>
 			<span class="text-[10px] text-destructive/70 shrink-0">Missing</span>
 		</div>
@@ -84,12 +83,17 @@ function handleAgentClick(e: MouseEvent, agentId: string) {
 		<div class="flex items-center h-8 shrink-0">
 			<!-- Project letter badge -->
 			<div class="inline-flex items-center justify-center h-8 w-8 shrink-0">
-				<ProjectLetterBadge name={data.project.name} {color} size={18} />
+				<ProjectLetterBadge
+					name={data.project.name}
+					{color}
+					iconSrc={data.project.iconPath ?? null}
+					size={18}
+				/>
 			</div>
 
 			<!-- Project name -->
 			<span class="text-[11px] font-semibold font-mono text-foreground truncate flex-1 min-w-0">
-				{capitalizeName(data.project.name)}
+				{data.project.name}
 			</span>
 
 			<!-- Keyboard shortcut hint -->

--- a/packages/desktop/src/lib/acp/components/project-header.svelte
+++ b/packages/desktop/src/lib/acp/components/project-header.svelte
@@ -5,7 +5,6 @@ import type { Snippet } from "svelte";
 
 import type { Project } from "../logic/project-manager.svelte.js";
 import { TAG_COLORS } from "../utils/colors.js";
-import { capitalizeName } from "../utils/index.js";
 
 interface Props {
 	/** Project object containing name and color */
@@ -14,6 +13,8 @@ interface Props {
 	projectName?: string;
 	/** Alternative: direct project color hex value */
 	projectColor?: string;
+	/** Alternative: direct project icon source */
+	projectIconSrc?: string | null;
 	/** Whether the project card is expanded */
 	expanded?: boolean;
 	/** Additional CSS classes */
@@ -28,6 +29,7 @@ let {
 	project,
 	projectName,
 	projectColor,
+	projectIconSrc = null,
 	expanded = false,
 	class: className = "",
 	trailing,
@@ -39,8 +41,7 @@ let {
  * Priority: project.name -> projectName prop -> "Unknown Project"
  */
 const displayName = $derived.by(() => {
-	const name = project?.name ? project.name : projectName ? projectName : "Unknown Project";
-	return capitalizeName(name);
+	return project?.name ? project.name : projectName ? projectName : "Unknown Project";
 });
 
 /**
@@ -51,13 +52,19 @@ const fallbackColor = TAG_COLORS.length > 0 ? TAG_COLORS[0] : "#FF5D5A";
 const resolvedColor = $derived(
 	project?.color ? project.color : projectColor ? projectColor : fallbackColor
 );
+const resolvedIconSrc = $derived(project?.iconPath ?? projectIconSrc);
 </script>
 
 <div
 	class="shrink-0 flex items-center rounded-md {expanded ? 'bg-background/30' : ''} {className}"
 >
 	<div class="inline-flex items-center justify-center h-7 w-7 shrink-0">
-		<ProjectLetterBadge name={displayName} color={resolvedColor} size={16} />
+		<ProjectLetterBadge
+			name={displayName}
+			color={resolvedColor}
+			iconSrc={resolvedIconSrc}
+			size={16}
+		/>
 	</div>
 	<div
 		class="flex items-center flex-1 min-w-0 h-7 pl-2 pr-2 cursor-pointer rounded-md hover:bg-background/70 transition-colors"

--- a/packages/desktop/src/lib/acp/components/project-selection-panel.svelte
+++ b/packages/desktop/src/lib/acp/components/project-selection-panel.svelte
@@ -16,6 +16,7 @@ import {
 	markProjectSelectionMetadataFieldLoadFinished,
 	markProjectSelectionMetadataFieldLoadStarted,
 	setCachedProjectSelectionMetadata,
+	shouldLoadProjectSelectionMetadata,
 	shouldLoadProjectSelectionMetadataField,
 } from "./project-selection-metadata-cache.js";
 
@@ -130,25 +131,62 @@ function ensureProjectInfoLoaded(project: Project): void {
 			markProjectSelectionMetadataFieldLoadStarted(projectPath, "gitStatus");
 		}
 
-		void tauriClient.fileIndex.getProjectGitOverviewSummary(projectPath).match(
-			(overview) => {
-				updateProjectCardData(projectPath, {
-					branch: overview.branch,
-					gitStatus: overview.gitStatus,
-				});
-				if (shouldLoadBranch) {
-					markProjectSelectionMetadataFieldLoadFinished(projectPath, "branch", true);
+		void tauriClient.git.isRepo(projectPath).match(
+			(isRepo) => {
+				if (!isRepo) {
+					setProjectCardData(projectPath, {
+						branch: null,
+						gitStatus: null,
+					});
+					if (shouldLoadBranch) {
+						markProjectSelectionMetadataFieldLoadFinished(projectPath, "branch", false);
+					}
+					if (shouldLoadGitStatus) {
+						markProjectSelectionMetadataFieldLoadFinished(projectPath, "gitStatus", false);
+					}
+					return;
 				}
-				if (shouldLoadGitStatus) {
-					markProjectSelectionMetadataFieldLoadFinished(projectPath, "gitStatus", true);
-				}
-				// Fetch remote status (ahead/behind) in background
-				void tauriClient.git.remoteStatus(projectPath).match(
-					(remote) => {
-						remoteStatusMap.set(projectPath, { ahead: remote.ahead, behind: remote.behind });
+
+				void tauriClient.fileIndex.getProjectGitOverviewSummary(projectPath).match(
+					(overview) => {
+						updateProjectCardData(projectPath, {
+							branch: overview.branch,
+							gitStatus: overview.gitStatus,
+						});
+						if (shouldLoadBranch) {
+							markProjectSelectionMetadataFieldLoadFinished(projectPath, "branch", true);
+						}
+						if (shouldLoadGitStatus) {
+							markProjectSelectionMetadataFieldLoadFinished(projectPath, "gitStatus", true);
+						}
+						// Fetch remote status (ahead/behind) in background
+						void tauriClient.git.remoteStatus(projectPath).match(
+							(remote) => {
+								remoteStatusMap.set(projectPath, {
+									ahead: remote.ahead,
+									behind: remote.behind,
+								});
+							},
+							() => {
+								/* no remote or not a git repo — ignore */
+							}
+						);
 					},
-					() => {
-						/* no remote or not a git repo — ignore */
+					(err) => {
+						const msg = err instanceof Error ? err.message : String(err);
+						if (
+							msg.includes("not found") ||
+							msg.includes("not a directory") ||
+							msg.includes("does not exist")
+						) {
+							missingProjectPaths.add(projectPath);
+						}
+						if (shouldLoadBranch) {
+							markProjectSelectionMetadataFieldLoadFinished(projectPath, "branch", false);
+						}
+						if (shouldLoadGitStatus) {
+							markProjectSelectionMetadataFieldLoadFinished(projectPath, "gitStatus", false);
+						}
 					}
 				);
 			},
@@ -231,7 +269,14 @@ function syncDisplayedProjectMetadata(): void {
 	}
 
 	const displayProjectsKey = getProjectPathsKey(displayProjects);
-	if (!isSinglePreselectedProject && displayProjectsKey === lastDisplayProjectsKey) {
+	const hasRetryableMetadata = displayProjects.some((project) =>
+		shouldLoadProjectSelectionMetadata(project.path)
+	);
+	if (
+		!isSinglePreselectedProject &&
+		displayProjectsKey === lastDisplayProjectsKey &&
+		!hasRetryableMetadata
+	) {
 		return;
 	}
 	lastDisplayProjectsKey = displayProjectsKey;

--- a/packages/desktop/src/lib/acp/components/project-selection-panel.svelte
+++ b/packages/desktop/src/lib/acp/components/project-selection-panel.svelte
@@ -134,6 +134,7 @@ function ensureProjectInfoLoaded(project: Project): void {
 		void tauriClient.git.isRepo(projectPath).match(
 			(isRepo) => {
 				if (!isRepo) {
+					remoteStatusMap.delete(projectPath);
 					setProjectCardData(projectPath, {
 						branch: null,
 						gitStatus: null,

--- a/packages/desktop/src/lib/acp/components/project-selector.svelte
+++ b/packages/desktop/src/lib/acp/components/project-selector.svelte
@@ -8,11 +8,10 @@ import { Skeleton } from "$lib/components/ui/skeleton/index.js";
 import { tauriClient } from "$lib/utils/tauri-client.js";
 import { LOGGER_IDS } from "../constants/logger-ids.js";
 
-import { getAgentIcon } from "../constants/thread-list-constants.js";
-import type { Project } from "../logic/project-manager.svelte.js";
-import { getProjectColor, TAG_COLORS } from "../utils/colors.js";
-import { capitalizeName } from "../utils/index.js";
-import { createLogger } from "../utils/logger.js";
+	import { getAgentIcon } from "../constants/thread-list-constants.js";
+	import type { Project } from "../logic/project-manager.svelte.js";
+	import { getProjectColor, TAG_COLORS } from "../utils/colors.js";
+	import { createLogger } from "../utils/logger.js";
 import SelectorCheck from "./selector-check.svelte";
 
 interface ProjectSelectorProps {
@@ -93,12 +92,17 @@ function handleOpenChange(open: boolean) {
 		{:else}
 			{@const color = selectedProject ? getProjectColor(selectedProject) : TAG_COLORS[0]}
 			{#if selectedProject}
-				<ProjectLetterBadge name={selectedProject.name} {color} size={14} />
+				<ProjectLetterBadge
+					name={selectedProject.name}
+					{color}
+					iconSrc={selectedProject.iconPath ?? null}
+					size={14}
+				/>
 			{:else}
 				<div class="h-2 w-2 shrink-0 rounded-full" style="background-color: {color};"></div>
 			{/if}
 			<span class="text-xs truncate min-w-0">
-				{selectedProject ? capitalizeName(selectedProject.name) : "Select project..."}
+				{selectedProject ? selectedProject.name : "Select project..."}
 			</span>
 		{/if}
 	{/snippet}
@@ -113,8 +117,13 @@ function handleOpenChange(open: boolean) {
 			{#if isMissing}
 				<DropdownMenu.Item disabled class="group/item py-1 opacity-50">
 					<div class="flex items-center gap-2 w-full min-w-0">
-						<ProjectLetterBadge name={project.name} {color} size={16} />
-						<span class="flex-1 text-sm truncate line-through">{capitalizeName(project.name)}</span>
+						<ProjectLetterBadge
+							name={project.name}
+							{color}
+							iconSrc={project.iconPath ?? null}
+							size={16}
+						/>
+						<span class="flex-1 text-sm truncate line-through">{project.name}</span>
 						<span class="text-[10px] text-destructive/70 shrink-0">Missing</span>
 					</div>
 				</DropdownMenu.Item>
@@ -124,8 +133,13 @@ function handleOpenChange(open: boolean) {
 					class="group/item py-1 {isSelected ? 'bg-accent' : ''}"
 				>
 					<div class="flex items-center gap-2 w-full min-w-0">
-						<ProjectLetterBadge name={project.name} {color} size={16} />
-						<span class="flex-1 text-sm truncate">{capitalizeName(project.name)}</span>
+						<ProjectLetterBadge
+							name={project.name}
+							{color}
+							iconSrc={project.iconPath ?? null}
+							size={16}
+						/>
+						<span class="flex-1 text-sm truncate">{project.name}</span>
 						<SelectorCheck visible={isSelected} />
 					</div>
 				</DropdownMenu.Item>

--- a/packages/desktop/src/lib/acp/logic/project-client.ts
+++ b/packages/desktop/src/lib/acp/logic/project-client.ts
@@ -10,6 +10,26 @@ import { ProjectError } from "./project-manager.svelte.js";
  * All methods use neverthrow ResultAsync for type-safe error handling.
  */
 export class ProjectClient {
+	private mapProject(project: {
+		path: string;
+		name: string;
+		last_opened?: string;
+		created_at: string;
+		color: string;
+		sort_order: number;
+		icon_path?: string | null;
+	}): Project {
+		return {
+			path: project.path,
+			name: project.name,
+			lastOpened: project.last_opened ? new Date(project.last_opened) : undefined,
+			createdAt: new Date(project.created_at),
+			color: resolveProjectColor(project.color),
+			sortOrder: project.sort_order,
+			iconPath: project.icon_path ?? null,
+		};
+	}
+
 	/**
 	 * Get all projects.
 	 *
@@ -19,15 +39,7 @@ export class ProjectClient {
 		return tauriClient.projects
 			.getProjects()
 			.mapErr((e) => new ProjectError(`Failed to get projects: ${e}`, "STORAGE_ERROR"))
-			.map((projects) =>
-				projects.map((p) => ({
-					path: p.path,
-					name: p.name,
-					lastOpened: p.last_opened ? new Date(p.last_opened) : undefined,
-					createdAt: new Date(p.created_at),
-					color: resolveProjectColor(p.color),
-				}))
-			);
+			.map((projects) => projects.map((project) => this.mapProject(project)));
 	}
 
 	/**
@@ -40,15 +52,7 @@ export class ProjectClient {
 		return tauriClient.projects
 			.getRecentProjects(limit)
 			.mapErr((e) => new ProjectError(`Failed to get recent projects: ${e}`, "STORAGE_ERROR"))
-			.map((projects) =>
-				projects.map((p) => ({
-					path: p.path,
-					name: p.name,
-					lastOpened: p.last_opened ? new Date(p.last_opened) : undefined,
-					createdAt: new Date(p.created_at),
-					color: resolveProjectColor(p.color),
-				}))
-			);
+			.map((projects) => projects.map((project) => this.mapProject(project)));
 	}
 
 	/**
@@ -72,13 +76,7 @@ export class ProjectClient {
 		return tauriClient.projects
 			.importProject(project.path, project.name)
 			.mapErr((e) => new ProjectError(`Failed to import project: ${e}`, "STORAGE_ERROR"))
-			.map((p) => ({
-				path: p.path,
-				name: p.name,
-				lastOpened: p.last_opened ? new Date(p.last_opened) : undefined,
-				createdAt: new Date(p.created_at),
-				color: resolveProjectColor(p.color),
-			}));
+			.map((importedProject) => this.mapProject(importedProject));
 	}
 
 	/**
@@ -92,13 +90,21 @@ export class ProjectClient {
 		return tauriClient.projects
 			.updateProjectColor(path, color)
 			.mapErr((e) => new ProjectError(`Failed to update project color: ${e}`, "STORAGE_ERROR"))
-			.map((project) => ({
-				path: project.path,
-				name: project.name,
-				lastOpened: project.last_opened ? new Date(project.last_opened) : undefined,
-				createdAt: new Date(project.created_at),
-				color: resolveProjectColor(project.color),
-			}));
+			.map((project) => this.mapProject(project));
+	}
+
+	updateProjectIcon(path: string, iconPath: string | null): ResultAsync<Project, ProjectError> {
+		return tauriClient.projects
+			.updateProjectIcon(path, iconPath)
+			.mapErr((e) => new ProjectError(`Failed to update project icon: ${e}`, "STORAGE_ERROR"))
+			.map((project) => this.mapProject(project));
+	}
+
+	updateProjectOrder(orderedPaths: string[]): ResultAsync<Project[], ProjectError> {
+		return tauriClient.projects
+			.updateProjectOrder(orderedPaths)
+			.mapErr((e) => new ProjectError(`Failed to update project order: ${e}`, "STORAGE_ERROR"))
+			.map((projects) => projects.map((project) => this.mapProject(project)));
 	}
 
 	/**
@@ -134,16 +140,6 @@ export class ProjectClient {
 		return tauriClient.projects
 			.browseProject()
 			.mapErr((e) => new ProjectError(`Failed to browse project: ${e}`, "STORAGE_ERROR"))
-			.map((project) =>
-				project
-					? {
-							path: project.path,
-							name: project.name,
-							lastOpened: project.last_opened ? new Date(project.last_opened) : undefined,
-							createdAt: new Date(project.created_at),
-							color: resolveProjectColor(project.color),
-						}
-					: null
-			);
+			.map((project) => (project ? this.mapProject(project) : null));
 	}
 }

--- a/packages/desktop/src/lib/acp/logic/project-manager.svelte.ts
+++ b/packages/desktop/src/lib/acp/logic/project-manager.svelte.ts
@@ -14,6 +14,8 @@ export interface Project {
 	lastOpened?: Date;
 	createdAt: Date;
 	color: string;
+	sortOrder?: number;
+	iconPath?: string | null;
 }
 
 /**
@@ -128,7 +130,16 @@ export class ProjectManager {
 
 				// Update projects list
 				if (isNew) {
-					this.projects = [project, ...this.projects];
+					const shiftedProjects = this.projects.map((existingProject) => ({
+						path: existingProject.path,
+						name: existingProject.name,
+						lastOpened: existingProject.lastOpened,
+						createdAt: existingProject.createdAt,
+						color: existingProject.color,
+						sortOrder: existingProject.sortOrder !== undefined ? existingProject.sortOrder + 1 : 1,
+						iconPath: existingProject.iconPath ?? null,
+					}));
+					this.projects = [project, ...shiftedProjects];
 					// Update count only for new projects
 					if (this.projectCount !== null) {
 						this.projectCount = this.projectCount + 1;
@@ -186,9 +197,20 @@ export class ProjectManager {
 			color: resolveProjectColor(color),
 			lastOpened: new SvelteDate(),
 			createdAt: new SvelteDate(),
+			sortOrder: 0,
+			iconPath: null,
 		};
 
-		this.projects = [optimisticProject, ...this.projects];
+		const shiftedProjects = this.projects.map((existingProject) => ({
+			path: existingProject.path,
+			name: existingProject.name,
+			lastOpened: existingProject.lastOpened,
+			createdAt: existingProject.createdAt,
+			color: existingProject.color,
+			sortOrder: existingProject.sortOrder !== undefined ? existingProject.sortOrder + 1 : 1,
+			iconPath: existingProject.iconPath ?? null,
+		}));
+		this.projects = [optimisticProject, ...shiftedProjects];
 
 		// Update count
 		this.projectCount = (this.projectCount ?? 0) + 1;
@@ -208,6 +230,23 @@ export class ProjectManager {
 			if (existingIndex >= 0) {
 				this.projects = this.projects.map((p, i) => (i === existingIndex ? updatedProject : p));
 			}
+		});
+	}
+
+	updateProjectIcon(path: string, iconPath: string | null): ResultAsync<void, ProjectError> {
+		return this.client.updateProjectIcon(path, iconPath).map((updatedProject) => {
+			const existingIndex = this.projects.findIndex((project) => project.path === path);
+			if (existingIndex >= 0) {
+				this.projects = this.projects.map((project, index) =>
+					index === existingIndex ? updatedProject : project
+				);
+			}
+		});
+	}
+
+	updateProjectOrder(orderedPaths: string[]): ResultAsync<void, ProjectError> {
+		return this.client.updateProjectOrder(orderedPaths).map((updatedProjects) => {
+			this.projects = updatedProjects;
 		});
 	}
 

--- a/packages/desktop/src/lib/components/main-app-view/components/content/__tests__/multi-project-group-label.svelte.vitest.ts
+++ b/packages/desktop/src/lib/components/main-app-view/components/content/__tests__/multi-project-group-label.svelte.vitest.ts
@@ -1,0 +1,31 @@
+import { cleanup, render } from "@testing-library/svelte";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("svelte", async () => {
+	const { createRequire } = await import("node:module");
+	const { dirname, join } = await import("node:path");
+	const require = createRequire(import.meta.url);
+	const svelteClientPath = join(
+		dirname(require.resolve("svelte/package.json")),
+		"src/index-client.js"
+	);
+
+	return import(/* @vite-ignore */ svelteClientPath);
+});
+
+const { default: MultiProjectGroupLabel } = await import("../multi-project-group-label.svelte");
+
+afterEach(() => {
+	cleanup();
+});
+
+describe("MultiProjectGroupLabel", () => {
+	it("renders a lightweight project identity row for non-agent groups", () => {
+		const view = render(MultiProjectGroupLabel, {
+			projectName: "alpha",
+			projectColor: "#FF5D5A",
+		});
+
+		expect(view.getByText("Alpha")).not.toBeNull();
+	});
+});

--- a/packages/desktop/src/lib/components/main-app-view/components/content/multi-project-group-label.svelte
+++ b/packages/desktop/src/lib/components/main-app-view/components/content/multi-project-group-label.svelte
@@ -1,0 +1,16 @@
+<script lang="ts">
+	import { ProjectLetterBadge } from "@acepe/ui";
+
+	interface Props {
+		projectName: string;
+		projectColor: string;
+		projectIconSrc?: string | null;
+	}
+
+	let { projectName, projectColor, projectIconSrc = null }: Props = $props();
+</script>
+
+<div class="flex items-center gap-1.5 px-1 py-0.5 text-[10px] font-semibold tracking-wide text-muted-foreground/75">
+	<ProjectLetterBadge name={projectName} color={projectColor} iconSrc={projectIconSrc} size={14} />
+	<span class="truncate">{projectName}</span>
+</div>

--- a/packages/desktop/src/lib/services/command-names.ts
+++ b/packages/desktop/src/lib/services/command-names.ts
@@ -13,7 +13,7 @@ export type SessionHistoryCommands = { get_session_history: string; get_session_
 /**
  * Storage command names
  */
-export type StorageCommands = { save_conversation_metadata: string; get_conversation_metadata: string; get_all_conversation_metadata: string; delete_conversation_metadata: string; update_conversation_metadata: string; delete_conversation: string; open_in_finder: string; open_streaming_log: string; get_projects: string; get_recent_projects: string; get_project_count: string; get_missing_project_paths: string; import_project: string; add_project: string; remove_project: string; browse_project: string; get_all_conversations: string; upsert_conversation: string; get_user_setting: string; save_user_setting: string; get_panel_layout: string; save_panel_layout: string; clear_panel_layout: string; get_thread_list_settings: string; save_thread_list_settings: string; get_api_key: string; save_api_key: string; delete_api_key: string; get_user_keybindings: string; save_user_keybinding: string; delete_user_keybinding: string; reset_keybindings_to_defaults: string }
+export type StorageCommands = { save_conversation_metadata: string; get_conversation_metadata: string; get_all_conversation_metadata: string; delete_conversation_metadata: string; update_conversation_metadata: string; delete_conversation: string; open_in_finder: string; open_streaming_log: string; get_projects: string; get_recent_projects: string; get_project_count: string; get_missing_project_paths: string; import_project: string; add_project: string; update_project_color: string; update_project_icon: string; update_project_order: string; remove_project: string; browse_project: string; get_all_conversations: string; upsert_conversation: string; get_user_setting: string; save_user_setting: string; get_panel_layout: string; save_panel_layout: string; clear_panel_layout: string; get_thread_list_settings: string; save_thread_list_settings: string; get_api_key: string; save_api_key: string; delete_api_key: string; get_user_keybindings: string; save_user_keybinding: string; delete_user_keybinding: string; reset_keybindings_to_defaults: string }
 
 /**
  * Cursor history command names
@@ -75,6 +75,9 @@ export const COMMANDS: Commands = {
     "get_missing_project_paths": "get_missing_project_paths",
     "import_project": "import_project",
     "add_project": "add_project",
+    "update_project_color": "update_project_color",
+    "update_project_icon": "update_project_icon",
+    "update_project_order": "update_project_order",
     "remove_project": "remove_project",
     "browse_project": "browse_project",
     "get_all_conversations": "get_all_conversations",

--- a/packages/desktop/src/lib/utils/tauri-client/commands.ts
+++ b/packages/desktop/src/lib/utils/tauri-client/commands.ts
@@ -62,11 +62,11 @@ export const CMD = {
 		get_missing_project_paths: storage.get_missing_project_paths,
 		import_project: storage.import_project,
 		add_project: storage.add_project,
+		update_project_color: storage.update_project_color,
+		update_project_icon: storage.update_project_icon,
+		update_project_order: storage.update_project_order,
 		remove_project: storage.remove_project,
 		browse_project: storage.browse_project,
-		update_project_color: "update_project_color",
-		update_project_icon: "update_project_icon",
-		update_project_order: "update_project_order",
 	} as const,
 
 	storage: {

--- a/packages/desktop/src/lib/utils/tauri-client/commands.ts
+++ b/packages/desktop/src/lib/utils/tauri-client/commands.ts
@@ -65,6 +65,8 @@ export const CMD = {
 		remove_project: storage.remove_project,
 		browse_project: storage.browse_project,
 		update_project_color: "update_project_color",
+		update_project_icon: "update_project_icon",
+		update_project_order: "update_project_order",
 	} as const,
 
 	storage: {

--- a/packages/desktop/src/lib/utils/tauri-client/projects.ts
+++ b/packages/desktop/src/lib/utils/tauri-client/projects.ts
@@ -31,6 +31,17 @@ export const projects = {
 		return invokeAsync(CMD.projects.update_project_color, { path, color });
 	},
 
+	updateProjectIcon: (
+		path: string,
+		iconPath: string | null
+	): ResultAsync<ProjectData, AppError> => {
+		return invokeAsync(CMD.projects.update_project_icon, { path, iconPath });
+	},
+
+	updateProjectOrder: (orderedPaths: string[]): ResultAsync<ProjectData[], AppError> => {
+		return invokeAsync(CMD.projects.update_project_order, { orderedPaths });
+	},
+
 	addProject: (path: string, name: string): ResultAsync<void, AppError> => {
 		return invokeAsync(CMD.projects.add_project, { path, name });
 	},

--- a/packages/desktop/src/lib/utils/tauri-client/types.ts
+++ b/packages/desktop/src/lib/utils/tauri-client/types.ts
@@ -67,6 +67,8 @@ export interface ProjectData {
 	last_opened?: string;
 	created_at: string;
 	color: string;
+	sort_order: number;
+	icon_path?: string | null;
 }
 
 /** Thread list display settings */

--- a/packages/ui/src/components/app-layout/app-sidebar-project-group.svelte
+++ b/packages/ui/src/components/app-layout/app-sidebar-project-group.svelte
@@ -30,7 +30,12 @@
 		<!-- Default header — matches ProjectHeader visual -->
 		<div class="shrink-0 flex items-center border-b border-border/50">
 			<div class="inline-flex items-center justify-center h-7 w-7 shrink-0">
-				<ProjectLetterBadge name={group.name} color={group.color ?? '#6B7280'} size={16} />
+				<ProjectLetterBadge
+					name={group.name}
+					color={group.color ?? '#6B7280'}
+					iconSrc={group.iconSrc ?? null}
+					size={16}
+				/>
 			</div>
 			<div class="flex items-center flex-1 min-w-0 h-7 pl-1.5 pr-2">
 				<span class="text-[11px] font-medium font-mono text-foreground truncate">{group.name}</span>

--- a/packages/ui/src/components/app-layout/types.ts
+++ b/packages/ui/src/components/app-layout/types.ts
@@ -25,6 +25,7 @@ export interface AppSessionItem {
 export interface AppProjectGroup {
   name: string;
   color?: string;
+  iconSrc?: string | null;
   sessions: AppSessionItem[];
 }
 

--- a/packages/ui/src/components/project-card/project-card.svelte
+++ b/packages/ui/src/components/project-card/project-card.svelte
@@ -8,6 +8,8 @@
 		projectName: string;
 		/** Resolved hex color for the project */
 		projectColor: string;
+		/** Optional project icon source */
+		projectIconSrc?: string | null;
 		/**
 		 * Badge placement variant:
 		 * - "inline": Badge inside the card on the left (tab bar groups)
@@ -21,7 +23,7 @@
 		/** Card content */
 		children: Snippet;
 		/** All projects for focused view — renders multiple badges in the left column */
-		allProjects?: Array<{ name: string; color: string; path: string }>;
+		allProjects?: Array<{ name: string; color: string; path: string; iconSrc?: string | null }>;
 		/** The active project path (determines which badge is full opacity) */
 		activeProjectPath?: string | null;
 		/** Callback when a project badge is clicked */
@@ -31,6 +33,7 @@
 	let {
 		projectName,
 		projectColor,
+		projectIconSrc = null,
 		variant = "inline",
 		badgeSize,
 		class: className = "",
@@ -59,14 +62,24 @@
 						onclick={() => onSelectProject?.(project.path)}
 						title={project.name}
 					>
-						<ProjectLetterBadge name={project.name} color={project.color} size={resolvedBadgeSize} />
+						<ProjectLetterBadge
+							name={project.name}
+							color={project.color}
+							iconSrc={project.iconSrc ?? null}
+							size={resolvedBadgeSize}
+						/>
 					</button>
 				{/each}
 			</div>
 		{:else}
 			<!-- Normal mode: single badge -->
 			<div class="shrink-0 self-start m-1">
-				<ProjectLetterBadge name={projectName} color={projectColor} size={resolvedBadgeSize} />
+				<ProjectLetterBadge
+					name={projectName}
+					color={projectColor}
+					iconSrc={projectIconSrc}
+					size={resolvedBadgeSize}
+				/>
 			</div>
 		{/if}
 		{@render children()}
@@ -79,7 +92,12 @@
 		aria-label="{projectName} tabs"
 	>
 		<div class="shrink-0 flex items-center justify-center px-1.5">
-			<ProjectLetterBadge name={projectName} color={projectColor} size={resolvedBadgeSize} />
+			<ProjectLetterBadge
+				name={projectName}
+				color={projectColor}
+				iconSrc={projectIconSrc}
+				size={resolvedBadgeSize}
+			/>
 		</div>
 		<div class="flex min-h-0 items-stretch">
 			{@render children()}

--- a/packages/ui/src/components/project-letter-badge/project-letter-badge.svelte
+++ b/packages/ui/src/components/project-letter-badge/project-letter-badge.svelte
@@ -6,6 +6,8 @@
 		name: string;
 		/** The color for the letter */
 		color: string;
+		/** Optional project icon source. When provided, renders the image instead of the letter badge. */
+		iconSrc?: string | null;
 		/** Badge size in px (default 20) */
 		size?: number;
 		/** Override font size in px (default: size * 0.55) */
@@ -21,6 +23,7 @@
 	let {
 		name,
 		color,
+		iconSrc = null,
 		size = 20,
 		fontSize: fontSizeProp,
 		sequenceId,
@@ -31,6 +34,7 @@
 	const letter = $derived(name.charAt(0).toUpperCase());
 	const hasSequenceId = $derived(sequenceId != null);
 	const displayColor = $derived(color === Colors.green ? "var(--success)" : color);
+	const iconAlt = $derived(name.length > 0 ? `${name} icon` : "Project icon");
 
 	const fontSize = $derived(fontSizeProp ?? size * 0.715);
 	const radius = $derived(size * 0.25);
@@ -39,7 +43,7 @@
 <span class="inline-flex items-center {className}" style="gap: 0px;">
 	{#if showLetter}
 		<div
-			class="flex items-center justify-center shrink-0"
+			class="flex items-center justify-center shrink-0 overflow-hidden"
 			style="
 				background-color: {displayColor};
 				width: {size}px;
@@ -47,12 +51,21 @@
 				border-radius: {hasSequenceId ? `${radius}px 0 0 ${radius}px` : `${radius}px`};
 			"
 		>
-			<span
-				class="font-black leading-none"
-				style="font-size: {fontSize}px; color: color-mix(in srgb, {displayColor} 30%, black);"
-			>
-				{letter}
-			</span>
+			{#if iconSrc}
+				<img
+					src={iconSrc}
+					alt={iconAlt}
+					class="block h-full w-full object-cover"
+					draggable="false"
+				/>
+			{:else}
+				<span
+					class="font-black leading-none"
+					style="font-size: {fontSize}px; color: color-mix(in srgb, {displayColor} 30%, black);"
+				>
+					{letter}
+				</span>
+			{/if}
 		</div>
 	{/if}
 	{#if hasSequenceId}


### PR DESCRIPTION
## Summary
Persist project sidebar metadata so Acepe can keep per-project icon choices and stable sidebar ordering across restores, while preserving the original project name casing in the UI.

## What changed
- add a project migration for `sort_order` and `icon_path`, then thread those fields through the repository and Tauri project commands
- teach the desktop project client/manager to preserve sidebar order metadata and update project icons/order without rewriting unrelated fields
- render custom project icons through the shared project badge/card/header surfaces and stop re-capitalizing project names in sidebar-facing UI
- add the focused sidebar/content label coverage that goes with the new project metadata plumbing

## Notes
This PR isolates the persistence and rendering layer for sidebar metadata first. It does **not** add drag-and-drop reorder UI yet; that can build on these stored fields in a follow-up without another schema change.

## Validation
- `bun run check` *(blocked in the fresh worktree because `svelte-kit` is unavailable until dependencies are installed there)*
- `cargo test repository_test --quiet` *(blocked locally by `No space left on device` while compiling test artifacts)*

---

[![Compound Engineering](https://img.shields.io/badge/Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
🤖 Generated with GPT-5.4 (unknown context, standard reasoning) via [GitHub Copilot CLI](https://github.com/features/copilot)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Persist project sidebar order and per‑project icons in the DB so the sidebar stays stable across restarts. Adds a migration; UI renders stored icons, preserves original name casing, and hardens project selection metadata loads.

- **New Features**
  - Schema: added `sort_order` and `icon_path`, backfilled `sort_order`, and indexed it; create sets new items to 0 and shifts others; delete compacts; `get_all` sorts by `sort_order`.
  - API: added `update_project_icon` and `update_project_order`; reorder requires the full set and runs in a transaction; all project APIs return `sort_order` and `icon_path`.
  - UI/client: render stored icons via `ProjectLetterBadge` across project card/header/selector/sidebar and a new lightweight group label; display names come from the path (no re-capitalizing); client/manager map `sortOrder`/`iconPath`, support icon updates and reordering, with optimistic order shift on add.

- **Refactors**
  - Single-sourced project storage command names and Tauri handler registration via macros in `names.rs`/`lib.rs`; updated TypeScript command maps/types to match.

<sup>Written for commit c3e01899e953806e2281c9b829b8828c81116af1. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

