### PR TITLE
feat: drag-to-reorder projects in the sidebar

### DIFF
--- a/packages/desktop/src/lib/acp/components/project-header.svelte
+++ b/packages/desktop/src/lib/acp/components/project-header.svelte
@@ -23,6 +23,10 @@ interface Props {
 	trailing?: Snippet;
 	/** Optional actions to render at the end (view toggle, terminal, plus, etc.) */
 	actions?: Snippet;
+	/** Whether the badge grip should be available for dragging */
+	draggable?: boolean;
+	/** Called when the badge grip receives pointer down */
+	onGripPointerDown?: (event: PointerEvent) => void;
 }
 
 let {
@@ -34,6 +38,8 @@ let {
 	class: className = "",
 	trailing,
 	actions,
+	draggable = false,
+	onGripPointerDown,
 }: Props = $props();
 
 /**
@@ -53,19 +59,44 @@ const resolvedColor = $derived(
 	project?.color ? project.color : projectColor ? projectColor : fallbackColor
 );
 const resolvedIconSrc = $derived(project?.iconPath ?? projectIconSrc);
+
+function handleGripPointerDown(event: PointerEvent): void {
+	event.stopPropagation();
+	onGripPointerDown?.(event);
+}
+
+function handleGripClick(event: MouseEvent): void {
+	event.stopPropagation();
+}
+
+function handleGripKeyDown(event: KeyboardEvent): void {
+	if (event.key === "Enter" || event.key === " ") {
+		event.preventDefault();
+		event.stopPropagation();
+	}
+}
 </script>
 
 <div
 	class="shrink-0 flex items-center rounded-md {expanded ? 'bg-background/30' : ''} {className}"
 >
-	<div class="inline-flex items-center justify-center h-7 w-7 shrink-0">
+	<button
+		type="button"
+		class="inline-flex items-center justify-center h-7 w-7 shrink-0 border-0 bg-transparent p-0"
+		tabindex={draggable ? 0 : -1}
+		aria-label={draggable ? `Reorder ${displayName}` : undefined}
+		onpointerdown={draggable ? handleGripPointerDown : undefined}
+		onclick={draggable ? handleGripClick : undefined}
+		onkeydown={draggable ? handleGripKeyDown : undefined}
+	>
 		<ProjectLetterBadge
 			name={displayName}
 			color={resolvedColor}
 			iconSrc={resolvedIconSrc}
+			{draggable}
 			size={16}
 		/>
-	</div>
+	</button>
 	<div
 		class="flex items-center flex-1 min-w-0 h-7 pl-2 pr-2 cursor-pointer rounded-md hover:bg-background/70 transition-colors"
 	>

--- a/packages/desktop/src/lib/acp/components/session-list/__tests__/session-list-logic.test.ts
+++ b/packages/desktop/src/lib/acp/components/session-list/__tests__/session-list-logic.test.ts
@@ -1,10 +1,12 @@
 import { describe, expect, it } from "bun:test";
 
 import type { SessionEntry } from "../../../application/dto/session.js";
+import type { Project } from "../../../logic/project-manager.svelte.js";
 import type { ToolCall } from "../../../types/tool-call.js";
 import {
 	buildSessionRows,
 	createDisplayItems,
+	createLoadingSessionGroups,
 	createSessionGroups,
 	extractActivityInfo,
 	extractCurrentToolInfo,
@@ -196,61 +198,150 @@ describe("createDisplayItems", () => {
 });
 
 describe("createSessionGroups", () => {
-	const mockItems: SessionListItem[] = [
-		{
-			id: "session-1",
-			title: "Session 1",
-			projectPath: "/path/1",
-			projectName: "project1",
+	function createSessionListItem(
+		id: string,
+		projectPath: string,
+		projectName: string
+	): SessionListItem {
+		const createdAt = new Date("2024-01-01T00:00:00.000Z");
+		return {
+			id,
+			title: id,
+			projectPath,
+			projectName,
 			projectColor: undefined,
 			projectIconSrc: null,
 			agentId: "claude-code",
-			createdAt: new Date(),
-			updatedAt: new Date(),
+			createdAt,
+			updatedAt: createdAt,
 			isLive: false,
 			isOpen: false,
 			activity: null,
 			parentId: null,
-		},
-		{
-			id: "session-2",
-			title: "Session 2",
-			projectPath: "/path/1",
-			projectName: "project1",
-			projectColor: undefined,
-			projectIconSrc: null,
-			agentId: "cursor",
-			createdAt: new Date(),
-			updatedAt: new Date(),
-			isLive: false,
-			isOpen: false,
-			activity: null,
-			parentId: null,
-		},
-		{
-			id: "session-3",
-			title: "Session 3",
-			projectPath: "/path/1",
-			projectName: "project1",
-			projectColor: undefined,
-			projectIconSrc: null,
-			agentId: "claude-code",
-			createdAt: new Date(),
-			updatedAt: new Date(),
-			isLive: false,
-			isOpen: false,
-			activity: null,
-			parentId: null,
-		},
-	];
+		};
+	}
+
+	function createProject(
+		path: string,
+		name: string,
+		createdAt: string,
+		sortOrder?: number
+	): Project {
+		return {
+			path,
+			name,
+			createdAt: new Date(createdAt),
+			color: "#000000",
+			sortOrder,
+			iconPath: null,
+		};
+	}
 
 	it("should group sessions by project", () => {
+		const mockItems: SessionListItem[] = [
+			createSessionListItem("session-1", "/path/1", "project1"),
+			createSessionListItem("session-2", "/path/1", "project1"),
+			createSessionListItem("session-3", "/path/1", "project1"),
+		];
 		const groups = createSessionGroups(mockItems);
 
 		expect(groups).toHaveLength(1);
 		const group = groups[0];
 		expect(group.sessions).toHaveLength(3);
 		expect(group.projectPath).toBe("/path/1");
+	});
+
+	it("sorts groups by persisted sortOrder ascending", () => {
+		const items: SessionListItem[] = [
+			createSessionListItem("session-a", "/project/a", "project-a"),
+			createSessionListItem("session-b", "/project/b", "project-b"),
+			createSessionListItem("session-c", "/project/c", "project-c"),
+		];
+
+		const projectCreatedAtMap = new Map<string, Date>([
+			["/project/a", new Date("2024-01-01T00:00:00.000Z")],
+			["/project/b", new Date("2024-03-01T00:00:00.000Z")],
+			["/project/c", new Date("2024-02-01T00:00:00.000Z")],
+		]);
+		const projectSortOrderMap = new Map<string, number>([
+			["/project/a", 2],
+			["/project/b", 0],
+			["/project/c", 1],
+		]);
+
+		const groups = createSessionGroups(items, projectCreatedAtMap, projectSortOrderMap);
+
+		expect(groups.map((group) => group.projectPath)).toEqual([
+			"/project/b",
+			"/project/c",
+			"/project/a",
+		]);
+	});
+
+	it("sorts loading groups by persisted sortOrder instead of createdAt", () => {
+		const projects: Project[] = [
+			createProject("/project/a", "project-a", "2024-01-01T00:00:00.000Z", 2),
+			createProject("/project/b", "project-b", "2024-03-01T00:00:00.000Z", 0),
+			createProject("/project/c", "project-c", "2024-02-01T00:00:00.000Z", 1),
+		];
+
+		const groups = createLoadingSessionGroups(projects);
+
+		expect(groups.map((group) => group.projectPath)).toEqual([
+			"/project/b",
+			"/project/c",
+			"/project/a",
+		]);
+	});
+
+	it("treats missing sortOrder as Infinity and falls back to createdAt desc", () => {
+		const items: SessionListItem[] = [
+			createSessionListItem("session-a", "/project/a", "project-a"),
+			createSessionListItem("session-b", "/project/b", "project-b"),
+			createSessionListItem("session-c", "/project/c", "project-c"),
+		];
+
+		const projectCreatedAtMap = new Map<string, Date>([
+			["/project/a", new Date("2024-01-01T00:00:00.000Z")],
+			["/project/b", new Date("2024-03-01T00:00:00.000Z")],
+			["/project/c", new Date("2024-02-01T00:00:00.000Z")],
+		]);
+		const projectSortOrderMap = new Map<string, number>([["/project/a", 0]]);
+
+		const groups = createSessionGroups(items, projectCreatedAtMap, projectSortOrderMap);
+
+		expect(groups.map((group) => group.projectPath)).toEqual([
+			"/project/a",
+			"/project/b",
+			"/project/c",
+		]);
+	});
+
+	it("falls back to createdAt desc when sortOrder values match", () => {
+		const items: SessionListItem[] = [
+			createSessionListItem("session-a", "/project/a", "project-a"),
+			createSessionListItem("session-b", "/project/b", "project-b"),
+			createSessionListItem("session-c", "/project/c", "project-c"),
+		];
+
+		const projectCreatedAtMap = new Map<string, Date>([
+			["/project/a", new Date("2024-01-01T00:00:00.000Z")],
+			["/project/b", new Date("2024-03-01T00:00:00.000Z")],
+			["/project/c", new Date("2024-02-01T00:00:00.000Z")],
+		]);
+		const projectSortOrderMap = new Map<string, number>([
+			["/project/a", 0],
+			["/project/b", 0],
+			["/project/c", 0],
+		]);
+
+		const groups = createSessionGroups(items, projectCreatedAtMap, projectSortOrderMap);
+
+		expect(groups.map((group) => group.projectPath)).toEqual([
+			"/project/b",
+			"/project/c",
+			"/project/a",
+		]);
 	});
 });
 

--- a/packages/desktop/src/lib/acp/components/session-list/__tests__/sidebar-reorder-state.test.ts
+++ b/packages/desktop/src/lib/acp/components/session-list/__tests__/sidebar-reorder-state.test.ts
@@ -4,7 +4,7 @@ import {
 SidebarReorderState,
 type SidebarReorderGroupElement,
 type SidebarReorderRect,
-} from "../sidebar-reorder-state.svelte.js";
+} from "../sidebar-reorder-state.js";
 import type { SessionGroup } from "../session-list-types.js";
 
 function createRect(top: number, height = 40): SidebarReorderRect {

--- a/packages/desktop/src/lib/acp/components/session-list/__tests__/sidebar-reorder-state.test.ts
+++ b/packages/desktop/src/lib/acp/components/session-list/__tests__/sidebar-reorder-state.test.ts
@@ -1,0 +1,236 @@
+import { describe, expect, it } from "bun:test";
+
+import {
+SidebarReorderState,
+type SidebarReorderGroupElement,
+type SidebarReorderRect,
+} from "../sidebar-reorder-state.svelte.js";
+import type { SessionGroup } from "../session-list-types.js";
+
+function createRect(top: number, height = 40): SidebarReorderRect {
+return {
+top,
+bottom: top + height,
+};
+}
+
+function createGroupElement(projectPath: string, top: number): SidebarReorderGroupElement {
+return {
+projectPath,
+element: {
+getBoundingClientRect() {
+return createRect(top);
+},
+},
+};
+}
+
+function createGroup(projectPath: string): SessionGroup {
+return {
+projectPath,
+projectName: projectPath,
+projectColor: undefined,
+projectIconSrc: null,
+sessions: [],
+};
+}
+
+describe("SidebarReorderState", () => {
+it("computes the insertion index from group midpoints while excluding the dragged project", () => {
+const state = new SidebarReorderState();
+state.startDrag(
+"/projects/path-0",
+[
+createGroupElement("/projects/path-0", 0),
+createGroupElement("/projects/path-1", 50),
+createGroupElement("/projects/path-2", 100),
+],
+new Set<string>()
+);
+
+state.updatePointer(70, createRect(0, 180), [createRect(0), createRect(50), createRect(100)]);
+
+expect(state.insertionIndex).toBe(1);
+});
+
+it("starts dragging and records the dragged project path", () => {
+const state = new SidebarReorderState();
+state.startDrag(
+"/projects/path-1",
+[
+createGroupElement("/projects/path-0", 0),
+createGroupElement("/projects/path-1", 50),
+],
+new Set<string>()
+);
+
+expect(state.isDragging).toBeTrue();
+expect(state.draggedProjectPath).toBe("/projects/path-1");
+});
+
+it("commits a downward drop using the filtered insertion index", () => {
+const state = new SidebarReorderState();
+state.startDrag(
+"/projects/path-0",
+[
+createGroupElement("/projects/path-0", 0),
+createGroupElement("/projects/path-1", 50),
+createGroupElement("/projects/path-2", 100),
+],
+new Set<string>()
+);
+state.updatePointer(160, createRect(0, 180), [createRect(0), createRect(50), createRect(100)]);
+
+const orderedPaths = state.commitDrop([
+createGroup("/projects/path-0"),
+createGroup("/projects/path-1"),
+createGroup("/projects/path-2"),
+]);
+
+expect(orderedPaths).toEqual([
+"/projects/path-1",
+"/projects/path-2",
+"/projects/path-0",
+]);
+expect(state.isDragging).toBeFalse();
+});
+
+it("cancels dragging and clears transient drag state", () => {
+const state = new SidebarReorderState();
+state.startDrag(
+"/projects/path-0",
+[
+createGroupElement("/projects/path-0", 0),
+createGroupElement("/projects/path-1", 50),
+],
+new Set<string>()
+);
+state.updatePointer(25, createRect(0, 120), [createRect(0), createRect(50)]);
+
+state.cancelDrag();
+
+expect(state.isDragging).toBeFalse();
+expect(state.draggedProjectPath).toBeNull();
+expect(state.insertionIndex).toBeNull();
+expect(state.ghostY).toBeNull();
+expect(state.autoScrollDirection).toBeNull();
+});
+
+it("returns the original order when dropped in the same position", () => {
+const state = new SidebarReorderState();
+state.startDrag(
+"/projects/path-1",
+[
+createGroupElement("/projects/path-0", 0),
+createGroupElement("/projects/path-1", 50),
+createGroupElement("/projects/path-2", 100),
+],
+new Set<string>()
+);
+
+const orderedPaths = state.commitDrop([
+createGroup("/projects/path-0"),
+createGroup("/projects/path-1"),
+createGroup("/projects/path-2"),
+]);
+
+expect(orderedPaths).toEqual([
+"/projects/path-0",
+"/projects/path-1",
+"/projects/path-2",
+]);
+});
+
+it("places the insertion index at the start when the pointer is above the first group", () => {
+const state = new SidebarReorderState();
+state.startDrag(
+"/projects/path-2",
+[
+createGroupElement("/projects/path-0", 0),
+createGroupElement("/projects/path-1", 50),
+createGroupElement("/projects/path-2", 100),
+],
+new Set<string>()
+);
+
+state.updatePointer(-10, createRect(0, 180), [createRect(0), createRect(50), createRect(100)]);
+
+expect(state.insertionIndex).toBe(0);
+});
+
+it("places the insertion index at the end when the pointer is below the last group", () => {
+const state = new SidebarReorderState();
+state.startDrag(
+"/projects/path-0",
+[
+createGroupElement("/projects/path-0", 0),
+createGroupElement("/projects/path-1", 50),
+createGroupElement("/projects/path-2", 100),
+],
+new Set<string>()
+);
+
+state.updatePointer(200, createRect(0, 180), [createRect(0), createRect(50), createRect(100)]);
+
+expect(state.insertionIndex).toBe(2);
+});
+
+it("returns a single-element order unchanged", () => {
+const state = new SidebarReorderState();
+state.startDrag(
+"/projects/path-0",
+[createGroupElement("/projects/path-0", 0)],
+new Set<string>()
+);
+
+const orderedPaths = state.commitDrop([createGroup("/projects/path-0")]);
+
+expect(orderedPaths).toEqual(["/projects/path-0"]);
+});
+
+it("keeps the pre-drag expansion snapshot available after commit and cancel", () => {
+const commitState = new SidebarReorderState();
+commitState.startDrag(
+"/projects/path-0",
+[
+createGroupElement("/projects/path-0", 0),
+createGroupElement("/projects/path-1", 50),
+],
+new Set<string>()
+);
+commitState.commitDrop([createGroup("/projects/path-0"), createGroup("/projects/path-1")]);
+
+expect(Array.from(commitState.preCollapsedPaths)).toEqual(["/projects/path-0"]);
+
+const cancelState = new SidebarReorderState();
+cancelState.startDrag(
+"/projects/path-1",
+[
+createGroupElement("/projects/path-0", 0),
+createGroupElement("/projects/path-1", 50),
+],
+new Set<string>(["/projects/path-0"])
+);
+cancelState.cancelDrag();
+
+expect(Array.from(cancelState.preCollapsedPaths)).toEqual(["/projects/path-1"]);
+});
+
+it("sets auto-scroll direction near the container edges", () => {
+const state = new SidebarReorderState();
+state.startDrag(
+"/projects/path-0",
+[
+createGroupElement("/projects/path-0", 0),
+createGroupElement("/projects/path-1", 50),
+],
+new Set<string>()
+);
+
+state.updatePointer(10, createRect(0, 180), [createRect(0), createRect(50)]);
+expect(state.autoScrollDirection).toBe("up");
+
+state.updatePointer(175, createRect(0, 180), [createRect(0), createRect(50)]);
+expect(state.autoScrollDirection).toBe("down");
+});
+});

--- a/packages/desktop/src/lib/acp/components/session-list/session-list-logic.ts
+++ b/packages/desktop/src/lib/acp/components/session-list/session-list-logic.ts
@@ -34,7 +34,7 @@ import { truncateText } from "../../utils/tool-state-utils.js";
  */
 export function createLoadingSessionGroups(projects: readonly Project[]): SessionGroup[] {
 	return projects
-		.toSorted((a, b) => b.createdAt.getTime() - a.createdAt.getTime())
+		.toSorted((a, b) => compareProjectOrder(a.sortOrder, a.createdAt, b.sortOrder, b.createdAt))
 		.map((project) => ({
 			projectPath: project.path,
 			projectName: project.name,
@@ -447,6 +447,7 @@ export function buildSessionRows(
 export function createSessionGroups(
 	items: readonly SessionListItem[],
 	projectCreatedAtMap?: Map<string, Date>,
+	projectSortOrderMap?: Map<string, number>,
 	allProjects?: readonly Project[]
 ): SessionGroup[] {
 	const groupMap = new Map<string, SessionGroup>();
@@ -479,10 +480,30 @@ export function createSessionGroups(
 		group.sessions.push(item);
 	}
 
-	// Sort groups by project creation date (when project was added)
+	// Sort groups by persisted project order, with creation date as tie-breaker.
 	return Array.from(groupMap.values()).sort((a, b) => {
-		const aTime = projectCreatedAtMap?.get(a.projectPath)?.getTime() ?? 0;
-		const bTime = projectCreatedAtMap?.get(b.projectPath)?.getTime() ?? 0;
-		return bTime - aTime;
+		const aCreatedAt = projectCreatedAtMap?.get(a.projectPath);
+		const bCreatedAt = projectCreatedAtMap?.get(b.projectPath);
+		const aSortOrder = projectSortOrderMap?.get(a.projectPath);
+		const bSortOrder = projectSortOrderMap?.get(b.projectPath);
+		return compareProjectOrder(aSortOrder, aCreatedAt, bSortOrder, bCreatedAt);
 	});
+}
+
+function compareProjectOrder(
+	aSortOrder: number | undefined,
+	aCreatedAt: Date | undefined,
+	bSortOrder: number | undefined,
+	bCreatedAt: Date | undefined
+): number {
+	const normalizedASortOrder = aSortOrder ?? Number.POSITIVE_INFINITY;
+	const normalizedBSortOrder = bSortOrder ?? Number.POSITIVE_INFINITY;
+
+	if (normalizedASortOrder !== normalizedBSortOrder) {
+		return normalizedASortOrder - normalizedBSortOrder;
+	}
+
+	const aTime = aCreatedAt?.getTime() ?? 0;
+	const bTime = bCreatedAt?.getTime() ?? 0;
+	return bTime - aTime;
 }

--- a/packages/desktop/src/lib/acp/components/session-list/session-list-ui.svelte
+++ b/packages/desktop/src/lib/acp/components/session-list/session-list-ui.svelte
@@ -1032,6 +1032,9 @@ function getMovedProjectOrder(projectPath: string, offset: -1 | 1): string[] | n
 
 async function focusProjectContextTrigger(projectPath: string): Promise<void> {
 	await tick();
+	// V1 intentionally returns focus to the outer header wrapper instead of the bits-ui
+	// ContextMenu.Trigger because the wrapper is reliably focusable and still supports
+	// reopening the context menu with Shift+F10 for consecutive keyboard moves.
 	projectHeaderFocusTargets.get(projectPath)?.focus();
 }
 
@@ -1377,7 +1380,7 @@ function openCreateBranchDialog(projectPath: string): void {
 											projectName={group.projectName}
 											projectIconSrc={group.projectIconSrc}
 											expanded={true}
-											draggable={true}
+											draggable={false}
 											onGripPointerDown={(event) => handleProjectGripPointerDown(group.projectPath, event)}
 											class="group min-w-0 flex-1 cursor-pointer transition-colors"
 										>

--- a/packages/desktop/src/lib/acp/components/session-list/session-list-ui.svelte
+++ b/packages/desktop/src/lib/acp/components/session-list/session-list-ui.svelte
@@ -9,7 +9,9 @@ import { IconPlus } from "@tabler/icons-svelte";
 import { listen } from "@tauri-apps/api/event";
 import { DropdownMenu } from "bits-ui";
 import { ArrowsClockwise } from "phosphor-svelte";
+import { ArrowDown } from "phosphor-svelte";
 import { ArrowCounterClockwise } from "phosphor-svelte";
+import { ArrowUp } from "phosphor-svelte";
 import { BookOpen } from "phosphor-svelte";
 import { Bug } from "phosphor-svelte";
 import { Check } from "phosphor-svelte";
@@ -21,6 +23,7 @@ import { Sparkle } from "phosphor-svelte";
 import { TestTube } from "phosphor-svelte";
 import { Wrench } from "phosphor-svelte";
 import type { Component } from "svelte";
+import { tick } from "svelte";
 import { SvelteMap, SvelteSet } from "svelte/reactivity";
 import { toast } from "svelte-sonner";
 import type { SessionDisplayItem } from "$lib/acp/types/thread-display-item.js";
@@ -168,10 +171,12 @@ const expandedProjects = $derived(
 );
 const reorderState = new SidebarReorderState();
 const projectGroupElements = new Map<string, HTMLDivElement>();
+const projectHeaderFocusTargets = new Map<string, HTMLDivElement>();
 let sidebarContainer = $state<HTMLDivElement | null>(null);
 let dragPointerId = $state<number | null>(null);
 let lastDragPointerY = $state<number | null>(null);
 let autoScrollFrame = 0;
+let reorderAnnouncement = $state("");
 
 // Per-project files state
 const filesByProject = new SvelteMap<string, FileTreeNode[]>();
@@ -292,6 +297,15 @@ function registerProjectGroupElement(projectPath: string, node: HTMLDivElement |
 	projectGroupElements.set(projectPath, node);
 }
 
+function registerProjectHeaderFocusTarget(projectPath: string, node: HTMLDivElement | null): void {
+	if (node === null) {
+		projectHeaderFocusTargets.delete(projectPath);
+		return;
+	}
+
+	projectHeaderFocusTargets.set(projectPath, node);
+}
+
 function projectGroupElement(
 	node: HTMLDivElement,
 	projectPath: string
@@ -311,6 +325,29 @@ function projectGroupElement(
 		},
 		destroy(): void {
 			projectGroupElements.delete(currentProjectPath);
+		},
+	};
+}
+
+function projectHeaderFocusTarget(
+	node: HTMLDivElement,
+	projectPath: string
+): { update: (nextProjectPath: string) => void; destroy: () => void } {
+	let currentProjectPath = projectPath;
+	registerProjectHeaderFocusTarget(currentProjectPath, node);
+
+	return {
+		update(nextProjectPath: string): void {
+			if (nextProjectPath === currentProjectPath) {
+				return;
+			}
+
+			projectHeaderFocusTargets.delete(currentProjectPath);
+			currentProjectPath = nextProjectPath;
+			registerProjectHeaderFocusTarget(currentProjectPath, node);
+		},
+		destroy(): void {
+			projectHeaderFocusTargets.delete(currentProjectPath);
 		},
 	};
 }
@@ -911,13 +948,113 @@ function handleProjectGripPointerDown(projectPath: string, event: PointerEvent):
 	updateReorderPointer(event.clientY);
 }
 
+function getProjectGroupByPath(projectPath: string): SessionGroup | null {
+	for (const group of sessionGroups) {
+		if (group.projectPath === projectPath) {
+			return group;
+		}
+	}
+
+	return null;
+}
+
+function getCurrentProjectOrder(): string[] {
+	const orderedPaths: string[] = [];
+	for (const group of sessionGroups) {
+		orderedPaths.push(group.projectPath);
+	}
+
+	return orderedPaths;
+}
+
+function isProjectOrderUnchanged(orderedPaths: string[]): boolean {
+	if (orderedPaths.length !== sessionGroups.length) {
+		return false;
+	}
+
+	for (let index = 0; index < orderedPaths.length; index += 1) {
+		if (orderedPaths[index] !== sessionGroups[index]?.projectPath) {
+			return false;
+		}
+	}
+
+	return true;
+}
+
+function announceProjectReorder(projectPath: string, orderedPaths: string[]): void {
+	const group = getProjectGroupByPath(projectPath);
+	const position = orderedPaths.indexOf(projectPath);
+
+	if (group === null || position < 0) {
+		return;
+	}
+
+	reorderAnnouncement = "";
+	queueMicrotask(() => {
+		reorderAnnouncement = m.project_reorder_announcement({
+			projectName: group.projectName,
+			position: position + 1,
+			total: orderedPaths.length,
+		});
+	});
+}
+
+function applyProjectOrder(projectPath: string, orderedPaths: string[]): void {
+	if (onReorderProjects === undefined || isProjectOrderUnchanged(orderedPaths)) {
+		return;
+	}
+
+	announceProjectReorder(projectPath, orderedPaths);
+	onReorderProjects(orderedPaths);
+}
+
+function getMovedProjectOrder(projectPath: string, offset: -1 | 1): string[] | null {
+	const orderedPaths = getCurrentProjectOrder();
+	const currentIndex = orderedPaths.indexOf(projectPath);
+	const nextIndex = currentIndex + offset;
+
+	if (currentIndex < 0 || nextIndex < 0 || nextIndex >= orderedPaths.length) {
+		return null;
+	}
+
+	const currentPath = orderedPaths[currentIndex];
+	const nextPath = orderedPaths[nextIndex];
+
+	if (currentPath === undefined || nextPath === undefined) {
+		return null;
+	}
+
+	orderedPaths[currentIndex] = nextPath;
+	orderedPaths[nextIndex] = currentPath;
+
+	return orderedPaths;
+}
+
+async function focusProjectContextTrigger(projectPath: string): Promise<void> {
+	await tick();
+	projectHeaderFocusTargets.get(projectPath)?.focus();
+}
+
+async function handleProjectContextMove(projectPath: string, offset: -1 | 1): Promise<void> {
+	const orderedPaths = getMovedProjectOrder(projectPath, offset);
+
+	if (orderedPaths === null) {
+		return;
+	}
+
+	applyProjectOrder(projectPath, orderedPaths);
+	await focusProjectContextTrigger(projectPath);
+}
+
 function finishProjectReorder(shouldCommit: boolean): void {
 	const draggedProjectPath = reorderState.draggedProjectPath;
 
 	if (shouldCommit) {
 		const orderedPaths = reorderState.commitDrop(sessionGroups);
 		restoreDraggedProjectExpansion(draggedProjectPath);
-		onReorderProjects?.(orderedPaths);
+		if (draggedProjectPath !== null) {
+			applyProjectOrder(draggedProjectPath, orderedPaths);
+		}
 	} else {
 		reorderState.cancelDrag();
 		restoreDraggedProjectExpansion(draggedProjectPath);
@@ -1181,12 +1318,13 @@ function openCreateBranchDialog(projectPath: string): void {
 		<!-- Initial loading (no sessions cached yet): real project headers + session list skeleton -->
 		{#if sessionGroups.length > 0}
 			<div class="flex flex-col flex-1 min-h-0 gap-0.5">
-				{#each sessionGroups as group (group.projectPath)}
+				{#each sessionGroups as group, projectIndex (group.projectPath)}
 					{@const viewMode = getProjectViewMode(group.projectPath)}
 					<div class="flex min-w-0 flex-col overflow-hidden rounded-md bg-card/75">
 						<!-- Real project header (only sessions are loading) -->
 						<!-- svelte-ignore a11y_no_noninteractive_tabindex -->
 						<div
+							use:projectHeaderFocusTarget={group.projectPath}
 							class="shrink-0 flex items-center"
 							role={projectPathShowingAgentStrip === group.projectPath ? undefined : "button"}
 							tabindex={projectPathShowingAgentStrip === group.projectPath ? undefined : 0}
@@ -1305,6 +1443,29 @@ function openCreateBranchDialog(projectPath: string): void {
 										</ProjectHeader>
 									</ContextMenu.Trigger>
 									<ContextMenu.Content class="min-w-[180px] p-1 text-[11px]">
+										<ContextMenu.Item
+											disabled={onReorderProjects === undefined || projectIndex === 0}
+											onSelect={() => {
+												void handleProjectContextMove(group.projectPath, -1);
+											}}
+										>
+											<ArrowUp class="mr-2 h-3.5 w-3.5" weight="bold" />
+											{m.project_move_up()}
+										</ContextMenu.Item>
+										<ContextMenu.Item
+											disabled={
+												onReorderProjects === undefined || projectIndex === sessionGroups.length - 1
+											}
+											onSelect={() => {
+												void handleProjectContextMove(group.projectPath, 1);
+											}}
+										>
+											<ArrowDown class="mr-2 h-3.5 w-3.5" weight="bold" />
+											{m.project_move_down()}
+										</ContextMenu.Item>
+										{#if onChangeProjectIcon || (onResetProjectIcon && group.projectIconSrc)}
+											<ContextMenu.Separator />
+										{/if}
 										{#if onChangeProjectIcon}
 											<ContextMenu.Item onclick={() => onChangeProjectIcon(group.projectPath)}>
 												<ImageSquare class="mr-2 h-3.5 w-3.5" weight="fill" />
@@ -1341,7 +1502,7 @@ function openCreateBranchDialog(projectPath: string): void {
 		{@const expandedCount = expandedProjects.size}
 		{@const maxHeightPercent = expandedCount > 0 ? 100 / expandedCount : 100}
 		<div class="relative flex flex-col flex-1 min-h-0 gap-0.5">
-			{#each sessionGroups as group (group.projectPath)}
+			{#each sessionGroups as group, projectIndex (group.projectPath)}
 				{@const isExpanded = expandedProjects.has(group.projectPath)}
 				{@const viewMode = getProjectViewMode(group.projectPath)}
 				{@const filesLoading = loadingFilesProjects.has(group.projectPath)}
@@ -1357,6 +1518,7 @@ function openCreateBranchDialog(projectPath: string): void {
 				<!-- Project header -->
 				<!-- svelte-ignore a11y_no_noninteractive_tabindex -->
 				<div
+					use:projectHeaderFocusTarget={group.projectPath}
 					class="shrink-0 flex items-center"
 					role={projectPathShowingAgentStrip === group.projectPath ? undefined : "button"}
 					tabindex={projectPathShowingAgentStrip === group.projectPath ? undefined : 0}
@@ -1475,6 +1637,27 @@ function openCreateBranchDialog(projectPath: string): void {
 								</ProjectHeader>
 							</ContextMenu.Trigger>
 							<ContextMenu.Content class="min-w-[180px] p-1 text-[11px]">
+								<ContextMenu.Item
+									disabled={onReorderProjects === undefined || projectIndex === 0}
+									onSelect={() => {
+										void handleProjectContextMove(group.projectPath, -1);
+									}}
+								>
+									<ArrowUp class="mr-2 h-3.5 w-3.5" weight="bold" />
+									{m.project_move_up()}
+								</ContextMenu.Item>
+								<ContextMenu.Item
+									disabled={onReorderProjects === undefined || projectIndex === sessionGroups.length - 1}
+									onSelect={() => {
+										void handleProjectContextMove(group.projectPath, 1);
+									}}
+								>
+									<ArrowDown class="mr-2 h-3.5 w-3.5" weight="bold" />
+									{m.project_move_down()}
+								</ContextMenu.Item>
+								{#if onChangeProjectIcon || (onResetProjectIcon && group.projectIconSrc)}
+									<ContextMenu.Separator />
+								{/if}
 								{#if onChangeProjectIcon}
 									<ContextMenu.Item onclick={() => onChangeProjectIcon(group.projectPath)}>
 										<ImageSquare class="mr-2 h-3.5 w-3.5" weight="fill" />
@@ -1822,6 +2005,7 @@ function openCreateBranchDialog(projectPath: string): void {
 			/>
 		</div>
 	{/if}
+	<span class="sr-only" role="status" aria-live="polite">{reorderAnnouncement}</span>
 </div>
 
 <!-- New file dialog -->

--- a/packages/desktop/src/lib/acp/components/session-list/session-list-ui.svelte
+++ b/packages/desktop/src/lib/acp/components/session-list/session-list-ui.svelte
@@ -41,6 +41,7 @@ import type { FileGitStatus } from "$lib/services/converted-session-types.js";
 import type { GitRemoteStatus } from "$lib/utils/tauri-client/git.js";
 import { revealInFinder, tauriClient } from "$lib/utils/tauri-client.js";
 import type { AgentInfo } from "../../logic/agent-manager.js";
+import { TAG_COLORS } from "../../utils/colors.js";
 import { createFileTree, flattenFileTree } from "../file-list/file-list-logic.js";
 import type { FileTreeNode } from "../file-list/file-list-types.js";
 import FileTreeItem from "../file-list/file-tree-item.svelte";
@@ -54,6 +55,8 @@ import {
 	getSessionListVisibleCount,
 	isSessionListNearBottom,
 } from "./session-list-logic.js";
+import type { SidebarReorderGroupElement } from "./sidebar-reorder-state.svelte.js";
+import { SidebarReorderState } from "./sidebar-reorder-state.svelte.js";
 import type { SessionGroup, SessionListItem } from "./session-list-types.js";
 import VirtualizedSessionList from "./virtualized-session-list.svelte";
 
@@ -111,6 +114,8 @@ interface Props {
 	onExportMarkdown?: (sessionId: string) => void | Promise<void>;
 	/** Called when user exports session as JSON */
 	onExportJson?: (sessionId: string) => void | Promise<void>;
+	/** Called when project order changes from sidebar drag/drop */
+	onReorderProjects?: (orderedPaths: string[]) => void;
 }
 
 let {
@@ -147,7 +152,12 @@ let {
 	onRenameSession,
 	onExportMarkdown,
 	onExportJson,
+	onReorderProjects,
 }: Props = $props();
+
+const REORDER_AUTO_SCROLL_STEP_PX = 14;
+const REORDER_GHOST_OFFSET_X_PX = 10;
+const REORDER_GHOST_FALLBACK_COLOR = TAG_COLORS.length > 0 ? TAG_COLORS[0] : "#FF5D5A";
 
 // Project collapse state (hydrated from persisted state in one-time effect)
 const collapsedProjects = new SvelteSet<string>();
@@ -156,6 +166,12 @@ const expandedProjects = $derived(
 		sessionGroups.map((group) => group.projectPath).filter((path) => !collapsedProjects.has(path))
 	)
 );
+const reorderState = new SidebarReorderState();
+const projectGroupElements = new Map<string, HTMLDivElement>();
+let sidebarContainer = $state<HTMLDivElement | null>(null);
+let dragPointerId = $state<number | null>(null);
+let lastDragPointerY = $state<number | null>(null);
+let autoScrollFrame = 0;
 
 // Per-project files state
 const filesByProject = new SvelteMap<string, FileTreeNode[]>();
@@ -260,7 +276,142 @@ function toggleProject(projectPath: string) {
 			openBranchPickerProject = null;
 		}
 	}
-	onCollapsedProjectPathsChange?.([...collapsedProjects]);
+	notifyCollapsedProjectPathsChange();
+}
+
+function notifyCollapsedProjectPathsChange(): void {
+	onCollapsedProjectPathsChange?.(Array.from(collapsedProjects));
+}
+
+function registerProjectGroupElement(projectPath: string, node: HTMLDivElement | null): void {
+	if (node === null) {
+		projectGroupElements.delete(projectPath);
+		return;
+	}
+
+	projectGroupElements.set(projectPath, node);
+}
+
+function projectGroupElement(
+	node: HTMLDivElement,
+	projectPath: string
+): { update: (nextProjectPath: string) => void; destroy: () => void } {
+	let currentProjectPath = projectPath;
+	registerProjectGroupElement(currentProjectPath, node);
+
+	return {
+		update(nextProjectPath: string): void {
+			if (nextProjectPath === currentProjectPath) {
+				return;
+			}
+
+			projectGroupElements.delete(currentProjectPath);
+			currentProjectPath = nextProjectPath;
+			registerProjectGroupElement(currentProjectPath, node);
+		},
+		destroy(): void {
+			projectGroupElements.delete(currentProjectPath);
+		},
+	};
+}
+
+function getReorderGroupElements(): SidebarReorderGroupElement[] {
+	const elements: SidebarReorderGroupElement[] = [];
+	for (const group of sessionGroups) {
+		const element = projectGroupElements.get(group.projectPath);
+		if (element === undefined) {
+			continue;
+		}
+
+		elements.push({
+			projectPath: group.projectPath,
+			element,
+		});
+	}
+
+	return elements;
+}
+
+function getReorderGroupRects(): { top: number; bottom: number }[] {
+	const rects: { top: number; bottom: number }[] = [];
+	for (const group of getReorderGroupElements()) {
+		rects.push(group.element.getBoundingClientRect());
+	}
+	return rects;
+}
+
+function restoreDraggedProjectExpansion(projectPath: string | null): void {
+	if (projectPath === null) {
+		return;
+	}
+
+	if (reorderState.preCollapsedPaths.has(projectPath)) {
+		collapsedProjects.delete(projectPath);
+	} else {
+		collapsedProjects.add(projectPath);
+	}
+	notifyCollapsedProjectPathsChange();
+}
+
+function updateReorderPointer(clientY: number): void {
+	if (!reorderState.isDragging || sidebarContainer === null) {
+		return;
+	}
+
+	const containerRect = sidebarContainer.getBoundingClientRect();
+	reorderState.updatePointer(
+		clientY,
+		{ top: containerRect.top, bottom: containerRect.bottom },
+		getReorderGroupRects()
+	);
+	syncAutoScrollLoop();
+}
+
+function stopAutoScrollLoop(): void {
+	if (autoScrollFrame === 0) {
+		return;
+	}
+
+	cancelAnimationFrame(autoScrollFrame);
+	autoScrollFrame = 0;
+}
+
+function runAutoScrollStep(): void {
+	autoScrollFrame = 0;
+	if (
+		!reorderState.isDragging ||
+		reorderState.autoScrollDirection === null ||
+		sidebarContainer === null
+	) {
+		return;
+	}
+
+	const nextScrollTop =
+		reorderState.autoScrollDirection === "up"
+			? sidebarContainer.scrollTop - REORDER_AUTO_SCROLL_STEP_PX
+			: sidebarContainer.scrollTop + REORDER_AUTO_SCROLL_STEP_PX;
+	sidebarContainer.scrollTop = nextScrollTop;
+
+	if (lastDragPointerY !== null) {
+		updateReorderPointer(lastDragPointerY);
+	}
+
+	if (reorderState.autoScrollDirection !== null) {
+		autoScrollFrame = requestAnimationFrame(runAutoScrollStep);
+	}
+}
+
+function syncAutoScrollLoop(): void {
+	if (!reorderState.isDragging || reorderState.autoScrollDirection === null) {
+		stopAutoScrollLoop();
+		return;
+	}
+
+	if (autoScrollFrame !== 0) {
+		return;
+	}
+
+	autoScrollFrame = requestAnimationFrame(runAutoScrollStep);
 }
 
 function setProjectViewMode(projectPath: string, mode: ProjectViewMode) {
@@ -725,8 +876,177 @@ function handleOpenGitPanel(event: MouseEvent, projectPath: string) {
 }
 
 function handleProjectHeaderClick(projectPath: string) {
+	if (reorderState.isDragging) {
+		return;
+	}
 	toggleProject(projectPath);
 }
+
+function releaseSidebarPointerCapture(pointerId: number | null): void {
+	if (sidebarContainer === null || pointerId === null) {
+		return;
+	}
+
+	if (sidebarContainer.hasPointerCapture(pointerId)) {
+		sidebarContainer.releasePointerCapture(pointerId);
+	}
+}
+
+function handleProjectGripPointerDown(projectPath: string, event: PointerEvent): void {
+	if (event.button !== 0 || sidebarContainer === null || reorderState.isDragging) {
+		return;
+	}
+
+	const groupElements = getReorderGroupElements();
+	if (groupElements.length === 0) {
+		return;
+	}
+
+	lastDragPointerY = event.clientY;
+	dragPointerId = event.pointerId;
+	reorderState.startDrag(projectPath, groupElements, collapsedProjects);
+	collapsedProjects.add(projectPath);
+	notifyCollapsedProjectPathsChange();
+	sidebarContainer.setPointerCapture(event.pointerId);
+	updateReorderPointer(event.clientY);
+}
+
+function finishProjectReorder(shouldCommit: boolean): void {
+	const draggedProjectPath = reorderState.draggedProjectPath;
+
+	if (shouldCommit) {
+		const orderedPaths = reorderState.commitDrop(sessionGroups);
+		restoreDraggedProjectExpansion(draggedProjectPath);
+		onReorderProjects?.(orderedPaths);
+	} else {
+		reorderState.cancelDrag();
+		restoreDraggedProjectExpansion(draggedProjectPath);
+	}
+
+	stopAutoScrollLoop();
+	lastDragPointerY = null;
+	releaseSidebarPointerCapture(dragPointerId);
+	dragPointerId = null;
+}
+
+function handleSidebarPointerMove(event: PointerEvent): void {
+	if (!reorderState.isDragging) {
+		return;
+	}
+
+	lastDragPointerY = event.clientY;
+	updateReorderPointer(event.clientY);
+}
+
+function handleSidebarPointerUp(event: PointerEvent): void {
+	if (!reorderState.isDragging || sidebarContainer === null) {
+		return;
+	}
+
+	const sidebarRect = sidebarContainer.getBoundingClientRect();
+	const pointerInsideSidebar =
+		event.clientX >= sidebarRect.left &&
+		event.clientX <= sidebarRect.right &&
+		event.clientY >= sidebarRect.top &&
+		event.clientY <= sidebarRect.bottom;
+
+	finishProjectReorder(pointerInsideSidebar && reorderState.insertionIndex !== null);
+}
+
+function handleSidebarPointerCancel(): void {
+	if (!reorderState.isDragging) {
+		return;
+	}
+
+	finishProjectReorder(false);
+}
+
+function handleSidebarKeyDown(event: KeyboardEvent): void {
+	if (event.key !== "Escape" || !reorderState.isDragging) {
+		return;
+	}
+
+	event.preventDefault();
+	finishProjectReorder(false);
+}
+
+const draggedProjectGroup = $derived.by(() => {
+	const draggedProjectPath = reorderState.draggedProjectPath;
+	if (draggedProjectPath === null) {
+		return null;
+	}
+
+	for (const group of sessionGroups) {
+		if (group.projectPath === draggedProjectPath) {
+			return group;
+		}
+	}
+
+	return null;
+});
+
+const insertionLineTop = $derived.by(() => {
+	if (
+		!reorderState.isDragging ||
+		reorderState.insertionIndex === null ||
+		sidebarContainer === null ||
+		draggedProjectGroup === null
+	) {
+		return null;
+	}
+
+	const candidateElements: HTMLDivElement[] = [];
+	for (const group of sessionGroups) {
+		if (group.projectPath === draggedProjectGroup.projectPath) {
+			continue;
+		}
+
+		const element = projectGroupElements.get(group.projectPath);
+		if (element === undefined) {
+			continue;
+		}
+
+		candidateElements.push(element);
+	}
+
+	if (candidateElements.length === 0) {
+		return null;
+	}
+
+	const containerRect = sidebarContainer.getBoundingClientRect();
+	const targetIndex = reorderState.insertionIndex;
+	const edgeRect =
+		targetIndex <= 0
+			? candidateElements[0]?.getBoundingClientRect()
+			: targetIndex >= candidateElements.length
+				? candidateElements[candidateElements.length - 1]?.getBoundingClientRect()
+				: candidateElements[targetIndex]?.getBoundingClientRect();
+
+	if (edgeRect === undefined) {
+		return null;
+	}
+
+	const viewportTop =
+		targetIndex <= 0
+			? edgeRect.top
+			: targetIndex >= candidateElements.length
+				? edgeRect.bottom
+				: edgeRect.top;
+
+	return viewportTop - containerRect.top + sidebarContainer.scrollTop - 1;
+});
+
+const ghostOverlayLeft = $derived.by(() => {
+	if (sidebarContainer === null) {
+		return null;
+	}
+
+	return sidebarContainer.getBoundingClientRect().left + REORDER_GHOST_OFFSET_X_PX;
+});
+
+const ghostOverlayColor = $derived(
+	draggedProjectGroup?.projectColor ? draggedProjectGroup.projectColor : REORDER_GHOST_FALLBACK_COLOR
+);
 
 // ─── Branch picker ───────────────────────────────────────────────
 
@@ -847,7 +1167,16 @@ function openCreateBranchDialog(projectPath: string): void {
 }
 </script>
 
-<div class="flex h-full flex-col gap-2" data-thread-list-scrollable>
+<svelte:window onkeydown={handleSidebarKeyDown} />
+
+<div
+	class="relative flex h-full min-h-0 flex-col gap-2 overflow-y-auto outline-none"
+	data-thread-list-scrollable
+	bind:this={sidebarContainer}
+	onpointermove={handleSidebarPointerMove}
+	onpointerup={handleSidebarPointerUp}
+	onpointercancel={handleSidebarPointerCancel}
+>
 	{#if loading && !scanning && sessionGroups.every((g) => g.sessions.length === 0)}
 		<!-- Initial loading (no sessions cached yet): real project headers + session list skeleton -->
 		{#if sessionGroups.length > 0}
@@ -910,6 +1239,8 @@ function openCreateBranchDialog(projectPath: string): void {
 											projectName={group.projectName}
 											projectIconSrc={group.projectIconSrc}
 											expanded={true}
+											draggable={true}
+											onGripPointerDown={(event) => handleProjectGripPointerDown(group.projectPath, event)}
 											class="group min-w-0 flex-1 cursor-pointer transition-colors"
 										>
 											{#snippet actions()}
@@ -1009,7 +1340,7 @@ function openCreateBranchDialog(projectPath: string): void {
 		<!-- Session groups - expanded sections share available space equally -->
 		{@const expandedCount = expandedProjects.size}
 		{@const maxHeightPercent = expandedCount > 0 ? 100 / expandedCount : 100}
-		<div class="flex flex-col flex-1 min-h-0 gap-0.5">
+		<div class="relative flex flex-col flex-1 min-h-0 gap-0.5">
 			{#each sessionGroups as group (group.projectPath)}
 				{@const isExpanded = expandedProjects.has(group.projectPath)}
 				{@const viewMode = getProjectViewMode(group.projectPath)}
@@ -1021,6 +1352,7 @@ function openCreateBranchDialog(projectPath: string): void {
 					style={isExpanded
 						? `flex: 0 1 auto; max-height: ${maxHeightPercent}%; min-height: 0;`
 						: "flex: 0 0 auto;"}
+					use:projectGroupElement={group.projectPath}
 				>
 				<!-- Project header -->
 				<!-- svelte-ignore a11y_no_noninteractive_tabindex -->
@@ -1077,6 +1409,8 @@ function openCreateBranchDialog(projectPath: string): void {
 									projectName={group.projectName}
 									projectIconSrc={group.projectIconSrc}
 									expanded={isExpanded}
+									draggable={true}
+									onGripPointerDown={(event) => handleProjectGripPointerDown(group.projectPath, event)}
 									class="group min-w-0 flex-1 cursor-pointer transition-colors"
 								>
 									{#snippet actions()}
@@ -1454,6 +1788,14 @@ function openCreateBranchDialog(projectPath: string): void {
 				</div>
 			{/each}
 
+			{#if insertionLineTop !== null}
+				<div
+					aria-hidden="true"
+					class="pointer-events-none absolute left-2 right-2 z-20 h-0.5 rounded-full bg-primary"
+					style={`top: ${insertionLineTop}px;`}
+				></div>
+			{/if}
+
 			<!-- Trailing project card skeletons while scanning -->
 			{#if scanning && sessionGroups.length > 0}
 				<div class="shrink-0 flex flex-col gap-0.5 opacity-50">
@@ -1462,6 +1804,22 @@ function openCreateBranchDialog(projectPath: string): void {
 					{/each}
 				</div>
 			{/if}
+		</div>
+	{/if}
+
+	{#if reorderState.isDragging && draggedProjectGroup !== null && reorderState.ghostY !== null && ghostOverlayLeft !== null}
+		<div
+			aria-hidden="true"
+			class="pointer-events-none fixed z-50 flex h-7 w-7 items-center justify-center rounded-md bg-card/60 opacity-50 shadow-lg backdrop-blur-sm"
+			style={`left: ${ghostOverlayLeft}px; top: ${reorderState.ghostY}px; transform: translateY(-50%);`}
+		>
+			<ProjectLetterBadge
+				name={draggedProjectGroup.projectName}
+				color={ghostOverlayColor}
+				iconSrc={draggedProjectGroup.projectIconSrc}
+				size={16}
+				draggable={true}
+			/>
 		</div>
 	{/if}
 </div>

--- a/packages/desktop/src/lib/acp/components/session-list/session-list.svelte
+++ b/packages/desktop/src/lib/acp/components/session-list/session-list.svelte
@@ -62,6 +62,8 @@ interface Props {
 	onExportMarkdown?: (sessionId: string) => void | Promise<void>;
 	/** Called when user exports session as JSON */
 	onExportJson?: (sessionId: string) => void | Promise<void>;
+	/** Called when project order changes from sidebar drag/drop */
+	onReorderProjects?: (orderedPaths: string[]) => void;
 }
 
 let {
@@ -98,6 +100,7 @@ let {
 	onRenameSession,
 	onExportMarkdown,
 	onExportJson,
+	onReorderProjects,
 }: Props = $props();
 
 // ✅ State manager for local UI state only
@@ -122,11 +125,12 @@ const projectIconSrcMap = $derived(logic.createProjectIconSrcMap(recentProjects)
 const projectNameMap = $derived(logic.createProjectNameMap(recentProjects));
 const projectCreatedAtMap = $derived(new Map(recentProjects.map((p) => [p.path, p.createdAt])));
 const projectSortOrderMap = $derived(
-	new Map(
-		recentProjects
-			.filter((project) => project.sortOrder !== undefined)
-			.map((project) => [project.path, project.sortOrder])
-	)
+	recentProjects.reduce((map, project) => {
+		if (project.sortOrder !== undefined) {
+			map.set(project.path, project.sortOrder);
+		}
+		return map;
+	}, new Map<string, number>())
 );
 
 // Filter sessions to only include those belonging to known projects
@@ -214,4 +218,5 @@ function handleCreateSessionForProject(projectPath: string, agentId?: string) {
 	onRenameSession={onRenameSession}
 	{onExportMarkdown}
 	{onExportJson}
+	{onReorderProjects}
 />

--- a/packages/desktop/src/lib/acp/components/session-list/session-list.svelte
+++ b/packages/desktop/src/lib/acp/components/session-list/session-list.svelte
@@ -121,6 +121,13 @@ const projectColorMap = $derived(logic.createProjectColorMap(recentProjects));
 const projectIconSrcMap = $derived(logic.createProjectIconSrcMap(recentProjects));
 const projectNameMap = $derived(logic.createProjectNameMap(recentProjects));
 const projectCreatedAtMap = $derived(new Map(recentProjects.map((p) => [p.path, p.createdAt])));
+const projectSortOrderMap = $derived(
+	new Map(
+		recentProjects
+			.filter((project) => project.sortOrder !== undefined)
+			.map((project) => [project.path, project.sortOrder])
+	)
+);
 
 // Filter sessions to only include those belonging to known projects
 const projectPaths = $derived(new Set(recentProjects.map((p) => p.path)));
@@ -139,7 +146,12 @@ const displayItems = $derived(
 
 const filteredItems = $derived(logic.filterItems(displayItems, state.searchQuery));
 const sessionGroupsFromData = $derived(
-	logic.createSessionGroups(filteredItems, projectCreatedAtMap, recentProjects)
+	logic.createSessionGroups(
+		filteredItems,
+		projectCreatedAtMap,
+		projectSortOrderMap,
+		recentProjects
+	)
 );
 const loadingSessionGroups = $derived(logic.createLoadingSessionGroups(recentProjects));
 // Only show skeletons on initial load (no sessions yet).

--- a/packages/desktop/src/lib/acp/components/session-list/sidebar-reorder-state.svelte.ts
+++ b/packages/desktop/src/lib/acp/components/session-list/sidebar-reorder-state.svelte.ts
@@ -1,176 +1,19 @@
 import { SvelteSet } from "svelte/reactivity";
 
-import type { SessionGroup } from "./session-list-types.js";
+import {
+	type AutoScrollDirection,
+	type SidebarReorderGroupElement,
+	type SidebarReorderRect,
+	SidebarReorderState as SidebarReorderStateBase,
+} from "./sidebar-reorder-state.js";
 
-export interface SidebarReorderRect {
-top: number;
-bottom: number;
-}
+export type { AutoScrollDirection, SidebarReorderGroupElement, SidebarReorderRect };
 
-export interface SidebarReorderGroupElement {
-projectPath: string;
-element: {
-getBoundingClientRect(): SidebarReorderRect;
-};
-}
-
-export type AutoScrollDirection = "up" | "down" | null;
-
-const AUTO_SCROLL_EDGE_THRESHOLD_PX = 48;
-
-function compareRects(a: SidebarReorderRect, b: SidebarReorderRect): number {
-if (a.top !== b.top) {
-return a.top - b.top;
-}
-
-return a.bottom - b.bottom;
-}
-
-function clamp(value: number, minimum: number, maximum: number): number {
-if (value < minimum) {
-return minimum;
-}
-
-if (value > maximum) {
-return maximum;
-}
-
-return value;
-}
-
-export class SidebarReorderState {
-isDragging = $state(false);
-draggedProjectPath = $state<string | null>(null);
-insertionIndex = $state<number | null>(null);
-ghostY = $state<number | null>(null);
-autoScrollDirection = $state<AutoScrollDirection>(null);
-preCollapsedPaths = $state(new SvelteSet<string>());
-
-private orderedProjectPaths: string[] = [];
-
-startDrag(
-projectPath: string,
-groupElements: ReadonlyArray<SidebarReorderGroupElement>,
-collapsedProjects: ReadonlySet<string>
-): void {
-this.preCollapsedPaths.clear();
-this.isDragging = true;
-this.draggedProjectPath = projectPath;
-this.autoScrollDirection = null;
-
-const orderedEntries = groupElements
-.map((groupElement) => ({
-projectPath: groupElement.projectPath,
-rect: groupElement.element.getBoundingClientRect(),
-}))
-.sort((left, right) => compareRects(left.rect, right.rect));
-
-this.orderedProjectPaths = orderedEntries.map((entry) => entry.projectPath);
-
-const sourceIndex = this.orderedProjectPaths.findIndex((path) => path === projectPath);
-this.insertionIndex = sourceIndex >= 0 ? sourceIndex : 0;
-
-const draggedEntry = orderedEntries.find((entry) => entry.projectPath === projectPath) ?? null;
-this.ghostY = draggedEntry ? draggedEntry.rect.top : null;
-
-if (!collapsedProjects.has(projectPath)) {
-this.preCollapsedPaths.add(projectPath);
-}
-}
-
-updatePointer(
-clientY: number,
-containerRect: SidebarReorderRect,
-groupRects: ReadonlyArray<SidebarReorderRect>
-): void {
-if (!this.isDragging || this.draggedProjectPath === null) {
-return;
-}
-
-this.ghostY = clientY;
-this.autoScrollDirection = this.getAutoScrollDirection(clientY, containerRect);
-
-const candidateRects: SidebarReorderRect[] = [];
-for (let index = 0; index < groupRects.length; index += 1) {
-const projectPath = this.orderedProjectPaths[index] ?? null;
-if (projectPath === this.draggedProjectPath) {
-continue;
-}
-
-candidateRects.push(groupRects[index]);
-}
-
-candidateRects.sort(compareRects);
-
-if (candidateRects.length === 0) {
-this.insertionIndex = 0;
-return;
-}
-
-let nextInsertionIndex = 0;
-for (const rect of candidateRects) {
-const midpoint = rect.top + (rect.bottom - rect.top) / 2;
-if (clientY >= midpoint) {
-nextInsertionIndex += 1;
-continue;
-}
-
-break;
-}
-
-this.insertionIndex = nextInsertionIndex;
-}
-
-commitDrop(currentGroups: ReadonlyArray<SessionGroup>): string[] {
-const originalOrder = currentGroups.map((group) => group.projectPath);
-const draggedProjectPath = this.draggedProjectPath;
-const fallbackInsertionIndex = draggedProjectPath
-? currentGroups.findIndex((group) => group.projectPath === draggedProjectPath)
-: -1;
-
-if (draggedProjectPath === null) {
-return originalOrder;
-}
-
-const remainingProjectPaths = currentGroups
-.filter((group) => group.projectPath !== draggedProjectPath)
-.map((group) => group.projectPath);
-const normalizedInsertionIndex = clamp(
-this.insertionIndex ?? Math.max(fallbackInsertionIndex, 0),
-0,
-remainingProjectPaths.length
-);
-
-remainingProjectPaths.splice(normalizedInsertionIndex, 0, draggedProjectPath);
-this.resetTransientDragState();
-return remainingProjectPaths;
-}
-
-cancelDrag(): void {
-this.resetTransientDragState();
-}
-
-private getAutoScrollDirection(
-clientY: number,
-containerRect: SidebarReorderRect
-): AutoScrollDirection {
-if (clientY <= containerRect.top + AUTO_SCROLL_EDGE_THRESHOLD_PX) {
-return "up";
-}
-
-if (clientY >= containerRect.bottom - AUTO_SCROLL_EDGE_THRESHOLD_PX) {
-return "down";
-}
-
-return null;
-}
-
-private resetTransientDragState(): void {
-this.isDragging = false;
-this.draggedProjectPath = null;
-this.insertionIndex = null;
-this.ghostY = null;
-this.autoScrollDirection = null;
-this.orderedProjectPaths = [];
-}
+export class SidebarReorderState extends SidebarReorderStateBase {
+	override isDragging = $state(false);
+	override draggedProjectPath = $state<string | null>(null);
+	override insertionIndex = $state<number | null>(null);
+	override ghostY = $state<number | null>(null);
+	override autoScrollDirection = $state<AutoScrollDirection>(null);
+	override preCollapsedPaths = new SvelteSet<string>();
 }

--- a/packages/desktop/src/lib/acp/components/session-list/sidebar-reorder-state.svelte.ts
+++ b/packages/desktop/src/lib/acp/components/session-list/sidebar-reorder-state.svelte.ts
@@ -1,0 +1,176 @@
+import { SvelteSet } from "svelte/reactivity";
+
+import type { SessionGroup } from "./session-list-types.js";
+
+export interface SidebarReorderRect {
+top: number;
+bottom: number;
+}
+
+export interface SidebarReorderGroupElement {
+projectPath: string;
+element: {
+getBoundingClientRect(): SidebarReorderRect;
+};
+}
+
+export type AutoScrollDirection = "up" | "down" | null;
+
+const AUTO_SCROLL_EDGE_THRESHOLD_PX = 48;
+
+function compareRects(a: SidebarReorderRect, b: SidebarReorderRect): number {
+if (a.top !== b.top) {
+return a.top - b.top;
+}
+
+return a.bottom - b.bottom;
+}
+
+function clamp(value: number, minimum: number, maximum: number): number {
+if (value < minimum) {
+return minimum;
+}
+
+if (value > maximum) {
+return maximum;
+}
+
+return value;
+}
+
+export class SidebarReorderState {
+isDragging = $state(false);
+draggedProjectPath = $state<string | null>(null);
+insertionIndex = $state<number | null>(null);
+ghostY = $state<number | null>(null);
+autoScrollDirection = $state<AutoScrollDirection>(null);
+preCollapsedPaths = $state(new SvelteSet<string>());
+
+private orderedProjectPaths: string[] = [];
+
+startDrag(
+projectPath: string,
+groupElements: ReadonlyArray<SidebarReorderGroupElement>,
+collapsedProjects: ReadonlySet<string>
+): void {
+this.preCollapsedPaths.clear();
+this.isDragging = true;
+this.draggedProjectPath = projectPath;
+this.autoScrollDirection = null;
+
+const orderedEntries = groupElements
+.map((groupElement) => ({
+projectPath: groupElement.projectPath,
+rect: groupElement.element.getBoundingClientRect(),
+}))
+.sort((left, right) => compareRects(left.rect, right.rect));
+
+this.orderedProjectPaths = orderedEntries.map((entry) => entry.projectPath);
+
+const sourceIndex = this.orderedProjectPaths.findIndex((path) => path === projectPath);
+this.insertionIndex = sourceIndex >= 0 ? sourceIndex : 0;
+
+const draggedEntry = orderedEntries.find((entry) => entry.projectPath === projectPath) ?? null;
+this.ghostY = draggedEntry ? draggedEntry.rect.top : null;
+
+if (!collapsedProjects.has(projectPath)) {
+this.preCollapsedPaths.add(projectPath);
+}
+}
+
+updatePointer(
+clientY: number,
+containerRect: SidebarReorderRect,
+groupRects: ReadonlyArray<SidebarReorderRect>
+): void {
+if (!this.isDragging || this.draggedProjectPath === null) {
+return;
+}
+
+this.ghostY = clientY;
+this.autoScrollDirection = this.getAutoScrollDirection(clientY, containerRect);
+
+const candidateRects: SidebarReorderRect[] = [];
+for (let index = 0; index < groupRects.length; index += 1) {
+const projectPath = this.orderedProjectPaths[index] ?? null;
+if (projectPath === this.draggedProjectPath) {
+continue;
+}
+
+candidateRects.push(groupRects[index]);
+}
+
+candidateRects.sort(compareRects);
+
+if (candidateRects.length === 0) {
+this.insertionIndex = 0;
+return;
+}
+
+let nextInsertionIndex = 0;
+for (const rect of candidateRects) {
+const midpoint = rect.top + (rect.bottom - rect.top) / 2;
+if (clientY >= midpoint) {
+nextInsertionIndex += 1;
+continue;
+}
+
+break;
+}
+
+this.insertionIndex = nextInsertionIndex;
+}
+
+commitDrop(currentGroups: ReadonlyArray<SessionGroup>): string[] {
+const originalOrder = currentGroups.map((group) => group.projectPath);
+const draggedProjectPath = this.draggedProjectPath;
+const fallbackInsertionIndex = draggedProjectPath
+? currentGroups.findIndex((group) => group.projectPath === draggedProjectPath)
+: -1;
+
+if (draggedProjectPath === null) {
+return originalOrder;
+}
+
+const remainingProjectPaths = currentGroups
+.filter((group) => group.projectPath !== draggedProjectPath)
+.map((group) => group.projectPath);
+const normalizedInsertionIndex = clamp(
+this.insertionIndex ?? Math.max(fallbackInsertionIndex, 0),
+0,
+remainingProjectPaths.length
+);
+
+remainingProjectPaths.splice(normalizedInsertionIndex, 0, draggedProjectPath);
+this.resetTransientDragState();
+return remainingProjectPaths;
+}
+
+cancelDrag(): void {
+this.resetTransientDragState();
+}
+
+private getAutoScrollDirection(
+clientY: number,
+containerRect: SidebarReorderRect
+): AutoScrollDirection {
+if (clientY <= containerRect.top + AUTO_SCROLL_EDGE_THRESHOLD_PX) {
+return "up";
+}
+
+if (clientY >= containerRect.bottom - AUTO_SCROLL_EDGE_THRESHOLD_PX) {
+return "down";
+}
+
+return null;
+}
+
+private resetTransientDragState(): void {
+this.isDragging = false;
+this.draggedProjectPath = null;
+this.insertionIndex = null;
+this.ghostY = null;
+this.autoScrollDirection = null;
+this.orderedProjectPaths = [];
+}
+}

--- a/packages/desktop/src/lib/acp/components/session-list/sidebar-reorder-state.ts
+++ b/packages/desktop/src/lib/acp/components/session-list/sidebar-reorder-state.ts
@@ -1,0 +1,179 @@
+import type { SessionGroup } from "./session-list-types.js";
+
+export interface SidebarReorderRect {
+	top: number;
+	bottom: number;
+}
+
+export interface SidebarReorderGroupElement {
+	projectPath: string;
+	element: {
+		getBoundingClientRect(): SidebarReorderRect;
+	};
+}
+
+export type AutoScrollDirection = "up" | "down" | null;
+
+const AUTO_SCROLL_EDGE_THRESHOLD_PX = 48;
+
+function compareRects(a: SidebarReorderRect, b: SidebarReorderRect): number {
+	if (a.top !== b.top) {
+		return a.top - b.top;
+	}
+
+	return a.bottom - b.bottom;
+}
+
+function clamp(value: number, minimum: number, maximum: number): number {
+	if (value < minimum) {
+		return minimum;
+	}
+
+	if (value > maximum) {
+		return maximum;
+	}
+
+	return value;
+}
+
+export class SidebarReorderState {
+	isDragging = false;
+	draggedProjectPath: string | null = null;
+	insertionIndex: number | null = null;
+	ghostY: number | null = null;
+	autoScrollDirection: AutoScrollDirection = null;
+	preCollapsedPaths = new Set<string>();
+
+	private orderedProjectPaths: string[] = [];
+
+	startDrag(
+		projectPath: string,
+		groupElements: ReadonlyArray<SidebarReorderGroupElement>,
+		collapsedProjects: ReadonlySet<string>
+	): void {
+		this.preCollapsedPaths.clear();
+		this.isDragging = true;
+		this.draggedProjectPath = projectPath;
+		this.autoScrollDirection = null;
+
+		const orderedEntries = groupElements
+			.map((groupElement) => ({
+				projectPath: groupElement.projectPath,
+				rect: groupElement.element.getBoundingClientRect(),
+			}))
+			.sort((left, right) => compareRects(left.rect, right.rect));
+
+		this.orderedProjectPaths = orderedEntries.map((entry) => entry.projectPath);
+
+		const sourceIndex = this.orderedProjectPaths.findIndex((path) => path === projectPath);
+		this.insertionIndex = sourceIndex >= 0 ? sourceIndex : 0;
+
+		const draggedEntry = orderedEntries.find((entry) => entry.projectPath === projectPath) ?? null;
+		this.ghostY = draggedEntry ? draggedEntry.rect.top : null;
+
+		if (!collapsedProjects.has(projectPath)) {
+			this.preCollapsedPaths.add(projectPath);
+		}
+	}
+
+	updatePointer(
+		clientY: number,
+		containerRect: SidebarReorderRect,
+		groupRects: ReadonlyArray<SidebarReorderRect>
+	): void {
+		if (!this.isDragging || this.draggedProjectPath === null) {
+			return;
+		}
+
+		this.ghostY = clientY;
+		this.autoScrollDirection = this.getAutoScrollDirection(clientY, containerRect);
+
+		const candidateRects: SidebarReorderRect[] = [];
+		for (let index = 0; index < groupRects.length; index += 1) {
+			const projectPath = this.orderedProjectPaths[index] ?? null;
+			if (projectPath === this.draggedProjectPath) {
+				continue;
+			}
+
+			const groupRect = groupRects[index];
+			if (groupRect === undefined) {
+				continue;
+			}
+
+			candidateRects.push(groupRect);
+		}
+
+		candidateRects.sort(compareRects);
+
+		if (candidateRects.length === 0) {
+			this.insertionIndex = 0;
+			return;
+		}
+
+		let nextInsertionIndex = 0;
+		for (const rect of candidateRects) {
+			const midpoint = rect.top + (rect.bottom - rect.top) / 2;
+			if (clientY >= midpoint) {
+				nextInsertionIndex += 1;
+				continue;
+			}
+
+			break;
+		}
+
+		this.insertionIndex = nextInsertionIndex;
+	}
+
+	commitDrop(currentGroups: ReadonlyArray<SessionGroup>): string[] {
+		const originalOrder = currentGroups.map((group) => group.projectPath);
+		const draggedProjectPath = this.draggedProjectPath;
+		const fallbackInsertionIndex = draggedProjectPath
+			? currentGroups.findIndex((group) => group.projectPath === draggedProjectPath)
+			: -1;
+
+		if (draggedProjectPath === null) {
+			return originalOrder;
+		}
+
+		const remainingProjectPaths = currentGroups
+			.filter((group) => group.projectPath !== draggedProjectPath)
+			.map((group) => group.projectPath);
+		const normalizedInsertionIndex = clamp(
+			this.insertionIndex ?? Math.max(fallbackInsertionIndex, 0),
+			0,
+			remainingProjectPaths.length
+		);
+
+		remainingProjectPaths.splice(normalizedInsertionIndex, 0, draggedProjectPath);
+		this.resetTransientDragState();
+		return remainingProjectPaths;
+	}
+
+	cancelDrag(): void {
+		this.resetTransientDragState();
+	}
+
+	private getAutoScrollDirection(
+		clientY: number,
+		containerRect: SidebarReorderRect
+	): AutoScrollDirection {
+		if (clientY <= containerRect.top + AUTO_SCROLL_EDGE_THRESHOLD_PX) {
+			return "up";
+		}
+
+		if (clientY >= containerRect.bottom - AUTO_SCROLL_EDGE_THRESHOLD_PX) {
+			return "down";
+		}
+
+		return null;
+	}
+
+	private resetTransientDragState(): void {
+		this.isDragging = false;
+		this.draggedProjectPath = null;
+		this.insertionIndex = null;
+		this.ghostY = null;
+		this.autoScrollDirection = null;
+		this.orderedProjectPaths = [];
+	}
+}

--- a/packages/desktop/src/lib/components/main-app-view/components/sidebar/app-sidebar.svelte
+++ b/packages/desktop/src/lib/components/main-app-view/components/sidebar/app-sidebar.svelte
@@ -372,7 +372,7 @@ function handleReorderProjects(orderedPaths: string[]) {
 	void projectManager
 		.updateProjectOrder(orderedPaths)
 		.mapErr((error) => {
-			projectManager.projects = restoreProjectSortOrders(projectManager.projects, previousSortOrders);
+			projectManager.projects = restoreProjectSortOrders(previousProjects, previousSortOrders);
 			logger.error("[ProjectReorder] Failed to persist project order", {
 				error,
 				orderedPaths,

--- a/packages/desktop/src/lib/components/main-app-view/components/sidebar/app-sidebar.svelte
+++ b/packages/desktop/src/lib/components/main-app-view/components/sidebar/app-sidebar.svelte
@@ -8,7 +8,7 @@ import ProjectIconPickerDialog from "$lib/acp/components/project-icon-picker-dia
 import type { SessionListItem } from "$lib/acp/components/session-list/session-list-types.js";
 import type { SessionDisplayItem } from "$lib/acp/types/thread-display-item.js";
 import { LOGGER_IDS } from "$lib/acp/constants/logger-ids.js";
-import type { ProjectManager } from "$lib/acp/logic/project-manager.svelte.js";
+import type { Project, ProjectManager } from "$lib/acp/logic/project-manager.svelte.js";
 import {
 	getAgentPreferencesStore,
 	getAgentStore,
@@ -249,6 +249,93 @@ const effectiveTheme = $derived(themeState.effectiveTheme);
 let iconPickerOpen = $state(false);
 let iconPickerImages = $state<string[]>([]);
 let iconPickerProjectPath = $state("");
+let reorderInFlight = $state(false);
+
+function cloneProject(project: Project): Project {
+	return {
+		path: project.path,
+		name: project.name,
+		lastOpened: project.lastOpened,
+		createdAt: project.createdAt,
+		color: project.color,
+		sortOrder: project.sortOrder,
+		iconPath: project.iconPath ?? null,
+	};
+}
+
+function cloneProjects(projects: readonly Project[]): Project[] {
+	return projects.map((project) => cloneProject(project));
+}
+
+function compareProjectOrder(a: Project, b: Project): number {
+	const aSortOrder = a.sortOrder ?? Number.POSITIVE_INFINITY;
+	const bSortOrder = b.sortOrder ?? Number.POSITIVE_INFINITY;
+	if (aSortOrder !== bSortOrder) {
+		return aSortOrder - bSortOrder;
+	}
+
+	return b.createdAt.getTime() - a.createdAt.getTime();
+}
+
+function getCurrentProjectOrder(projects: readonly Project[]): string[] {
+	return Array.from(projects)
+		.sort((a, b) => compareProjectOrder(a, b))
+		.map((project) => project.path);
+}
+
+function areProjectOrdersEqual(currentOrder: readonly string[], nextOrder: readonly string[]): boolean {
+	if (currentOrder.length !== nextOrder.length) {
+		return false;
+	}
+
+	return currentOrder.every((path, index) => path === nextOrder[index]);
+}
+
+function buildOptimisticProjectOrder(
+	projects: readonly Project[],
+	orderedPaths: readonly string[]
+): Project[] {
+	const projectByPath = new Map(projects.map((project) => [project.path, project]));
+	const remainingProjects = Array.from(projects).sort((a, b) => compareProjectOrder(a, b));
+	const reorderedProjects: Project[] = [];
+	const includedPaths = new Set<string>();
+
+	for (const path of orderedPaths) {
+		const project = projectByPath.get(path);
+		if (!project) {
+			continue;
+		}
+
+		reorderedProjects.push({
+			path: project.path,
+			name: project.name,
+			lastOpened: project.lastOpened,
+			createdAt: project.createdAt,
+			color: project.color,
+			sortOrder: reorderedProjects.length,
+			iconPath: project.iconPath ?? null,
+		});
+		includedPaths.add(project.path);
+	}
+
+	for (const project of remainingProjects) {
+		if (includedPaths.has(project.path)) {
+			continue;
+		}
+
+		reorderedProjects.push({
+			path: project.path,
+			name: project.name,
+			lastOpened: project.lastOpened,
+			createdAt: project.createdAt,
+			color: project.color,
+			sortOrder: reorderedProjects.length,
+			iconPath: project.iconPath ?? null,
+		});
+	}
+
+	return reorderedProjects;
+}
 
 function handleIconPickerOpenChange(open: boolean) {
 	iconPickerOpen = open;
@@ -256,6 +343,40 @@ function handleIconPickerOpenChange(open: boolean) {
 		iconPickerImages = [];
 		iconPickerProjectPath = "";
 	}
+}
+
+function handleReorderProjects(orderedPaths: string[]) {
+	if (reorderInFlight) {
+		return;
+	}
+
+	const previousProjects = cloneProjects(projectManager.projects);
+	const currentOrder = getCurrentProjectOrder(previousProjects);
+	if (areProjectOrdersEqual(currentOrder, orderedPaths)) {
+		return;
+	}
+
+	reorderInFlight = true;
+	projectManager.projects = buildOptimisticProjectOrder(previousProjects, orderedPaths);
+
+	void projectManager
+		.updateProjectOrder(orderedPaths)
+		.mapErr((error) => {
+			projectManager.projects = previousProjects;
+			logger.error("[ProjectReorder] Failed to persist project order", {
+				error,
+				orderedPaths,
+			});
+			return error;
+		})
+		.match(
+			() => {
+				reorderInFlight = false;
+			},
+			() => {
+				reorderInFlight = false;
+			}
+		);
 }
 
 function handleSelectProjectIcon(iconPath: string) {
@@ -340,12 +461,13 @@ const visibleSessions = $derived.by(() => {
 			onOpenTerminal={handleOpenTerminal}
 			onOpenBrowser={handleOpenBrowser}
 			onOpenGitPanel={handleOpenGitPanel}
-						onOpenPr={handleOpenPr}
-						onArchiveSession={handleArchiveSession}
-						onRenameSession={handleRenameSession}
-						onExportMarkdown={handleExportMarkdown}
-						onExportJson={handleExportJson}
-					/>
+			onOpenPr={handleOpenPr}
+			onArchiveSession={handleArchiveSession}
+			onRenameSession={handleRenameSession}
+			onExportMarkdown={handleExportMarkdown}
+			onExportJson={handleExportJson}
+			onReorderProjects={handleReorderProjects}
+		/>
 	{/snippet}
 
 	{#snippet footer()}

--- a/packages/desktop/src/lib/components/main-app-view/components/sidebar/app-sidebar.svelte
+++ b/packages/desktop/src/lib/components/main-app-view/components/sidebar/app-sidebar.svelte
@@ -251,20 +251,37 @@ let iconPickerImages = $state<string[]>([]);
 let iconPickerProjectPath = $state("");
 let reorderInFlight = $state(false);
 
-function cloneProject(project: Project): Project {
+function copyProject(project: Project, sortOrder: number | undefined = project.sortOrder): Project {
 	return {
 		path: project.path,
 		name: project.name,
 		lastOpened: project.lastOpened,
 		createdAt: project.createdAt,
 		color: project.color,
-		sortOrder: project.sortOrder,
+		sortOrder,
 		iconPath: project.iconPath ?? null,
 	};
 }
 
-function cloneProjects(projects: readonly Project[]): Project[] {
-	return projects.map((project) => cloneProject(project));
+function snapshotProjectSortOrders(projects: readonly Project[]): Map<string, number | undefined> {
+	const sortOrders = new Map<string, number | undefined>();
+	for (const project of projects) {
+		sortOrders.set(project.path, project.sortOrder);
+	}
+	return sortOrders;
+}
+
+function restoreProjectSortOrders(
+	projects: readonly Project[],
+	sortOrders: ReadonlyMap<string, number | undefined>
+): Project[] {
+	return projects.map((project) => {
+		if (!sortOrders.has(project.path)) {
+			return copyProject(project);
+		}
+
+		return copyProject(project, sortOrders.get(project.path));
+	});
 }
 
 function compareProjectOrder(a: Project, b: Project): number {
@@ -323,15 +340,7 @@ function buildOptimisticProjectOrder(
 			continue;
 		}
 
-		reorderedProjects.push({
-			path: project.path,
-			name: project.name,
-			lastOpened: project.lastOpened,
-			createdAt: project.createdAt,
-			color: project.color,
-			sortOrder: reorderedProjects.length,
-			iconPath: project.iconPath ?? null,
-		});
+		reorderedProjects.push(copyProject(project, reorderedProjects.length));
 	}
 
 	return reorderedProjects;
@@ -350,7 +359,8 @@ function handleReorderProjects(orderedPaths: string[]) {
 		return;
 	}
 
-	const previousProjects = cloneProjects(projectManager.projects);
+	const previousSortOrders = snapshotProjectSortOrders(projectManager.projects);
+	const previousProjects = projectManager.projects;
 	const currentOrder = getCurrentProjectOrder(previousProjects);
 	if (areProjectOrdersEqual(currentOrder, orderedPaths)) {
 		return;
@@ -362,7 +372,7 @@ function handleReorderProjects(orderedPaths: string[]) {
 	void projectManager
 		.updateProjectOrder(orderedPaths)
 		.mapErr((error) => {
-			projectManager.projects = previousProjects;
+			projectManager.projects = restoreProjectSortOrders(projectManager.projects, previousSortOrders);
 			logger.error("[ProjectReorder] Failed to persist project order", {
 				error,
 				orderedPaths,

--- a/packages/desktop/src/lib/messages.ts
+++ b/packages/desktop/src/lib/messages.ts
@@ -1399,6 +1399,18 @@ export function project_icon_reset(args: MessageArgs = {}): string {
 	return interpolate(`Reset to letter badge`, args);
 }
 
+export function project_move_up(args: MessageArgs = {}): string {
+	return interpolate(`Move Up`, args);
+}
+
+export function project_move_down(args: MessageArgs = {}): string {
+	return interpolate(`Move Down`, args);
+}
+
+export function project_reorder_announcement(args: MessageArgs = {}): string {
+	return interpolate(`Moved {projectName} to position {position} of {total}`, args);
+}
+
 export function project_color_red(args: MessageArgs = {}): string {
 	return interpolate(`Red`, args);
 }

--- a/packages/ui/src/components/project-letter-badge/project-letter-badge.svelte
+++ b/packages/ui/src/components/project-letter-badge/project-letter-badge.svelte
@@ -8,6 +8,8 @@
 		color: string;
 		/** Optional project icon source. When provided, renders the image instead of the letter badge. */
 		iconSrc?: string | null;
+		/** Whether the badge should show a draggable grip on hover. */
+		draggable?: boolean;
 		/** Badge size in px (default 20) */
 		size?: number;
 		/** Override font size in px (default: size * 0.55) */
@@ -24,6 +26,7 @@
 		name,
 		color,
 		iconSrc = null,
+		draggable = false,
 		size = 20,
 		fontSize: fontSizeProp,
 		sequenceId,
@@ -50,7 +53,9 @@
 <span class="inline-flex items-center {className}" style="gap: 0px;">
 	{#if showLetter}
 		<div
-			class="flex items-center justify-center shrink-0 overflow-hidden"
+			class="relative flex items-center justify-center shrink-0 overflow-hidden {draggable
+				? 'group/project-letter-badge'
+				: ''}"
 			style="
 				background-color: {badgeBg};
 				width: {size}px;
@@ -58,25 +63,53 @@
 				border-radius: {hasSequenceId ? `${radius}px 0 0 ${radius}px` : `${radius}px`};
 			"
 		>
-			{#if showImage}
-				<img
-					src={iconSrc}
-					alt={iconAlt}
-					class="block h-full w-full object-cover"
-					draggable="false"
-					onerror={(e: Event) => {
-						const img = e.currentTarget as HTMLImageElement;
-						hasError = true;
-						errorSrc = img.src;
-					}}
-				/>
-			{:else}
-				<span
-					class="font-black leading-none"
-					style="font-size: {fontSize}px; color: {badgeFg};"
+			<div
+				class="absolute inset-0 flex items-center justify-center transition-opacity duration-150 ease-out motion-reduce:transition-none {draggable
+					? 'opacity-100 group-hover/project-letter-badge:opacity-0'
+					: ''}"
+			>
+				{#if showImage}
+					<img
+						src={iconSrc}
+						alt={iconAlt}
+						class="block h-full w-full object-cover"
+						draggable="false"
+						onerror={(e: Event) => {
+							const img = e.currentTarget as HTMLImageElement;
+							hasError = true;
+							errorSrc = img.src;
+						}}
+					/>
+				{:else}
+					<span
+						class="font-black leading-none"
+						style="font-size: {fontSize}px; color: {badgeFg};"
+					>
+						{letter}
+					</span>
+				{/if}
+			</div>
+			{#if draggable}
+				<div
+					aria-hidden="true"
+					class="absolute inset-0 flex items-center justify-center opacity-0 transition-opacity duration-150 ease-out motion-reduce:transition-none group-hover/project-letter-badge:opacity-100"
 				>
-					{letter}
-				</span>
+					<span class="inline-flex h-full w-full cursor-grab items-center justify-center">
+						<svg
+							viewBox="0 0 8 12"
+							class="h-[60%] w-[60%]"
+							fill="currentColor"
+							style="color: {badgeFg};"
+						>
+							<circle cx="2" cy="2" r="1" />
+							<circle cx="6" cy="2" r="1" />
+							<circle cx="2" cy="6" r="1" />
+							<circle cx="6" cy="6" r="1" />
+							<circle cx="2" cy="10" r="1" />
+							<circle cx="6" cy="10" r="1" />
+						</svg>
+					</span>
+				</div>
 			{/if}
 		</div>
 	{/if}


### PR DESCRIPTION
## Summary

Add drag-to-reorder and context-menu reorder to the project sidebar. Users hover a project's letter badge to reveal a 6-dot grip, drag to reorder, and the new order persists across restarts via the existing `updateProjectOrder` backend path. A context-menu Move Up/Move Down fallback ensures keyboard-only users can reorder too.

Closes #97 (drag-to-reorder request)

## What changed

### Sort by persisted order
- `createSessionGroups()` and `createLoadingSessionGroups()` now sort by `sortOrder ASC` with `createdAt DESC` tiebreaker, matching the backend's `get_all()` ordering
- Projects with undefined `sortOrder` sort to the end

### Badge grip hover
- `ProjectLetterBadge` gains a `draggable` prop — on hover, the letter/icon crossfades to a 6-dot grip icon (~150ms opacity transition, `prefers-reduced-motion` fallback)
- Purely presentational, no drag logic in the UI component

### Reorder state class
- New `SidebarReorderState` encapsulates drag lifecycle, insertion index computation (excludes dragged item from candidates), auto-scroll direction, ghost tracking, and expansion snapshot/restore
- Pure TS logic extracted for testability (10 tests, all passing)

### Drag wiring
- Pointer events on the badge grip area: `pointerdown` → set capture → `pointermove` → `pointerup` → commit/cancel
- Ghost overlay (fixed-position badge clone at 50% opacity) + insertion line (2px accent bar)
- Auto-scroll near sidebar edges via RAF loop
- Escape cancels, coordinate check against sidebar rect for commit vs cancel
- Click-to-expand suppressed during drag

### Optimistic persistence
- On drop, `sortOrder` rewritten locally before backend call for instant UI feedback
- Rollback scoped to `sortOrder` fields only (doesn't clobber concurrent icon/color changes)
- Serialized: blocks new reorders while one is in flight
- Backend order adopted as canonical on success

### Context menu fallback
- Move Up / Move Down items in the project context menu (disabled at boundaries)
- ARIA live region announces position after any reorder
- Focus returns to moved project header for consecutive keyboard moves

## Testing

- 10 new unit tests for `SidebarReorderState` (insertion index, commit/cancel, edge cases, auto-scroll)
- 4 new tests for sort-by-`sortOrder` logic (happy path, loading state, undefined fallback, tiebreaker)
- All 61 sidebar tests pass
- `bun run check` clean in both `packages/desktop` and `packages/ui`
- Manual verification needed: full drag flow, ghost rendering, insertion line positioning

## Post-Deploy Monitoring & Validation

No additional operational monitoring required — this is a client-side UI feature with no new backend endpoints or data model changes. The existing `updateProjectOrder` backend path is already exercised by existing tests.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add drag-to-reorder for projects in the sidebar with a hover grip and a keyboard-friendly Move Up/Down option. Order is saved via `updateProjectOrder` with optimistic updates, blocked concurrent saves, and reliable rollback.

- **New Features**
  - Drag projects by the badge grip; shows a ghost badge, insertion line, and auto-scroll; Esc cancels.
  - Context menu adds Move Up/Down actions with ARIA announcements and focus return for quick repeats.
  - Projects now sort by persisted `sortOrder` (ASC) with `createdAt` (DESC) as a tiebreaker; missing `sortOrder` goes last. Applies to loading and live groups.
  - `ProjectLetterBadge` shows a 6-dot grip on hover; the component stays presentational.
  - Reorder is persisted through `updateProjectOrder`; UI updates optimistically and blocks new reorders while saving. Tests cover reorder logic and sorting.

- **Bug Fixes**
  - Rollback now restores the pre-reorder project array on persistence failure to prevent stale ordering in views.

<sup>Written for commit 7b654f1fda45ae18450e126f3d998720e147fd05. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

