### PR TITLE
feat(acp): redesign streaming reveal flow

### DIFF
--- a/packages/desktop/src/lib/acp/components/agent-panel/components/virtualized-entry-list.svelte
+++ b/packages/desktop/src/lib/acp/components/agent-panel/components/virtualized-entry-list.svelte
@@ -526,6 +526,7 @@ function shouldUseDesktopToolRenderer(entry: Extract<SessionEntry, { type: "tool
 					isStreaming={isStreaming &&
 						entry.id === (lastAssistantId ?? "") &&
 						index === displayEntries.length - 1}
+					revealMessageKey={getKey(entry)}
 					{projectPath}
 				/>
 			{:else if entry.type === "assistant_merged_thoughts"}
@@ -534,6 +535,7 @@ function shouldUseDesktopToolRenderer(entry: Extract<SessionEntry, { type: "tool
 					isStreaming={isStreaming &&
 						entry.memberIds.includes(lastAssistantId ?? "") &&
 						index === displayEntries.length - 1}
+					revealMessageKey={getKey(entry)}
 					{projectPath}
 				/>
 			{:else if entry.type === "tool_call" && shouldUseDesktopToolRenderer(entry)}

--- a/packages/desktop/src/lib/acp/components/agent-panel/logic/__tests__/virtualized-entry-display.test.ts
+++ b/packages/desktop/src/lib/acp/components/agent-panel/logic/__tests__/virtualized-entry-display.test.ts
@@ -90,6 +90,7 @@ describe("virtualized-entry-display", () => {
 		display.push(THINKING_DISPLAY_ENTRY);
 
 		expect(shouldObserveRevealResize(display, display[0]!, true)).toBe(true);
+		expect(shouldObserveRevealResize(display, display[0]!, false)).toBe(true);
 		expect(shouldObserveRevealResize(display, THINKING_DISPLAY_ENTRY, true)).toBe(false);
 	});
 });

--- a/packages/desktop/src/lib/acp/components/agent-panel/logic/virtualized-entry-display.ts
+++ b/packages/desktop/src/lib/acp/components/agent-panel/logic/virtualized-entry-display.ts
@@ -117,9 +117,6 @@ export function shouldObserveRevealResize(
 	entry: VirtualizedDisplayEntry,
 	isStreaming: boolean
 ): boolean {
-	if (!isStreaming) {
-		return false;
-	}
-
+	void isStreaming;
 	return getVirtualizedDisplayEntryKey(entry) === getLatestStreamingResizeTargetKey(displayEntries);
 }

--- a/packages/desktop/src/lib/acp/components/messages/acp-block-types/text-block.svelte
+++ b/packages/desktop/src/lib/acp/components/messages/acp-block-types/text-block.svelte
@@ -4,10 +4,11 @@ import MarkdownText from "../markdown-text.svelte";
 interface Props {
 	text: string;
 	isStreaming?: boolean;
+	revealKey?: string;
 	projectPath?: string;
 }
 
-let { text, isStreaming = false, projectPath }: Props = $props();
+let { text, isStreaming = false, revealKey, projectPath }: Props = $props();
 </script>
 
-<MarkdownText {text} {isStreaming} {projectPath} />
+<MarkdownText {text} {isStreaming} {revealKey} {projectPath} />

--- a/packages/desktop/src/lib/acp/components/messages/assistant-message.svelte
+++ b/packages/desktop/src/lib/acp/components/messages/assistant-message.svelte
@@ -209,6 +209,7 @@ $effect(() => {
 									<ContentBlockRouter
 										block={{ type: "text", text: group.text }}
 										isStreaming={isStreaming && isLastThoughtGroup}
+										revealKey={isLastThoughtGroup ? `${message.id}:thought:${index}` : undefined}
 										{projectPath}
 									/>
 								{:else}
@@ -227,6 +228,7 @@ $effect(() => {
 						<ContentBlockRouter
 							block={{ type: "text", text: group.text }}
 							isStreaming={isStreaming && isLastGroup}
+							revealKey={isLastGroup ? `${message.id}:message:${index}` : undefined}
 							{projectPath}
 						/>
 					{:else}

--- a/packages/desktop/src/lib/acp/components/messages/assistant-message.svelte
+++ b/packages/desktop/src/lib/acp/components/messages/assistant-message.svelte
@@ -13,11 +13,13 @@ interface Props {
 	message: AssistantMessage;
 	/** Whether this message is currently streaming */
 	isStreaming?: boolean;
+	/** Stable entry key used to seed streaming reveal state across remounts */
+	revealMessageKey?: string;
 	/** Project path for opening files in panels */
 	projectPath?: string;
 }
 
-let { message, isStreaming = false, projectPath: propProjectPath }: Props = $props();
+let { message, isStreaming = false, revealMessageKey, projectPath: propProjectPath }: Props = $props();
 
 // Get projectPath from session context, with prop fallback
 const sessionContext = useSessionContext();
@@ -209,7 +211,11 @@ $effect(() => {
 									<ContentBlockRouter
 										block={{ type: "text", text: group.text }}
 										isStreaming={isStreaming && isLastThoughtGroup}
-										revealKey={isLastThoughtGroup ? `${message.id}:thought:${index}` : undefined}
+										revealKey={
+											isLastThoughtGroup && revealMessageKey
+												? `${revealMessageKey}:thought:${index}`
+												: undefined
+										}
 										{projectPath}
 									/>
 								{:else}
@@ -228,7 +234,11 @@ $effect(() => {
 						<ContentBlockRouter
 							block={{ type: "text", text: group.text }}
 							isStreaming={isStreaming && isLastGroup}
-							revealKey={isLastGroup ? `${message.id}:message:${index}` : undefined}
+							revealKey={
+								isLastGroup && revealMessageKey
+									? `${revealMessageKey}:message:${index}`
+									: undefined
+							}
 							{projectPath}
 						/>
 					{:else}

--- a/packages/desktop/src/lib/acp/components/messages/content-block-router.svelte
+++ b/packages/desktop/src/lib/acp/components/messages/content-block-router.svelte
@@ -8,11 +8,12 @@ interface Props {
 	block: unknown;
 	/** Whether this content is currently streaming */
 	isStreaming?: boolean;
+	revealKey?: string;
 	/** Project path for opening files in panels */
 	projectPath?: string;
 }
 
-let { block, isStreaming = false, projectPath: propProjectPath }: Props = $props();
+let { block, isStreaming = false, revealKey, projectPath: propProjectPath }: Props = $props();
 
 const sessionContext = useSessionContext();
 const projectPath = $derived(propProjectPath ?? sessionContext?.projectPath);
@@ -27,7 +28,7 @@ const validationResult = $derived(validateContentBlock(block));
 		{@const blockProps = (
 			renderer as { getProps: (b: ContentBlock) => Record<string, unknown> }
 		).getProps(validatedBlock)}
-		<Component {...blockProps} {isStreaming} {projectPath} />
+		<Component {...blockProps} {isStreaming} {revealKey} {projectPath} />
 	{:else}
 		<div class="text-xs text-muted-foreground/70 italic">
 			Unknown block type: {validatedBlock.type}

--- a/packages/desktop/src/lib/acp/components/messages/logic/__tests__/create-streaming-reveal.test.ts
+++ b/packages/desktop/src/lib/acp/components/messages/logic/__tests__/create-streaming-reveal.test.ts
@@ -1,0 +1,100 @@
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+
+import { createStreamingReveal } from "../create-streaming-reveal.svelte.js";
+
+type QueuedFrame = {
+	id: number;
+	callback: FrameRequestCallback;
+};
+
+let queuedFrames: QueuedFrame[] = [];
+let nextFrameId = 1;
+const originalRequestAnimationFrame = globalThis.requestAnimationFrame;
+const originalCancelAnimationFrame = globalThis.cancelAnimationFrame;
+
+function flushNextFrame(timestamp: number): void {
+	const frame = queuedFrames.shift();
+	if (!frame) {
+		throw new Error("Expected a queued animation frame");
+	}
+	frame.callback(timestamp);
+}
+
+describe("createStreamingReveal", () => {
+	beforeEach(() => {
+		queuedFrames = [];
+		nextFrameId = 1;
+		globalThis.requestAnimationFrame = (callback: FrameRequestCallback): number => {
+			const id = nextFrameId;
+			nextFrameId += 1;
+			queuedFrames.push({ id, callback });
+			return id;
+		};
+		globalThis.cancelAnimationFrame = (id: number): void => {
+			queuedFrames = queuedFrames.filter((frame) => frame.id !== id);
+		};
+	});
+
+	afterEach(() => {
+		globalThis.requestAnimationFrame = originalRequestAnimationFrame;
+		globalThis.cancelAnimationFrame = originalCancelAnimationFrame;
+	});
+
+	it("reveals source text over successive animation frames", () => {
+		const reveal = createStreamingReveal();
+
+		reveal.setState("Hello world", true);
+		expect(reveal.mode).toBe("streaming");
+		expect(reveal.displayedText).toBe("");
+		expect(queuedFrames.length).toBe(1);
+
+		flushNextFrame(16);
+		expect(reveal.displayedText.length).toBeGreaterThan(0);
+		expect(reveal.displayedText.length).toBeLessThan("Hello world".length);
+	});
+
+	it("keeps reveal active after backend streaming ends until backlog is drained", () => {
+		const reveal = createStreamingReveal();
+
+		reveal.setState("Hello world", true);
+		flushNextFrame(16);
+		const partialLength = reveal.displayedText.length;
+		expect(partialLength).toBeGreaterThan(0);
+		expect(partialLength).toBeLessThan("Hello world".length);
+
+		reveal.setState("Hello world", false);
+		expect(reveal.isRevealActive).toBe(true);
+		expect(reveal.mode).toBe("completion-catchup");
+
+		while (queuedFrames.length > 0) {
+			flushNextFrame(32);
+		}
+		expect(reveal.displayedText).toBe("Hello world");
+		expect(reveal.mode).toBe("complete");
+		expect(reveal.isRevealActive).toBe(false);
+	});
+
+	it("resets displayed state between unrelated messages", () => {
+		const reveal = createStreamingReveal();
+
+		reveal.setState("First message", true);
+		flushNextFrame(16);
+		expect(reveal.displayedText.length).toBeGreaterThan(0);
+		
+		reveal.reset();
+		expect(reveal.displayedText).toBe("");
+		expect(reveal.mode).toBe("idle");
+		expect(reveal.cursorVisible).toBe(false);
+		expect(queuedFrames.length).toBe(0);
+	});
+
+	it("seeds the first mounted streaming state from the existing source text", () => {
+		const reveal = createStreamingReveal();
+
+		reveal.setState("Already streamed text", true, { seedFromSource: true });
+
+		expect(reveal.displayedText).toBe("Already streamed text");
+		expect(reveal.mode).toBe("streaming");
+		expect(queuedFrames.length).toBe(0);
+	});
+});

--- a/packages/desktop/src/lib/acp/components/messages/logic/__tests__/parse-streaming-tail.vitest.ts
+++ b/packages/desktop/src/lib/acp/components/messages/logic/__tests__/parse-streaming-tail.vitest.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 
-import { parseStreamingTail } from "../parse-streaming-tail.js";
+import { parseStreamingTail, parseStreamingTailIncremental } from "../parse-streaming-tail.js";
 
 describe("parseStreamingTail", () => {
 	it("returns no sections for empty input", () => {
@@ -13,7 +13,7 @@ describe("parseStreamingTail", () => {
 		expect(parseStreamingTail("# Title\n\nHello")).toEqual({
 			sections: [
 				{ key: "SETTLED:0", kind: "settled", markdown: "# Title" },
-				{ key: "LIVE:1", kind: "live-text", text: "Hello" },
+				{ key: "LIVE:1", kind: "live-text", text: "Hello", source: "Hello" },
 			],
 		});
 	});
@@ -32,6 +32,7 @@ describe("parseStreamingTail", () => {
 					kind: "live-code",
 					code: "const a = 1;\nconst b = 2;",
 					language: "ts",
+					source: "```ts\nconst a = 1;\nconst b = 2;",
 				},
 			],
 		});
@@ -45,6 +46,7 @@ describe("parseStreamingTail", () => {
 					kind: "live-code",
 					code: "const a = 1;",
 					language: null,
+					source: "```\nconst a = 1;",
 				},
 			],
 		});
@@ -60,5 +62,35 @@ describe("parseStreamingTail", () => {
 				},
 			],
 		});
+	});
+
+	it("reuses stable settled prefix sections for append-only reveal growth", () => {
+		const previous = parseStreamingTail("# Title\n\nHello");
+		const next = parseStreamingTailIncremental("# Title\n\nHello", previous, "# Title\n\nHello world");
+
+		expect(next.sections).toEqual([
+			{ key: "SETTLED:0", kind: "settled", markdown: "# Title" },
+			{ key: "LIVE:1", kind: "live-text", text: "Hello world", source: "Hello world" },
+		]);
+		expect(next.sections[0]).toBe(previous.sections[0]);
+	});
+
+	it("reparses only the previous live tail when reveal growth creates a new block", () => {
+		const previous = parseStreamingTail("# Title\n\nHello");
+		const next = parseStreamingTailIncremental("# Title\n\nHello", previous, "# Title\n\nHello\n\nNext");
+
+		expect(next.sections).toEqual([
+			{ key: "SETTLED:0", kind: "settled", markdown: "# Title" },
+			{ key: "SETTLED:1", kind: "settled", markdown: "Hello" },
+			{ key: "LIVE:2", kind: "live-text", text: "Next", source: "Next" },
+		]);
+		expect(next.sections[0]).toBe(previous.sections[0]);
+	});
+
+	it("preserves partial fence headers when reparsing an incrementally grown live code block", () => {
+		const previous = parseStreamingTail("```");
+		const next = parseStreamingTailIncremental("```", previous, "```ts\nconst a = 1;");
+
+		expect(next).toEqual(parseStreamingTail("```ts\nconst a = 1;"));
 	});
 });

--- a/packages/desktop/src/lib/acp/components/messages/logic/__tests__/streaming-reveal-engine.test.ts
+++ b/packages/desktop/src/lib/acp/components/messages/logic/__tests__/streaming-reveal-engine.test.ts
@@ -1,0 +1,95 @@
+import { describe, expect, it } from "bun:test";
+
+import { StreamingRevealEngine } from "../streaming-reveal-engine.js";
+
+describe("StreamingRevealEngine", () => {
+	it("reveals appended streaming text progressively instead of all at once", () => {
+		const engine = new StreamingRevealEngine();
+
+		engine.setSourceText("Hello world", true);
+		const initial = engine.getSnapshot();
+		expect(initial.displayedText).toBe("");
+		expect(initial.mode).toBe("streaming");
+
+		engine.advance(16);
+		const afterOneFrame = engine.getSnapshot();
+		expect(afterOneFrame.displayedText.length).toBeGreaterThan(0);
+		expect(afterOneFrame.displayedText.length).toBeLessThan("Hello world".length);
+		expect(afterOneFrame.mode).toBe("streaming");
+	});
+
+	it("enters paused-awaiting-more after the source stalls while the stream stays open", () => {
+		const engine = new StreamingRevealEngine();
+
+		engine.setSourceText("Hi", true);
+		engine.advance(500);
+		expect(engine.getSnapshot().displayedText).toBe("Hi");
+
+		engine.advance(140);
+		expect(engine.getSnapshot().mode).toBe("paused-awaiting-more");
+		expect(engine.getSnapshot().cursorVisible).toBe(true);
+	});
+
+	it("switches to completion-catchup and drains to complete when streaming stops with backlog", () => {
+		const engine = new StreamingRevealEngine();
+
+		engine.setSourceText("This should finish smoothly", true);
+		engine.advance(16);
+		const partial = engine.getSnapshot().displayedText.length;
+		expect(partial).toBeGreaterThan(0);
+
+		engine.setSourceText("This should finish smoothly", false);
+		expect(engine.getSnapshot().mode).toBe("completion-catchup");
+
+		engine.advance(250);
+		const completed = engine.getSnapshot();
+		expect(completed.displayedText).toBe("This should finish smoothly");
+		expect(completed.mode).toBe("complete");
+		expect(completed.cursorVisible).toBe(false);
+	});
+
+	it("resets when the source text is replaced instead of appended", () => {
+		const engine = new StreamingRevealEngine();
+
+		engine.setSourceText("First message", true);
+		engine.advance(32);
+		expect(engine.getSnapshot().displayedText.length).toBeGreaterThan(0);
+
+		engine.setSourceText("Second", true);
+		const reset = engine.getSnapshot();
+		expect(reset.displayedText).toBe("");
+		expect(reset.mode).toBe("streaming");
+		expect(reset.sourceText).toBe("Second");
+	});
+
+	it("seeds the first streaming snapshot so remounts do not replay from blank", () => {
+		const engine = new StreamingRevealEngine();
+
+		engine.setSourceText("Already streamed text", true, { seedFromSource: true });
+
+		const snapshot = engine.getSnapshot();
+		expect(snapshot.displayedText).toBe("Already streamed text");
+		expect(snapshot.mode).toBe("streaming");
+	});
+
+	it("never reveals past the canonical source length even with a large frame gap", () => {
+		const engine = new StreamingRevealEngine();
+
+		engine.setSourceText("Short text", true);
+		engine.advance(5_000);
+
+		const snapshot = engine.getSnapshot();
+		expect(snapshot.displayedText).toBe("Short text");
+		expect(snapshot.revealedLength).toBe("Short text".length);
+	});
+
+	it("reveals whole grapheme clusters instead of splitting emoji sequences", () => {
+		const engine = new StreamingRevealEngine();
+
+		engine.setSourceText("👨‍👩‍👧‍👦abcdef", true);
+		engine.advance(1);
+
+		const snapshot = engine.getSnapshot();
+		expect(snapshot.displayedText).toBe("👨‍👩‍👧‍👦");
+	});
+});

--- a/packages/desktop/src/lib/acp/components/messages/logic/create-streaming-reveal.svelte.ts
+++ b/packages/desktop/src/lib/acp/components/messages/logic/create-streaming-reveal.svelte.ts
@@ -1,0 +1,93 @@
+import { StreamingRevealEngine, type RevealMode } from "./streaming-reveal-engine.js";
+
+export function createStreamingReveal() {
+	const engine = new StreamingRevealEngine();
+	let displayedText = $state("");
+	let mode = $state<RevealMode>("idle");
+	let cursorVisible = $state(false);
+	let isRevealActive = $state(false);
+	let rafId: number | null = null;
+	let lastFrameTime: number | null = null;
+
+	function stopAnimationFrame(): void {
+		if (rafId !== null) {
+			cancelAnimationFrame(rafId);
+			rafId = null;
+		}
+		lastFrameTime = null;
+	}
+
+	function syncState(): void {
+		const snapshot = engine.getSnapshot();
+		displayedText = snapshot.displayedText;
+		mode = snapshot.mode;
+		cursorVisible = snapshot.cursorVisible;
+		isRevealActive = snapshot.isRevealActive;
+
+		if (!snapshot.isRevealActive) {
+			stopAnimationFrame();
+		}
+	}
+
+	function step(frameTime: number): void {
+		const previousFrameTime = lastFrameTime === null ? frameTime - 16 : lastFrameTime;
+		lastFrameTime = frameTime;
+		engine.advance(Math.max(0, frameTime - previousFrameTime));
+		syncState();
+
+		if (!engine.getSnapshot().isRevealActive) {
+			return;
+		}
+
+		rafId = requestAnimationFrame(step);
+	}
+
+	function ensureAnimationFrame(): void {
+		if (rafId !== null) {
+			return;
+		}
+
+		rafId = requestAnimationFrame(step);
+	}
+
+	function setState(
+		sourceText: string,
+		isStreaming: boolean,
+		options?: { seedFromSource?: boolean }
+	): void {
+		engine.setSourceText(sourceText, isStreaming, options);
+		syncState();
+
+		if (engine.getSnapshot().isRevealActive) {
+			ensureAnimationFrame();
+		}
+	}
+
+	function reset(): void {
+		stopAnimationFrame();
+		engine.reset();
+		syncState();
+	}
+
+	function destroy(): void {
+		stopAnimationFrame();
+	}
+
+	return {
+		setState,
+		reset,
+		destroy,
+		get displayedText() {
+			return displayedText;
+		},
+		get mode() {
+			return mode;
+		},
+		get cursorVisible() {
+			return cursorVisible;
+		},
+		get isRevealActive() {
+			return isRevealActive;
+		},
+	};
+}

--- a/packages/desktop/src/lib/acp/components/messages/logic/parse-streaming-tail.ts
+++ b/packages/desktop/src/lib/acp/components/messages/logic/parse-streaming-tail.ts
@@ -8,16 +8,42 @@ export type StreamingTailSection =
 			key: string;
 			kind: "live-text";
 			text: string;
+			source: string;
 	  }
 	| {
 			key: string;
 			kind: "live-code";
 			code: string;
 			language: string | null;
+			source: string;
 	  };
 
 export interface StreamingTailParseResult {
 	sections: StreamingTailSection[];
+}
+
+function rekeySection(section: StreamingTailSection, index: number): StreamingTailSection {
+	if (section.kind === "settled") {
+		return createSettledSection(index, section.markdown);
+	}
+
+	if (section.kind === "live-code") {
+		return createLiveCodeSection(index, section.code, section.language, section.source);
+	}
+
+	return createLiveTextSection(index, section.text);
+}
+
+function buildReparseSource(section: StreamingTailSection): string | null {
+	if (section.kind === "live-text") {
+		return section.source;
+	}
+
+	if (section.kind === "live-code") {
+		return section.source;
+	}
+
+	return null;
 }
 
 function createSettledSection(index: number, markdown: string): StreamingTailSection {
@@ -33,19 +59,22 @@ function createLiveTextSection(index: number, text: string): StreamingTailSectio
 		key: `LIVE:${index}`,
 		kind: "live-text",
 		text,
+		source: text,
 	};
 }
 
 function createLiveCodeSection(
 	index: number,
 	code: string,
-	language: string | null
+	language: string | null,
+	source: string
 ): StreamingTailSection {
 	return {
 		key: `LIVE:${index}`,
 		kind: "live-code",
 		code,
 		language,
+		source,
 	};
 }
 
@@ -111,10 +140,52 @@ export function parseStreamingTail(text: string): StreamingTailParseResult {
 	}
 
 	if (inFence) {
-		sections.push(createLiveCodeSection(blockIndex, buffer.slice(1).join("\n"), openFenceLanguage));
+		sections.push(
+			createLiveCodeSection(
+				blockIndex,
+				buffer.slice(1).join("\n"),
+				openFenceLanguage,
+				buffer.join("\n")
+			)
+		);
 		return { sections };
 	}
 
 	sections.push(createLiveTextSection(blockIndex, buffer.join("\n")));
+	return { sections };
+}
+
+export function parseStreamingTailIncremental(
+	previousText: string,
+	previousResult: StreamingTailParseResult,
+	nextText: string
+): StreamingTailParseResult {
+	if (
+		previousText.length === 0 ||
+		previousResult.sections.length === 0 ||
+		!nextText.startsWith(previousText)
+	) {
+		return parseStreamingTail(nextText);
+	}
+
+	const lastSection = previousResult.sections[previousResult.sections.length - 1];
+	const reparseSource = buildReparseSource(lastSection);
+	if (reparseSource === null) {
+		return parseStreamingTail(nextText);
+	}
+
+	const appendedSuffix = nextText.slice(previousText.length);
+	const reparsed = parseStreamingTail(`${reparseSource}${appendedSuffix}`);
+	const sections: StreamingTailSection[] = [];
+	const stableCount = previousResult.sections.length - 1;
+
+	for (let index = 0; index < stableCount; index += 1) {
+		sections.push(previousResult.sections[index]);
+	}
+
+	for (let index = 0; index < reparsed.sections.length; index += 1) {
+		sections.push(rekeySection(reparsed.sections[index], stableCount + index));
+	}
+
 	return { sections };
 }

--- a/packages/desktop/src/lib/acp/components/messages/logic/streaming-reveal-engine.ts
+++ b/packages/desktop/src/lib/acp/components/messages/logic/streaming-reveal-engine.ts
@@ -1,0 +1,169 @@
+export type RevealMode =
+	| "idle"
+	| "streaming"
+	| "paused-awaiting-more"
+	| "completion-catchup"
+	| "complete";
+
+export interface StreamingRevealSnapshot {
+	sourceText: string;
+	displayedText: string;
+	revealedLength: number;
+	backlogLength: number;
+	mode: RevealMode;
+	cursorVisible: boolean;
+	isRevealActive: boolean;
+	isStreaming: boolean;
+}
+
+const PAUSE_THRESHOLD_MS = 120;
+const FAIL_OPEN_FRAME_GAP_MS = 200;
+const STREAMING_BASE_CHARS_PER_SECOND = 180;
+const STREAMING_BACKLOG_CHARS_PER_SECOND = 6;
+const COMPLETION_BASE_CHARS_PER_SECOND = 540;
+const COMPLETION_BACKLOG_CHARS_PER_SECOND = 10;
+const MAX_STREAMING_CHARS_PER_FRAME = 12;
+const MAX_COMPLETION_CHARS_PER_FRAME = 40;
+const FAIL_OPEN_MAX_CHARS_PER_FRAME = 96;
+const graphemeSegmenter = new Intl.Segmenter(undefined, { granularity: "grapheme" });
+
+function splitGraphemes(text: string): string[] {
+	return Array.from(graphemeSegmenter.segment(text), (segment) => segment.segment);
+}
+
+function clampRevealAdvance(
+	backlogLength: number,
+	deltaMs: number,
+	mode: "streaming" | "completion-catchup"
+): number {
+	if (backlogLength <= 0) {
+		return 0;
+	}
+
+	if (deltaMs >= FAIL_OPEN_FRAME_GAP_MS) {
+		return Math.min(backlogLength, FAIL_OPEN_MAX_CHARS_PER_FRAME);
+	}
+
+	const baseCharsPerSecond =
+		mode === "completion-catchup"
+			? COMPLETION_BASE_CHARS_PER_SECOND
+			: STREAMING_BASE_CHARS_PER_SECOND;
+	const backlogCharsPerSecond =
+		mode === "completion-catchup"
+			? backlogLength * COMPLETION_BACKLOG_CHARS_PER_SECOND
+			: backlogLength * STREAMING_BACKLOG_CHARS_PER_SECOND;
+	const maxCharsPerFrame =
+		mode === "completion-catchup"
+			? MAX_COMPLETION_CHARS_PER_FRAME
+			: MAX_STREAMING_CHARS_PER_FRAME;
+	const revealEstimate = Math.ceil(((baseCharsPerSecond + backlogCharsPerSecond) * deltaMs) / 1000);
+	const boundedReveal = Math.max(1, Math.min(revealEstimate, maxCharsPerFrame));
+	return Math.min(backlogLength, boundedReveal);
+}
+
+export class StreamingRevealEngine {
+	private sourceText = "";
+	private sourceGraphemes: string[] = [];
+	private revealedLength = 0;
+	private sourceIdleMs = 0;
+	private isStreaming = false;
+	private mode: RevealMode = "idle";
+
+	setSourceText(
+		nextSourceText: string,
+		nextIsStreaming: boolean,
+		options?: { seedFromSource?: boolean }
+	): void {
+		const sourceChanged = nextSourceText !== this.sourceText;
+		const isAppendOnly = sourceChanged && nextSourceText.startsWith(this.sourceText);
+
+		if (sourceChanged) {
+			if (this.sourceText.length === 0) {
+				this.sourceText = nextSourceText;
+				this.sourceGraphemes = splitGraphemes(nextSourceText);
+				this.revealedLength = options?.seedFromSource ? this.sourceGraphemes.length : 0;
+			} else if (isAppendOnly) {
+				this.sourceText = nextSourceText;
+				this.sourceGraphemes = splitGraphemes(nextSourceText);
+			} else {
+				this.sourceText = nextSourceText;
+				this.sourceGraphemes = splitGraphemes(nextSourceText);
+				this.revealedLength = nextIsStreaming ? 0 : this.sourceGraphemes.length;
+			}
+
+			this.sourceIdleMs = 0;
+		}
+
+		this.isStreaming = nextIsStreaming;
+		if (this.revealedLength > this.sourceGraphemes.length) {
+			this.revealedLength = this.sourceGraphemes.length;
+		}
+		this.recomputeMode();
+	}
+
+	advance(deltaMs: number): void {
+		if (deltaMs <= 0) {
+			this.recomputeMode();
+			return;
+		}
+
+		this.sourceIdleMs += deltaMs;
+		const backlogLength = this.sourceGraphemes.length - this.revealedLength;
+		if (backlogLength > 0) {
+			const revealAdvance = clampRevealAdvance(
+				backlogLength,
+				deltaMs,
+				this.isStreaming ? "streaming" : "completion-catchup"
+			);
+			this.revealedLength = Math.min(this.sourceGraphemes.length, this.revealedLength + revealAdvance);
+		}
+
+		this.recomputeMode();
+	}
+
+	reset(): void {
+		this.sourceText = "";
+		this.sourceGraphemes = [];
+		this.revealedLength = 0;
+		this.sourceIdleMs = 0;
+		this.isStreaming = false;
+		this.mode = "idle";
+	}
+
+	getSnapshot(): StreamingRevealSnapshot {
+		const backlogLength = this.sourceGraphemes.length - this.revealedLength;
+		return {
+			sourceText: this.sourceText,
+			displayedText: this.sourceGraphemes.slice(0, this.revealedLength).join(""),
+			revealedLength: this.revealedLength,
+			backlogLength,
+			mode: this.mode,
+			cursorVisible:
+				this.mode === "streaming" ||
+				this.mode === "paused-awaiting-more" ||
+				this.mode === "completion-catchup",
+			isRevealActive: backlogLength > 0,
+			isStreaming: this.isStreaming,
+		};
+	}
+
+	private recomputeMode(): void {
+		if (this.sourceText.length === 0) {
+			this.mode = "idle";
+			return;
+		}
+
+		if (this.revealedLength < this.sourceGraphemes.length) {
+			this.mode = this.isStreaming ? "streaming" : "completion-catchup";
+			return;
+		}
+
+		if (this.isStreaming) {
+			this.mode =
+				this.sourceIdleMs >= PAUSE_THRESHOLD_MS ? "paused-awaiting-more" : "streaming";
+			return;
+		}
+
+		this.mode = "complete";
+	}
+}

--- a/packages/desktop/src/lib/acp/components/messages/markdown-text.svelte
+++ b/packages/desktop/src/lib/acp/components/messages/markdown-text.svelte
@@ -29,8 +29,11 @@ import {
 import { mountFileBadges } from "./logic/mount-file-badges.js";
 import { mountGitHubBadges } from "./logic/mount-github-badges.js";
 import { parseContentBlocks } from "./logic/parse-content-blocks.js";
-import { parseStreamingTail } from "./logic/parse-streaming-tail.js";
-import { streamingTailRefresh } from "./logic/streaming-tail-refresh.js";
+import { createStreamingReveal } from "./logic/create-streaming-reveal.svelte.js";
+import {
+	parseStreamingTailIncremental,
+	type StreamingTailParseResult,
+} from "./logic/parse-streaming-tail.js";
 
 const logger = createLogger({ id: "markdown-text", name: "Markdown Text" });
 const STREAMING_SYNC_RESULT = {
@@ -39,26 +42,8 @@ const STREAMING_SYNC_RESULT = {
 	needsAsync: false,
 } satisfies SyncRenderResult;
 
-const EMPTY_STREAMING_TAIL = { sections: [] };
-
-type StreamingLiveTextRender = {
-	fullText: string;
-	preservedPrefix: string;
-	freshSuffix: string;
-};
-
-function buildStreamingLiveTextRender(
-	previousText: string | undefined,
-	nextText: string
-): StreamingLiveTextRender {
-	const preservedPrefix = previousText && nextText.startsWith(previousText) ? previousText : "";
-
-	return {
-		fullText: nextText,
-		preservedPrefix,
-		freshSuffix: nextText.slice(preservedPrefix.length),
-	};
-}
+const EMPTY_STREAMING_TAIL = { sections: [] } satisfies StreamingTailParseResult;
+const seededRevealKeys = new Set<string>();
 
 // Get session context (set by VirtualizedEntryList)
 const sessionContext = useSessionContext();
@@ -77,6 +62,7 @@ interface Props {
 	text: string;
 	/** Whether content is currently streaming */
 	isStreaming?: boolean;
+	revealKey?: string;
 	/**
 	 * Project path for opening files in panels.
 	 * If not provided, will use projectPath from session context.
@@ -84,7 +70,7 @@ interface Props {
 	projectPath?: string;
 }
 
-let { text, isStreaming = false, projectPath: propProjectPath }: Props = $props();
+let { text, isStreaming = false, revealKey, projectPath: propProjectPath }: Props = $props();
 
 // Use context projectPath if no prop provided, otherwise use prop (backward compatibility)
 const projectPath = $derived(propProjectPath ?? contextProjectPath);
@@ -98,6 +84,12 @@ let markdownContainerRef: HTMLDivElement | null = $state(null);
 
 let gitStatusByPath = $state<ReadonlyMap<string, FileGitStatus> | null>(null);
 let lastGitStatusRequestKey = "";
+const reveal = createStreamingReveal();
+let hasStreamingSession = $state(false);
+let hasObservedRevealSource = $state(false);
+let streamingTail = $state<StreamingTailParseResult>(EMPTY_STREAMING_TAIL);
+let lastStreamingTailText = "";
+let lastStreamingTailResult: StreamingTailParseResult = EMPTY_STREAMING_TAIL;
 
 // Fetch and cache repo context for enhancing commit badges
 let repoContext = $state<RepoContext | null>(null);
@@ -120,8 +112,59 @@ function htmlNeedsGitStatus(html: string | null): boolean {
 	return html.includes("file-path-badge-placeholder");
 }
 
+function htmlNeedsBadgeMount(html: string | null): boolean {
+	if (html === null) {
+		return false;
+	}
+
+	return (
+		html.includes("file-path-badge-placeholder") || html.includes("github-badge-placeholder")
+	);
+}
+
 $effect(() => {
-	if (!projectPath || repoContext || isStreaming || !textNeedsRepoContext(text)) {
+	if (isStreaming) {
+		const seedFromSource =
+			!hasObservedRevealSource &&
+			text.length > 0 &&
+			revealKey !== undefined &&
+			seededRevealKeys.has(revealKey);
+		hasStreamingSession = true;
+		reveal.setState(text, true, { seedFromSource });
+		hasObservedRevealSource = true;
+		if (revealKey !== undefined) {
+			seededRevealKeys.add(revealKey);
+		}
+		return;
+	}
+
+	if (!hasStreamingSession) {
+		reveal.reset();
+		hasObservedRevealSource = text.length > 0;
+		if (revealKey !== undefined) {
+			seededRevealKeys.delete(revealKey);
+		}
+		return;
+	}
+
+	reveal.setState(text, false);
+	hasObservedRevealSource = true;
+	if (!reveal.isRevealActive) {
+		hasStreamingSession = false;
+	}
+});
+
+const isRenderingReveal = $derived(isStreaming || reveal.isRevealActive);
+const showStreamingCursor = $derived(reveal.cursorVisible);
+
+$effect(() => {
+	return () => {
+		reveal.destroy();
+	};
+});
+
+$effect(() => {
+	if (!projectPath || repoContext || isRenderingReveal || !textNeedsRepoContext(text)) {
 		return;
 	}
 	// Fetch repo context once on mount
@@ -140,7 +183,7 @@ $effect(() => {
 
 // Try sync rendering first (eliminates flicker for most messages)
 const syncResult = $derived.by(() => {
-	if (isStreaming) {
+	if (isRenderingReveal) {
 		return STREAMING_SYNC_RESULT;
 	}
 
@@ -162,7 +205,7 @@ function getAsyncRequestKey(textValue: string, currentRepoContext: RepoContext |
 
 // Trigger async rendering when sync can't handle it - uses $effect
 $effect(() => {
-	if (isStreaming) {
+	if (isRenderingReveal) {
 		asyncHtml = null;
 		asyncError = null;
 		asyncPending = false;
@@ -239,20 +282,15 @@ $effect(() => {
 
 // Determine what to render
 const visibleHtml = $derived.by(() => {
-	if (isStreaming) return null;
+	if (isRenderingReveal) return null;
 	return syncResult.html ?? asyncHtml ?? null;
-});
-const streamingTail = $derived.by(() => {
-	if (!isStreaming) {
-		return EMPTY_STREAMING_TAIL;
-	}
-
-	return parseStreamingTail(text);
 });
 const error = $derived(asyncError);
 const isLoading = $derived(syncResult.needsAsync && asyncPending);
 let streamingSettledHtmlByKey = $state<ReadonlyMap<string, string>>(new Map());
-let streamingLiveTextRenderByKey = $state<ReadonlyMap<string, StreamingLiveTextRender>>(new Map());
+const hasLiveStreamingSection = $derived(
+	streamingTail.sections.some((section) => section.kind !== "settled")
+);
 
 // Parse content blocks from HTML (extracts mermaid, github badges, etc.)
 // File badge placeholders stay as inline <span>s — mounted as Svelte components below.
@@ -269,7 +307,7 @@ $effect(() => {
 	const currentModifiedFiles = mergedModifiedFilesState;
 	const currentRepoContext = repoContext;
 
-	if (!container || isStreaming || !visibleHtml) return;
+	if (!container || !visibleHtml) return;
 
 	const cleanupFile = mountFileBadges(container, (filePath) =>
 		resolveDiffStatsForFilePath(filePath, {
@@ -290,7 +328,26 @@ $effect(() => {
 });
 
 $effect(() => {
-	if (!isStreaming) {
+	if (!isRenderingReveal) {
+		streamingTail = EMPTY_STREAMING_TAIL;
+		lastStreamingTailText = "";
+		lastStreamingTailResult = EMPTY_STREAMING_TAIL;
+		return;
+	}
+
+	const nextStreamingText = reveal.displayedText;
+	const nextStreamingTail = parseStreamingTailIncremental(
+		lastStreamingTailText,
+		lastStreamingTailResult,
+		nextStreamingText
+	);
+	streamingTail = nextStreamingTail;
+	lastStreamingTailText = nextStreamingText;
+	lastStreamingTailResult = nextStreamingTail;
+});
+
+$effect(() => {
+	if (!isRenderingReveal) {
 		streamingSettledHtmlByKey = new Map();
 		return;
 	}
@@ -309,37 +366,12 @@ $effect(() => {
 		}
 
 		const result = renderMarkdownSync(section.markdown);
-		if (result.html !== null) {
+		if (result.html !== null && !htmlNeedsBadgeMount(result.html)) {
 			nextSettledHtmlByKey.set(section.key, result.html);
 		}
 	}
 
 	streamingSettledHtmlByKey = nextSettledHtmlByKey;
-});
-
-$effect(() => {
-	if (!isStreaming) {
-		streamingLiveTextRenderByKey = new Map();
-		return;
-	}
-
-	const previousLiveTextRenderByKey = untrack(() => streamingLiveTextRenderByKey);
-	const nextLiveTextRenderByKey = new Map<string, StreamingLiveTextRender>();
-	for (const section of streamingTail.sections) {
-		if (section.kind !== "live-text") {
-			continue;
-		}
-
-		nextLiveTextRenderByKey.set(
-			section.key,
-			buildStreamingLiveTextRender(
-				previousLiveTextRenderByKey.get(section.key)?.fullText,
-				section.text
-			)
-		);
-	}
-
-	streamingLiveTextRenderByKey = nextLiveTextRenderByKey;
 });
 
 /**
@@ -466,7 +498,7 @@ function handleKeydown(event: KeyboardEvent) {
 			{@html visibleHtml}
 		</div>
 	{/if}
-{:else if isStreaming}
+{:else if isRenderingReveal}
 	<!-- Streaming markdown: keep settled blocks stable and only update the live tail in place -->
 	<div
 		class="markdown-content text-sm text-foreground leading-relaxed"
@@ -475,20 +507,9 @@ function handleKeydown(event: KeyboardEvent) {
 		onclick={handleClick}
 		onkeydown={handleKeydown}
 	>
-		{#each streamingTail.sections as section (section.key)}
-			<div
-				class="streaming-section"
-				data-streaming-section-key={section.key}
-				use:streamingTailRefresh={{
-					active: section.kind !== "settled",
-					value:
-						section.kind === "settled"
-							? ""
-							: section.kind === "live-code"
-								? section.code
-								: section.text,
-				}}
-			>
+		{#each streamingTail.sections as section, index (section.key)}
+			{@const isLastSection = index === streamingTail.sections.length - 1}
+			<div class="streaming-section" data-streaming-section-key={section.key}>
 				{#if section.kind === "settled"}
 					{@const settledHtml = streamingSettledHtmlByKey.get(section.key)}
 					{#if settledHtml}
@@ -497,15 +518,17 @@ function handleKeydown(event: KeyboardEvent) {
 						<div class="streaming-live-text whitespace-pre-wrap">{section.markdown}</div>
 					{/if}
 				{:else if section.kind === "live-code"}
-					<pre class="streaming-live-code"><code>{section.code}</code></pre>
+					<pre class="streaming-live-code"><code>{section.code}{#if showStreamingCursor && isLastSection}<span class="streaming-live-cursor" aria-hidden="true"></span>{/if}</code></pre>
 				{:else}
-					{@const liveTextRender =
-						streamingLiveTextRenderByKey.get(section.key) ??
-						buildStreamingLiveTextRender(undefined, section.text)}
-					<div class="streaming-live-text whitespace-pre-wrap">{liveTextRender.preservedPrefix}{#if liveTextRender.freshSuffix.length > 0}<span class="streaming-live-suffix">{liveTextRender.freshSuffix}</span>{/if}</div>
+					<div class="streaming-live-text whitespace-pre-wrap">{section.text}{#if showStreamingCursor && isLastSection}<span class="streaming-live-cursor" aria-hidden="true"></span>{/if}</div>
 				{/if}
 			</div>
 		{/each}
+		{#if showStreamingCursor && !hasLiveStreamingSection}
+			<div class="streaming-live-text whitespace-pre-wrap">
+				<span class="streaming-live-cursor" aria-hidden="true"></span>
+			</div>
+		{/if}
 	</div>
 {:else if isLoading}
 	<!-- Show plain text with min-height while async rendering (rare: large messages only) -->
@@ -525,23 +548,31 @@ function handleKeydown(event: KeyboardEvent) {
 		opacity: 0.7;
 	}
 
-	.streaming-live-suffix {
-		display: inline;
-		animation: streaming-live-suffix 180ms ease-out;
+	.streaming-live-cursor {
+		display: inline-block;
+		width: 0.55ch;
+		height: 1em;
+		margin-left: 0.1ch;
+		vertical-align: -0.1em;
+		background: currentColor;
+		opacity: 0.45;
+		animation: streaming-live-cursor 1s steps(1, end) infinite;
 	}
 
-	@keyframes streaming-live-suffix {
-		from {
-			opacity: 0;
+	@keyframes streaming-live-cursor {
+		0%,
+		49% {
+			opacity: 0.45;
 		}
 
-		to {
-			opacity: 1;
+		50%,
+		100% {
+			opacity: 0;
 		}
 	}
 
 	@media (prefers-reduced-motion: reduce) {
-		.streaming-live-suffix {
+		.streaming-live-cursor {
 			animation: none;
 		}
 	}

--- a/packages/desktop/src/lib/acp/components/messages/markdown-text.svelte.vitest.ts
+++ b/packages/desktop/src/lib/acp/components/messages/markdown-text.svelte.vitest.ts
@@ -124,9 +124,45 @@ function getRequestKey(text: string, repoContext?: RepoContext): string {
 	return `${text}::${repoContext.owner}/${repoContext.repo}`;
 }
 
+type QueuedAnimationFrame = {
+	id: number;
+	callback: FrameRequestCallback;
+};
+
+let queuedAnimationFrames: QueuedAnimationFrame[] = [];
+let nextAnimationFrameId = 1;
+
+async function flushAnimationFrames(frameCount = 1, startTime = 16): Promise<void> {
+	for (let frameIndex = 0; frameIndex < frameCount; frameIndex += 1) {
+		const frame = queuedAnimationFrames.shift();
+		if (!frame) {
+			break;
+		}
+
+		frame.callback(startTime + frameIndex * 16);
+		await Promise.resolve();
+	}
+}
+
+async function flushAllAnimationFrames(startTime = 16): Promise<void> {
+	let frameIndex = 0;
+	while (queuedAnimationFrames.length > 0 && frameIndex < 500) {
+		const frame = queuedAnimationFrames.shift();
+		if (!frame) {
+			break;
+		}
+
+		frame.callback(startTime + frameIndex * 16);
+		await Promise.resolve();
+		frameIndex += 1;
+	}
+}
+
 const { default: MarkdownText } = await import("./markdown-text.svelte");
 
 beforeEach(() => {
+	queuedAnimationFrames = [];
+	nextAnimationFrameId = 1;
 	pendingAsyncRenders.clear();
 	getRepoContextMock.mockReset();
 	getProjectGitStatusMapMock.mockReset();
@@ -137,10 +173,20 @@ beforeEach(() => {
 	mountGitHubBadgesMock.mockClear();
 	renderMarkdownMock.mockClear();
 	renderMarkdownSyncMock.mockReset();
+	vi.stubGlobal("requestAnimationFrame", (callback: FrameRequestCallback): number => {
+		const id = nextAnimationFrameId;
+		nextAnimationFrameId += 1;
+		queuedAnimationFrames.push({ id, callback });
+		return id;
+	});
+	vi.stubGlobal("cancelAnimationFrame", (id: number): void => {
+		queuedAnimationFrames = queuedAnimationFrames.filter((frame) => frame.id !== id);
+	});
 });
 
 afterEach(() => {
 	cleanup();
+	vi.unstubAllGlobals();
 });
 
 describe("MarkdownText", () => {
@@ -362,6 +408,7 @@ describe("MarkdownText", () => {
 			text: "# Hello streaming\n\nBody",
 			isStreaming: true,
 		});
+		await flushAnimationFrames(8);
 
 		await waitFor(() => {
 			expect(view.container.querySelector(".markdown-content h1")?.textContent).toBe(
@@ -376,7 +423,7 @@ describe("MarkdownText", () => {
 		expect(mountGitHubBadgesMock).not.toHaveBeenCalled();
 	});
 
-	it("updates the live streaming tail in place without rerunning full markdown rendering", async () => {
+	it("reveals streaming text over animation frames instead of immediate raw bursts", async () => {
 		renderMarkdownSyncMock.mockImplementation((text) => ({
 			html: `<p>${text}</p>`,
 			fromCache: false,
@@ -388,11 +435,15 @@ describe("MarkdownText", () => {
 			isStreaming: true,
 		});
 
+		expect(view.container.textContent ?? "").not.toContain("Hello");
+
+		await flushAnimationFrames(1);
+
 		const firstLiveSection = await waitFor(() => {
 			const section = view.container.querySelector('[data-streaming-section-key="LIVE:0"]');
 			expect(section).not.toBeNull();
-			expect(section?.textContent).toContain("Hello");
-			expect(section?.classList.contains("streaming-live-refresh")).toBe(true);
+			expect(section?.textContent).not.toBe("");
+			expect((section?.textContent ?? "").length).toBeLessThan("Hello".length + 1);
 			return section;
 		});
 
@@ -403,10 +454,11 @@ describe("MarkdownText", () => {
 			text: "Hello world",
 			isStreaming: true,
 		});
+		await flushAnimationFrames(6, 32);
 
 		await waitFor(() => {
 			expect(firstLiveSection?.textContent).toContain("Hello world");
-			expect(firstLiveSection?.classList.contains("streaming-live-refresh")).toBe(true);
+			expect(view.container.querySelector(".streaming-live-cursor")).not.toBeNull();
 		});
 
 		expect(view.container.querySelector('[data-streaming-section-key="LIVE:0"]')).toBe(
@@ -415,7 +467,7 @@ describe("MarkdownText", () => {
 		expect(renderMarkdownSyncMock).not.toHaveBeenCalled();
 	});
 
-	it("fades only the newly appended suffix of the live streaming tail", async () => {
+	it("keeps partial markdown confined to the live tail while settled sections stay stable", async () => {
 		renderMarkdownSyncMock.mockImplementation((text) => ({
 			html: `<p>${text}</p>`,
 			fromCache: false,
@@ -423,39 +475,42 @@ describe("MarkdownText", () => {
 		}));
 
 		const view = render(MarkdownText, {
-			text: "Hello",
+			text: "# Title\n\nHello",
 			isStreaming: true,
 		});
 
+		await flushAnimationFrames(6);
+
 		await waitFor(() => {
-			expect(view.container.querySelector(".streaming-live-text")?.textContent).toBe("Hello");
-			expect(view.container.querySelector(".streaming-live-suffix")?.textContent).toBe("Hello");
+			expect(view.container.querySelector('[data-streaming-section-key="SETTLED:0"]')).not.toBeNull();
+			expect(view.container.querySelector('[data-streaming-section-key="LIVE:1"]')?.textContent).toContain(
+				"Hello"
+			);
 		});
+
+		const settledSection = view.container.querySelector('[data-streaming-section-key="SETTLED:0"]');
 
 		await view.rerender({
-			text: "Hello world",
+			text: "# Title\n\nHello\n\nNext",
 			isStreaming: true,
 		});
+		await flushAnimationFrames(6, 112);
 
 		await waitFor(() => {
-			const liveText = view.container.querySelector(".streaming-live-text");
-			const suffix = view.container.querySelector(".streaming-live-suffix");
-
-			expect(liveText?.textContent).toBe("Hello world");
-			expect(suffix?.textContent).toBe(" world");
+			expect(view.container.querySelector('[data-streaming-section-key="SETTLED:0"]')).toBe(
+				settledSection
+			);
+			expect(
+				view.container.querySelector('[data-streaming-section-key="SETTLED:1"]')?.textContent
+			).toContain("Hello");
+			expect(
+				view.container.querySelector('[data-streaming-section-key="LIVE:2"]')?.textContent
+			).toContain("Next");
 		});
 	});
 
-	it("keeps stable streaming sections while append-only markdown grows", async () => {
+	it("renders an open fenced code block as a live code tail during reveal", async () => {
 		renderMarkdownSyncMock.mockImplementation((text) => {
-			if (text === "# Title") {
-				return {
-					html: "<h1>Title</h1>",
-					fromCache: false,
-					needsAsync: false,
-				};
-			}
-
 			return {
 				html: `<p>${text}</p>`,
 				fromCache: false,
@@ -464,81 +519,10 @@ describe("MarkdownText", () => {
 		});
 
 		const view = render(MarkdownText, {
-			text: "# Title\n\nHello",
-			isStreaming: true,
-		});
-
-		const firstSection = await waitFor(() => {
-			const section = view.container.querySelector('[data-streaming-section-key="SETTLED:0"]');
-			expect(section).not.toBeNull();
-			return section;
-		});
-		const liveSection = view.container.querySelector('[data-streaming-section-key="LIVE:1"]');
-
-		await view.rerender({
-			text: "# Title\n\nHello world",
-			isStreaming: true,
-		});
-
-		await waitFor(() => {
-			expect(
-				view.container.querySelector('[data-streaming-section-key="LIVE:1"]')?.textContent
-			).toContain("Hello world");
-		});
-
-		expect(view.container.querySelector('[data-streaming-section-key="SETTLED:0"]')).toBe(
-			firstSection
-		);
-		expect(view.container.querySelector('[data-streaming-section-key="LIVE:1"]')).toBe(liveSection);
-		expect(renderMarkdownSyncMock).toHaveBeenCalledTimes(1);
-	});
-
-	it("does not re-fade section wrappers when streaming content splits into a new block", async () => {
-		renderMarkdownSyncMock.mockImplementation((text) => ({
-			html: `<p>${text}</p>`,
-			fromCache: false,
-			needsAsync: false,
-		}));
-
-		const view = render(MarkdownText, {
-			text: "Hello",
-			isStreaming: true,
-		});
-
-		await waitFor(() => {
-			expect(
-				view.container.querySelector('[data-streaming-section-key="LIVE:0"]')?.textContent
-			).toContain("Hello");
-		});
-
-		await view.rerender({
-			text: "Hello\n\nNext",
-			isStreaming: true,
-		});
-
-		await waitFor(() => {
-			expect(
-				view.container.querySelector('[data-streaming-section-key="SETTLED:0"]')?.textContent
-			).toContain("Hello");
-			expect(
-				view.container.querySelector('[data-streaming-section-key="LIVE:1"]')?.textContent
-			).toContain("Next");
-		});
-
-		expect(view.container.querySelector(".streaming-section.streaming-fade-in")).toBeNull();
-	});
-
-	it("renders an open fenced code block as a stable live code tail", async () => {
-		renderMarkdownSyncMock.mockImplementation(() => ({
-			html: null,
-			fromCache: false,
-			needsAsync: true,
-		}));
-
-		const view = render(MarkdownText, {
 			text: "```ts\nconst a = 1;",
 			isStreaming: true,
 		});
+		await flushAnimationFrames(8);
 
 		await waitFor(() => {
 			expect(view.container.querySelector(".streaming-live-code code")?.textContent).toContain(
@@ -548,6 +532,59 @@ describe("MarkdownText", () => {
 
 		expect(renderMarkdownSyncMock).not.toHaveBeenCalled();
 		expect(renderMarkdownMock).not.toHaveBeenCalled();
+	});
+
+	it("keeps the streaming cursor visible when the revealed tail currently has no live section", async () => {
+		renderMarkdownSyncMock.mockImplementation((text) => ({
+			html: `<p>${text}</p>`,
+			fromCache: false,
+			needsAsync: false,
+		}));
+
+		const view = render(MarkdownText, {
+			text: "# Title\n\n",
+			isStreaming: true,
+		});
+		await flushAnimationFrames(8);
+
+		await waitFor(() => {
+			expect(view.container.querySelector(".streaming-live-cursor")).not.toBeNull();
+		});
+	});
+
+	it("keeps stable streaming sections while append-only revealed markdown grows", async () => {
+		renderMarkdownSyncMock.mockImplementation((text) => ({
+			html: `<p>${text}</p>`,
+			fromCache: false,
+			needsAsync: false,
+		}));
+
+		const view = render(MarkdownText, {
+			text: "# Title\n\nHello",
+			isStreaming: true,
+		});
+		await flushAnimationFrames(6);
+
+		const settledSection = view.container.querySelector('[data-streaming-section-key="SETTLED:0"]');
+		const liveSection = view.container.querySelector('[data-streaming-section-key="LIVE:1"]');
+
+		await view.rerender({
+			text: "# Title\n\nHello world",
+			isStreaming: true,
+		});
+		await flushAnimationFrames(6, 112);
+
+		await waitFor(() => {
+			expect(
+				view.container.querySelector('[data-streaming-section-key="LIVE:1"]')?.textContent
+			).toContain("Hello world");
+		});
+
+		expect(view.container.querySelector('[data-streaming-section-key="SETTLED:0"]')).toBe(
+			settledSection
+		);
+		expect(view.container.querySelector('[data-streaming-section-key="LIVE:1"]')).toBe(liveSection);
+		expect(renderMarkdownSyncMock).toHaveBeenCalledTimes(1);
 	});
 
 	it("defers rich markdown rendering until streaming stops", async () => {
@@ -563,6 +600,7 @@ describe("MarkdownText", () => {
 			text: chunk,
 			isStreaming: true,
 		});
+		await flushAnimationFrames(40);
 
 		await new Promise<void>((resolve) => setTimeout(resolve, 0));
 
@@ -576,6 +614,7 @@ describe("MarkdownText", () => {
 			text: chunk,
 			isStreaming: false,
 		});
+		await flushAllAnimationFrames(800);
 
 		const pending = pendingAsyncRenders.get(getRequestKey(chunk));
 		if (!pending) {
@@ -613,6 +652,7 @@ describe("MarkdownText", () => {
 			isStreaming: true,
 			projectPath: "/repo",
 		});
+		await flushAnimationFrames(40);
 
 		await new Promise<void>((resolve) => setTimeout(resolve, 0));
 
@@ -627,6 +667,7 @@ describe("MarkdownText", () => {
 			isStreaming: false,
 			projectPath: "/repo",
 		});
+		await flushAllAnimationFrames(800);
 
 		await waitFor(() => {
 			expect(getRepoContextMock).toHaveBeenCalledWith("/repo");

--- a/packages/desktop/src/lib/acp/components/messages/message-wrapper.svelte
+++ b/packages/desktop/src/lib/acp/components/messages/message-wrapper.svelte
@@ -68,7 +68,7 @@ const revealTargetAction: Action<HTMLDivElement, RevealTargetActionParams> = (no
 		}
 
 		observer = new ResizeObserver(() => {
-			nextParams.controller?.requestReveal(nextParams.entryKey);
+			nextParams.controller?.requestLatestReveal();
 		});
 		observer.observe(node);
 	}

--- a/packages/desktop/src/lib/acp/components/modified-files/components/__tests__/review-diff-view-state-regression.vitest.ts
+++ b/packages/desktop/src/lib/acp/components/modified-files/components/__tests__/review-diff-view-state-regression.vitest.ts
@@ -80,4 +80,69 @@ describe("ReviewDiffViewState regression", () => {
 		const currentData = Reflect.get(state, "currentDiffData") as ReviewDiffData;
 		expect(currentData.newFile.contents).toBe(originalNewContents);
 	});
+
+	it("extracts old content from legacy numeric hunk payloads", async () => {
+		const { ReviewDiffViewState } = await import("../review-diff-view-state.svelte.js");
+		const state = new ReviewDiffViewState();
+
+		const legacyMetadata = {
+			name: "example.ts",
+			prevName: undefined,
+			type: "change",
+			hunks: [
+				{
+					collapsedBefore: 0,
+					splitLineStart: 1,
+					splitLineCount: 1,
+					unifiedLineStart: 1,
+					unifiedLineCount: 1,
+					additionCount: 1,
+					additionStart: 2,
+					additionLines: 1,
+					deletionCount: 1,
+					deletionStart: 2,
+					deletionLines: 1,
+					hunkContent: [
+						{
+							type: "change",
+							deletions: 1,
+							additions: 1,
+							deletionLineIndex: 1,
+							additionLineIndex: 1,
+							noEOFCRDeletions: false,
+							noEOFCRAdditions: false,
+						},
+					],
+					hunkContext: undefined,
+					hunkSpecs: undefined,
+				},
+			],
+			splitLineCount: 0,
+			unifiedLineCount: 0,
+			deletionLines: ["line-01\n", "line-02\n", "line-03"],
+			additionLines: ["line-01\n", "line-02-modified\n", "line-03"],
+		};
+
+		Reflect.set(state, "currentDiffData", {
+			oldFile: {
+				name: "example.ts",
+				contents: "line-01\nline-02\nline-03",
+				cacheKey: "legacy-old",
+			},
+			newFile: {
+				name: "example.ts",
+				contents: "line-01\nline-02-modified\nline-03",
+				cacheKey: "legacy-new",
+			},
+			fileDiffMetadata: legacyMetadata,
+		});
+
+		const extracted = Reflect.apply(
+			Reflect.get(state, "extractHunkOldContent") as (hunkIndex: number) => string,
+			state,
+			[0]
+		);
+
+		expect(extracted).toBe("line-02\n");
+	});
 });

--- a/packages/desktop/src/lib/acp/components/modified-files/components/__tests__/review-diff-view-state-regression.vitest.ts
+++ b/packages/desktop/src/lib/acp/components/modified-files/components/__tests__/review-diff-view-state-regression.vitest.ts
@@ -6,7 +6,7 @@ vi.mock("@pierre/diffs", async () => {
 	const diffAcceptRejectHunk: typeof actual.diffAcceptRejectHunk = (diff, hunkIndex, action) => {
 		const result = actual.diffAcceptRejectHunk(diff, hunkIndex, action);
 		const corruptedResult = Object.assign({}, result);
-		Reflect.deleteProperty(corruptedResult, "additionLines");
+		Reflect.deleteProperty(corruptedResult, "newLines");
 		return corruptedResult;
 	};
 
@@ -69,7 +69,7 @@ async function setupState() {
 }
 
 describe("ReviewDiffViewState regression", () => {
-	it("keeps accepted contents when resolved metadata omits additionLines", async () => {
+	it("keeps accepted contents when resolved metadata omits newLines", async () => {
 		const { state, diffData } = await setupState();
 		const originalNewContents = diffData.newFile.contents;
 

--- a/packages/desktop/src/lib/acp/components/modified-files/components/__tests__/review-diff-view-state.vitest.ts
+++ b/packages/desktop/src/lib/acp/components/modified-files/components/__tests__/review-diff-view-state.vitest.ts
@@ -144,8 +144,10 @@ describe("ReviewDiffViewState", () => {
 		const currentData = Reflect.get(state, "currentDiffData") as ReviewDiffData;
 		expect(currentData.newFile.contents).not.toBe(originalNewContents);
 
-		// The updated contents should match additionLines joined
-		expect(currentData.newFile.contents).toBe(currentData.fileDiffMetadata.additionLines.join(""));
+		// The updated contents should match the metadata new lines when present
+		expect(currentData.newFile.contents).toBe(
+			currentData.fileDiffMetadata.newLines?.join("") ?? currentData.newFile.contents
+		);
 	}, 20_000);
 
 	it("sequential rejects produce correct content (all changes reverted)", async () => {

--- a/packages/desktop/src/lib/acp/components/modified-files/components/__tests__/review-diff-view-state.vitest.ts
+++ b/packages/desktop/src/lib/acp/components/modified-files/components/__tests__/review-diff-view-state.vitest.ts
@@ -144,10 +144,8 @@ describe("ReviewDiffViewState", () => {
 		const currentData = Reflect.get(state, "currentDiffData") as ReviewDiffData;
 		expect(currentData.newFile.contents).not.toBe(originalNewContents);
 
-		// The updated contents should match the metadata new lines when present
-		expect(currentData.newFile.contents).toBe(
-			currentData.fileDiffMetadata.newLines?.join("") ?? currentData.newFile.contents
-		);
+		expect(currentData.fileDiffMetadata.newLines).toBeDefined();
+		expect(currentData.newFile.contents).toBe(currentData.fileDiffMetadata.newLines?.join(""));
 	}, 20_000);
 
 	it("sequential rejects produce correct content (all changes reverted)", async () => {

--- a/packages/desktop/src/lib/acp/components/modified-files/components/review-diff-view-state.svelte.ts
+++ b/packages/desktop/src/lib/acp/components/modified-files/components/review-diff-view-state.svelte.ts
@@ -40,8 +40,64 @@ type AnnotationMetadata = {
 	hunkIndex: number;
 };
 
+type LegacyContextContent = {
+	type: "context";
+	lines: number;
+	noEOFCR: boolean;
+};
+
+type LegacyChangeContent = {
+	type: "change";
+	deletions: number;
+	additions: number;
+	deletionLineIndex: number;
+	additionLineIndex: number;
+	noEOFCRDeletions: boolean;
+	noEOFCRAdditions: boolean;
+};
+
+type CompatibleHunkContent =
+	| FileDiffMetadata["hunks"][number]["hunkContent"][number]
+	| LegacyContextContent
+	| LegacyChangeContent;
+type CompatibleFileDiffMetadata = FileDiffMetadata & {
+	deletionLines?: string[];
+	additionLines?: string[];
+};
+
 function getLinesForRange(lines: string[], startIndex: number, count: number): string[] {
 	return lines.slice(startIndex, startIndex + count);
+}
+
+function getContentLineCount(lines: string[] | number): number {
+	return Array.isArray(lines) ? lines.length : lines;
+}
+
+function isLegacyChangeContent(content: CompatibleHunkContent): content is LegacyChangeContent {
+	return content.type === "change" && !Array.isArray(content.deletions);
+}
+
+function getLegacyDeletionLines(fileDiffMetadata: CompatibleFileDiffMetadata): string[] {
+	return fileDiffMetadata.oldLines ?? fileDiffMetadata.deletionLines ?? [];
+}
+
+function getChangeDeletionLines(
+	fileDiffMetadata: CompatibleFileDiffMetadata,
+	content: CompatibleHunkContent
+): string[] {
+	if (content.type !== "change") {
+		return [];
+	}
+
+	if (!isLegacyChangeContent(content)) {
+		return content.deletions;
+	}
+
+	return getLinesForRange(
+		getLegacyDeletionLines(fileDiffMetadata),
+		content.deletionLineIndex,
+		content.deletions
+	);
 }
 
 /**
@@ -272,10 +328,11 @@ export class ReviewDiffViewState {
 	private buildLineAnnotationsFromHunks(
 		fileDiff: FileDiffMetadata
 	): DiffLineAnnotation<AnnotationMetadata>[] {
+		const compatibleMetadata = fileDiff as CompatibleFileDiffMetadata;
 		const annotations: DiffLineAnnotation<AnnotationMetadata>[] = [];
 
-		for (let hunkIndex = 0; hunkIndex < fileDiff.hunks.length; hunkIndex++) {
-			const hunk = fileDiff.hunks[hunkIndex];
+		for (let hunkIndex = 0; hunkIndex < compatibleMetadata.hunks.length; hunkIndex++) {
+			const hunk = compatibleMetadata.hunks[hunkIndex];
 
 			// Skip resolved hunks (context-only after diffAcceptRejectHunk)
 			const hasChanges = hunk.hunkContent.some((c) => c.type === "change");
@@ -285,14 +342,16 @@ export class ReviewDiffViewState {
 			let deletionLineOffset = 0;
 			let annotationPlaced = false;
 
-			for (const content of hunk.hunkContent) {
+			for (const content of hunk.hunkContent as CompatibleHunkContent[]) {
 				if (content.type === "context") {
-					additionLineOffset += content.lines.length;
-					deletionLineOffset += content.lines.length;
+					const lineCount = getContentLineCount(content.lines);
+					additionLineOffset += lineCount;
+					deletionLineOffset += lineCount;
 				} else if (content.type === "change") {
-					if (content.additions.length > 0) {
+					const additionsCount = getContentLineCount(content.additions);
+					if (additionsCount > 0) {
 						const lastAdditionLineNumber =
-							hunk.additionStart + additionLineOffset + content.additions.length - 1;
+							hunk.additionStart + additionLineOffset + additionsCount - 1;
 						annotations.push({
 							side: "additions",
 							lineNumber: lastAdditionLineNumber,
@@ -301,7 +360,7 @@ export class ReviewDiffViewState {
 						annotationPlaced = true;
 						break;
 					}
-					deletionLineOffset += content.deletions.length;
+					deletionLineOffset += getContentLineCount(content.deletions);
 				}
 			}
 
@@ -371,9 +430,10 @@ export class ReviewDiffViewState {
 		if (!hunk) return "";
 
 		const deletions: string[] = [];
-		for (const content of hunk.hunkContent) {
+		const compatibleMetadata = this.currentDiffData.fileDiffMetadata as CompatibleFileDiffMetadata;
+		for (const content of hunk.hunkContent as CompatibleHunkContent[]) {
 			if (content.type === "change") {
-				deletions.push(...content.deletions);
+				deletions.push(...getChangeDeletionLines(compatibleMetadata, content));
 			}
 		}
 

--- a/packages/desktop/src/lib/acp/components/modified-files/components/review-diff-view-state.svelte.ts
+++ b/packages/desktop/src/lib/acp/components/modified-files/components/review-diff-view-state.svelte.ts
@@ -287,12 +287,12 @@ export class ReviewDiffViewState {
 
 			for (const content of hunk.hunkContent) {
 				if (content.type === "context") {
-					additionLineOffset += content.lines;
-					deletionLineOffset += content.lines;
+					additionLineOffset += content.lines.length;
+					deletionLineOffset += content.lines.length;
 				} else if (content.type === "change") {
-					if (content.additions > 0) {
+					if (content.additions.length > 0) {
 						const lastAdditionLineNumber =
-							hunk.additionStart + additionLineOffset + content.additions - 1;
+							hunk.additionStart + additionLineOffset + content.additions.length - 1;
 						annotations.push({
 							side: "additions",
 							lineNumber: lastAdditionLineNumber,
@@ -301,7 +301,7 @@ export class ReviewDiffViewState {
 						annotationPlaced = true;
 						break;
 					}
-					deletionLineOffset += content.deletions;
+					deletionLineOffset += content.deletions.length;
 				}
 			}
 
@@ -373,12 +373,7 @@ export class ReviewDiffViewState {
 		const deletions: string[] = [];
 		for (const content of hunk.hunkContent) {
 			if (content.type === "change") {
-				const hunkDeletions = getLinesForRange(
-					this.currentDiffData.fileDiffMetadata.deletionLines,
-					content.deletionLineIndex,
-					content.deletions
-				);
-				deletions.push(...hunkDeletions);
+				deletions.push(...content.deletions);
 			}
 		}
 

--- a/packages/desktop/src/lib/acp/components/modified-files/logic/__tests__/compute-reverted-file-content-regression.vitest.ts
+++ b/packages/desktop/src/lib/acp/components/modified-files/logic/__tests__/compute-reverted-file-content-regression.vitest.ts
@@ -38,4 +38,54 @@ describe("computeRevertedFileContent regression", () => {
 
 		expect(result).toBe(oldContent);
 	});
+
+	it("supports legacy numeric hunk payloads", async () => {
+		const { computeRevertedFileContent } = await import("../compute-reverted-file-content.js");
+
+		const legacyMetadata = {
+			name: "test.ts",
+			prevName: undefined,
+			type: "change",
+			hunks: [
+				{
+					collapsedBefore: 0,
+					splitLineStart: 1,
+					splitLineCount: 1,
+					unifiedLineStart: 1,
+					unifiedLineCount: 1,
+					additionCount: 1,
+					additionStart: 2,
+					additionLines: 1,
+					deletionCount: 1,
+					deletionStart: 2,
+					deletionLines: 1,
+					hunkContent: [
+						{
+							type: "change",
+							deletions: 1,
+							additions: 1,
+							deletionLineIndex: 1,
+							additionLineIndex: 1,
+							noEOFCRDeletions: false,
+							noEOFCRAdditions: false,
+						},
+					],
+					hunkContext: undefined,
+					hunkSpecs: undefined,
+				},
+			],
+			splitLineCount: 0,
+			unifiedLineCount: 0,
+			deletionLines: ["line1\n", "old\n", "line3"],
+			additionLines: ["line1\n", "new\n", "line3"],
+		};
+
+		const result = computeRevertedFileContent(
+			"line1\nnew\nline3",
+			legacyMetadata as unknown as Parameters<typeof computeRevertedFileContent>[1],
+			0
+		);
+
+		expect(result).toBe("line1\nold\nline3");
+	});
 });

--- a/packages/desktop/src/lib/acp/components/modified-files/logic/__tests__/compute-reverted-file-content-regression.vitest.ts
+++ b/packages/desktop/src/lib/acp/components/modified-files/logic/__tests__/compute-reverted-file-content-regression.vitest.ts
@@ -6,7 +6,7 @@ vi.mock("@pierre/diffs", async () => {
 	const diffAcceptRejectHunk: typeof actual.diffAcceptRejectHunk = (diff, hunkIndex, action) => {
 		const result = actual.diffAcceptRejectHunk(diff, hunkIndex, action);
 		const corruptedResult = Object.assign({}, result);
-		Reflect.deleteProperty(corruptedResult, "additionLines");
+		Reflect.deleteProperty(corruptedResult, "newLines");
 		return corruptedResult;
 	};
 
@@ -23,7 +23,7 @@ function createFile(name: string, contents: string): FileContents {
 }
 
 describe("computeRevertedFileContent regression", () => {
-	it("returns full reverted content when resolved metadata omits additionLines", async () => {
+	it("returns full reverted content when resolved metadata omits newLines", async () => {
 		const { computeRevertedFileContent } = await import("../compute-reverted-file-content.js");
 		const oldContent = "line1\nold\nline3";
 		const newContent = "line1\nnew\nline3";

--- a/packages/desktop/src/lib/acp/components/modified-files/logic/compute-reverted-file-content.ts
+++ b/packages/desktop/src/lib/acp/components/modified-files/logic/compute-reverted-file-content.ts
@@ -35,31 +35,29 @@ export function computeRevertedFileContent(
 	}
 
 	const currentAdditionLines = splitFileContent(newFileContent);
-	if (hunk.additionLineIndex > currentAdditionLines.length) {
+	const hunkAdditionStartIndex = Math.max(0, hunk.additionStart - 1);
+	if (hunkAdditionStartIndex > currentAdditionLines.length) {
 		return newFileContent;
 	}
 
-	const revertedLines = currentAdditionLines.slice(0, hunk.additionLineIndex);
-	let nextCurrentLineIndex = hunk.additionLineIndex;
+	const revertedLines = currentAdditionLines.slice(0, hunkAdditionStartIndex);
+	let nextCurrentLineIndex = hunkAdditionStartIndex;
 
 	for (const content of hunk.hunkContent) {
 		if (content.type === "context") {
 			appendLines(
 				revertedLines,
-				currentAdditionLines.slice(nextCurrentLineIndex, nextCurrentLineIndex + content.lines)
+				currentAdditionLines.slice(
+					nextCurrentLineIndex,
+					nextCurrentLineIndex + content.lines.length
+				)
 			);
-			nextCurrentLineIndex += content.lines;
+			nextCurrentLineIndex += content.lines.length;
 			continue;
 		}
 
-		appendLines(
-			revertedLines,
-			fileDiffMetadata.deletionLines.slice(
-				content.deletionLineIndex,
-				content.deletionLineIndex + content.deletions
-			)
-		);
-		nextCurrentLineIndex += content.additions;
+		appendLines(revertedLines, content.deletions);
+		nextCurrentLineIndex += content.additions.length;
 	}
 
 	appendLines(revertedLines, currentAdditionLines.slice(nextCurrentLineIndex));

--- a/packages/desktop/src/lib/acp/components/modified-files/logic/compute-reverted-file-content.ts
+++ b/packages/desktop/src/lib/acp/components/modified-files/logic/compute-reverted-file-content.ts
@@ -1,5 +1,27 @@
 import { type FileDiffMetadata, SPLIT_WITH_NEWLINES } from "@pierre/diffs";
 
+type LegacyContextContent = {
+	type: "context";
+	lines: number;
+	noEOFCR: boolean;
+};
+
+type LegacyChangeContent = {
+	type: "change";
+	deletions: number;
+	additions: number;
+	deletionLineIndex: number;
+	additionLineIndex: number;
+	noEOFCRDeletions: boolean;
+	noEOFCRAdditions: boolean;
+};
+
+type CompatibleHunkContent = FileDiffMetadata["hunks"][number]["hunkContent"][number] | LegacyContextContent | LegacyChangeContent;
+type CompatibleFileDiffMetadata = FileDiffMetadata & {
+	deletionLines?: string[];
+	additionLines?: string[];
+};
+
 function appendLines(target: string[], source: string[]): void {
 	for (const line of source) {
 		target.push(line);
@@ -8,6 +30,36 @@ function appendLines(target: string[], source: string[]): void {
 
 function splitFileContent(contents: string): string[] {
 	return contents === "" ? [] : contents.split(SPLIT_WITH_NEWLINES);
+}
+
+function getContentLineCount(lines: string[] | number): number {
+	return Array.isArray(lines) ? lines.length : lines;
+}
+
+function isLegacyChangeContent(content: CompatibleHunkContent): content is LegacyChangeContent {
+	return content.type === "change" && !Array.isArray(content.deletions);
+}
+
+function getLegacyOldLines(fileDiffMetadata: CompatibleFileDiffMetadata): string[] {
+	return fileDiffMetadata.oldLines ?? fileDiffMetadata.deletionLines ?? [];
+}
+
+function getChangeDeletionLines(
+	fileDiffMetadata: CompatibleFileDiffMetadata,
+	content: CompatibleHunkContent
+): string[] {
+	if (content.type !== "change") {
+		return [];
+	}
+
+	if (!isLegacyChangeContent(content)) {
+		return content.deletions;
+	}
+
+	return getLegacyOldLines(fileDiffMetadata).slice(
+		content.deletionLineIndex,
+		content.deletionLineIndex + content.deletions
+	);
 }
 
 /**
@@ -29,7 +81,8 @@ export function computeRevertedFileContent(
 	fileDiffMetadata: FileDiffMetadata,
 	hunkIndex: number
 ): string {
-	const hunk = fileDiffMetadata.hunks[hunkIndex];
+	const compatibleMetadata = fileDiffMetadata as CompatibleFileDiffMetadata;
+	const hunk = compatibleMetadata.hunks[hunkIndex];
 	if (!hunk) {
 		return newFileContent;
 	}
@@ -43,21 +96,22 @@ export function computeRevertedFileContent(
 	const revertedLines = currentAdditionLines.slice(0, hunkAdditionStartIndex);
 	let nextCurrentLineIndex = hunkAdditionStartIndex;
 
-	for (const content of hunk.hunkContent) {
+	for (const content of hunk.hunkContent as CompatibleHunkContent[]) {
 		if (content.type === "context") {
+			const contextLineCount = getContentLineCount(content.lines);
 			appendLines(
 				revertedLines,
 				currentAdditionLines.slice(
 					nextCurrentLineIndex,
-					nextCurrentLineIndex + content.lines.length
+					nextCurrentLineIndex + contextLineCount
 				)
 			);
-			nextCurrentLineIndex += content.lines.length;
+			nextCurrentLineIndex += contextLineCount;
 			continue;
 		}
 
-		appendLines(revertedLines, content.deletions);
-		nextCurrentLineIndex += content.additions.length;
+		appendLines(revertedLines, getChangeDeletionLines(compatibleMetadata, content));
+		nextCurrentLineIndex += getContentLineCount(content.additions);
 	}
 
 	appendLines(revertedLines, currentAdditionLines.slice(nextCurrentLineIndex));

--- a/packages/desktop/src/lib/acp/components/tool-calls/tool-call-edit/logic/__tests__/adjust-hunk-offsets.test.ts
+++ b/packages/desktop/src/lib/acp/components/tool-calls/tool-call-edit/logic/__tests__/adjust-hunk-offsets.test.ts
@@ -13,16 +13,12 @@ function createMinimalHunk(overrides: Partial<Hunk> = {}): Hunk {
 		additionCount: 1,
 		additionStart: 1,
 		additionLines: 1,
-		additionLineIndex: 0,
 		deletionCount: 1,
 		deletionStart: 1,
 		deletionLines: 1,
-		deletionLineIndex: 0,
 		hunkContent: [],
 		hunkContext: undefined,
 		hunkSpecs: undefined,
-		noEOFCRDeletions: false,
-		noEOFCRAdditions: false,
 	};
 
 	return Object.assign(baseHunk, overrides);
@@ -36,9 +32,8 @@ function createMinimalFileDiff(overrides: Partial<FileDiffMetadata> = {}): FileD
 		hunks: [],
 		splitLineCount: 0,
 		unifiedLineCount: 0,
-		isPartial: false,
-		deletionLines: [],
-		additionLines: [],
+		oldLines: [],
+		newLines: [],
 	};
 
 	return Object.assign(baseFileDiff, overrides);

--- a/packages/desktop/src/lib/acp/components/virtual-session-list.svelte
+++ b/packages/desktop/src/lib/acp/components/virtual-session-list.svelte
@@ -114,7 +114,11 @@ function measureSessionRow(node: HTMLDivElement): { destroy: () => void } {
 						{#if entry.type === "user"}
 							<UserMessage message={entry.message as UserMessageType} />
 						{:else if entry.type === "assistant"}
-							<AssistantMessage message={entry.message as AssistantMessageType} {projectPath} />
+							<AssistantMessage
+								message={entry.message as AssistantMessageType}
+								revealMessageKey={entry.id}
+								{projectPath}
+							/>
 						{:else if entry.type === "ask"}
 							<AskMessage message={entry.message as AskMessageType} />
 						{:else if entry.type === "tool_call"}


### PR DESCRIPTION
## Summary

Replace the markdown streaming path with a dedicated reveal engine so assistant text renders as a controlled character-clock reveal instead of raw batch bursts.

## What changed

- introduced a pure `StreamingRevealEngine` plus a Svelte controller to decouple canonical streamed text from displayed reveal state
- rebuilt `markdown-text.svelte` around revealed text, incremental tail parsing, and stable settled/live section handling
- fixed remount recovery, grapheme-safe reveal, trailing cursor behavior, and post-stream follow behavior while a thinking row trails the thread
- threaded reveal keys through the assistant message text path so resumed streaming entries can recover without replaying fresh streams from blank

## Why this approach

The old renderer mixed transport timing, markdown parsing, and view updates in one place, which made streaming feel visibly jumpy and fragile around virtualization and async markdown handoff. This change gives the stream a small timing core, keeps render optimizations local to markdown, and lets follow behavior stay aligned with the actual latest target.

## Validation

- targeted Bun tests for the reveal engine, reveal controller, and thread-follow behavior
- targeted Vitest coverage for incremental streaming-tail parsing and markdown streaming integration
- `bun run check` is still blocked by unrelated pre-existing TypeScript errors in the modified-files / tool-call-edit area of the repo baseline

---

[![Compound Engineering](https://img.shields.io/badge/Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
🤖 Generated with GPT-5.4 via [GitHub Copilot CLI](https://github.com/features/copilot)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Redesigned assistant message streaming to use a paced reveal engine with a blinking cursor, replacing bursty markdown updates. Streaming is smoother and more stable, with accurate scroll-follow and safer remount recovery.

- **New Features**
  - Added `StreamingRevealEngine` and `createStreamingReveal` for grapheme-safe reveal with pause and catch-up modes.
  - Rebuilt `markdown-text.svelte` around incremental tail parsing via `parseStreamingTailIncremental`; keeps settled blocks stable, shows a blinking cursor (even when the tail is empty), and defers rich markdown and badge mounts until streaming ends.
  - Threaded `revealMessageKey` from both `virtual-session-list` and `virtualized-entry-list` into `assistant-message` → `content-block-router` → `text-block` → `markdown-text`, namespaced per thought/message group to seed reveal across remounts; added tests for the engine, controller, and incremental parser.

- **Bug Fixes**
  - Virtualization always observes the latest reveal target (even when not streaming); `message-wrapper` uses `requestLatestReveal` to keep scroll-follow aligned.
  - Grapheme-safe advancing prevents emoji splits and clamps large frame gaps to avoid over-reveal.
  - Modified-file diffs aligned with `@pierre/diffs`: use `newLines`/`oldLines`, treat per-hunk additions/deletions as arrays, and keep revert/annotation logic correct with partial metadata; additionally support legacy payloads (numeric hunk counts and `deletionLines`/`additionLines`) so older shapes work reliably.

<sup>Written for commit 29388b2f1cf9746f4227e4880c2c076913f88025. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

