### PR TITLE
fix(agent-panel): normalize tool rows and preserve grep details

### DIFF
--- a/packages/desktop/src-tauri/src/copilot_history/mod.rs
+++ b/packages/desktop/src-tauri/src/copilot_history/mod.rs
@@ -328,7 +328,21 @@ fn combine_user_blocks(chunks: &[StoredContentBlock]) -> StoredContentBlock {
 }
 
 fn merge_replay_tool_arguments(current: ToolArguments, incoming: ToolArguments) -> ToolArguments {
+    fn merge_optional<T>(current: Option<T>, incoming: Option<T>) -> Option<T> {
+        incoming.or(current)
+    }
+
     match (current, incoming) {
+        (
+            ToolArguments::Read {
+                file_path: current_file_path,
+            },
+            ToolArguments::Read {
+                file_path: incoming_file_path,
+            },
+        ) => ToolArguments::Read {
+            file_path: merge_optional(current_file_path, incoming_file_path),
+        },
         (
             ToolArguments::Edit {
                 edits: current_edits,
@@ -338,6 +352,142 @@ fn merge_replay_tool_arguments(current: ToolArguments, incoming: ToolArguments) 
             },
         ) => ToolArguments::Edit {
             edits: merge_replay_edit_entries(current_edits, incoming_edits),
+        },
+        (
+            ToolArguments::Execute {
+                command: current_command,
+            },
+            ToolArguments::Execute {
+                command: incoming_command,
+            },
+        ) => ToolArguments::Execute {
+            command: merge_optional(current_command, incoming_command),
+        },
+        (
+            ToolArguments::Search {
+                query: current_query,
+                file_path: current_file_path,
+            },
+            ToolArguments::Search {
+                query: incoming_query,
+                file_path: incoming_file_path,
+            },
+        ) => ToolArguments::Search {
+            query: merge_optional(current_query, incoming_query),
+            file_path: merge_optional(current_file_path, incoming_file_path),
+        },
+        (
+            ToolArguments::Glob {
+                pattern: current_pattern,
+                path: current_path,
+            },
+            ToolArguments::Glob {
+                pattern: incoming_pattern,
+                path: incoming_path,
+            },
+        ) => ToolArguments::Glob {
+            pattern: merge_optional(current_pattern, incoming_pattern),
+            path: merge_optional(current_path, incoming_path),
+        },
+        (ToolArguments::Fetch { url: current_url }, ToolArguments::Fetch { url: incoming_url }) => {
+            ToolArguments::Fetch {
+                url: merge_optional(current_url, incoming_url),
+            }
+        }
+        (
+            ToolArguments::WebSearch {
+                query: current_query,
+            },
+            ToolArguments::WebSearch {
+                query: incoming_query,
+            },
+        ) => ToolArguments::WebSearch {
+            query: merge_optional(current_query, incoming_query),
+        },
+        (
+            ToolArguments::Think {
+                description: current_description,
+                prompt: current_prompt,
+                subagent_type: current_subagent_type,
+                skill: current_skill,
+                skill_args: current_skill_args,
+                raw: current_raw,
+            },
+            ToolArguments::Think {
+                description: incoming_description,
+                prompt: incoming_prompt,
+                subagent_type: incoming_subagent_type,
+                skill: incoming_skill,
+                skill_args: incoming_skill_args,
+                raw: incoming_raw,
+            },
+        ) => ToolArguments::Think {
+            description: merge_optional(current_description, incoming_description),
+            prompt: merge_optional(current_prompt, incoming_prompt),
+            subagent_type: merge_optional(current_subagent_type, incoming_subagent_type),
+            skill: merge_optional(current_skill, incoming_skill),
+            skill_args: merge_optional(current_skill_args, incoming_skill_args),
+            raw: merge_optional(current_raw, incoming_raw),
+        },
+        (
+            ToolArguments::TaskOutput {
+                task_id: current_task_id,
+                timeout: current_timeout,
+            },
+            ToolArguments::TaskOutput {
+                task_id: incoming_task_id,
+                timeout: incoming_timeout,
+            },
+        ) => ToolArguments::TaskOutput {
+            task_id: merge_optional(current_task_id, incoming_task_id),
+            timeout: merge_optional(current_timeout, incoming_timeout),
+        },
+        (
+            ToolArguments::Move {
+                from: current_from,
+                to: current_to,
+            },
+            ToolArguments::Move {
+                from: incoming_from,
+                to: incoming_to,
+            },
+        ) => ToolArguments::Move {
+            from: merge_optional(current_from, incoming_from),
+            to: merge_optional(current_to, incoming_to),
+        },
+        (
+            ToolArguments::Delete {
+                file_path: current_file_path,
+                file_paths: current_file_paths,
+            },
+            ToolArguments::Delete {
+                file_path: incoming_file_path,
+                file_paths: incoming_file_paths,
+            },
+        ) => ToolArguments::Delete {
+            file_path: merge_optional(current_file_path, incoming_file_path),
+            file_paths: merge_optional(current_file_paths, incoming_file_paths),
+        },
+        (
+            ToolArguments::PlanMode { mode: current_mode },
+            ToolArguments::PlanMode {
+                mode: incoming_mode,
+            },
+        ) => ToolArguments::PlanMode {
+            mode: merge_optional(current_mode, incoming_mode),
+        },
+        (
+            ToolArguments::ToolSearch {
+                query: current_query,
+                max_results: current_max_results,
+            },
+            ToolArguments::ToolSearch {
+                query: incoming_query,
+                max_results: incoming_max_results,
+            },
+        ) => ToolArguments::ToolSearch {
+            query: merge_optional(current_query, incoming_query),
+            max_results: merge_optional(current_max_results, incoming_max_results),
         },
         (_, incoming_arguments) => incoming_arguments,
     }
@@ -852,6 +1002,89 @@ mod tests {
                     .expect("task children should be preserved");
                 assert_eq!(children.len(), 1);
                 assert_eq!(children[0].id, "child-read-1");
+            }
+            other => panic!("expected tool call entry, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn preserves_search_arguments_when_replayed_tool_call_becomes_sparse() {
+        let session_id = "copilot-session-search";
+        let converted = convert_replay_updates_to_session(
+            session_id,
+            "Copilot Session",
+            &[
+                (
+                    1_710_000_012_000,
+                    crate::acp::session_update::SessionUpdate::ToolCall {
+                        tool_call: ToolCallData {
+                            id: "tool-search-1".to_string(),
+                            name: "Search".to_string(),
+                            arguments: ToolArguments::Search {
+                                query: Some("#\\[tauri::command\\]".to_string()),
+                                file_path: Some("src/".to_string()),
+                            },
+                            raw_input: None,
+                            status: ToolCallStatus::Pending,
+                            result: None,
+                            kind: Some(ToolKind::Search),
+                            title: Some("Grepped".to_string()),
+                            locations: None,
+                            skill_meta: None,
+                            normalized_questions: None,
+                            normalized_todos: None,
+                            parent_tool_use_id: None,
+                            task_children: None,
+                            question_answer: None,
+                            awaiting_plan_approval: false,
+                            plan_approval_request_id: None,
+                        },
+                        session_id: Some(session_id.to_string()),
+                    },
+                ),
+                (
+                    1_710_000_012_500,
+                    crate::acp::session_update::SessionUpdate::ToolCall {
+                        tool_call: ToolCallData {
+                            id: "tool-search-1".to_string(),
+                            name: "Search".to_string(),
+                            arguments: ToolArguments::Search {
+                                query: None,
+                                file_path: None,
+                            },
+                            raw_input: None,
+                            status: ToolCallStatus::Completed,
+                            result: None,
+                            kind: Some(ToolKind::Search),
+                            title: Some("Grepped".to_string()),
+                            locations: None,
+                            skill_meta: None,
+                            normalized_questions: None,
+                            normalized_todos: None,
+                            parent_tool_use_id: None,
+                            task_children: None,
+                            question_answer: None,
+                            awaiting_plan_approval: false,
+                            plan_approval_request_id: None,
+                        },
+                        session_id: Some(session_id.to_string()),
+                    },
+                ),
+            ],
+        );
+
+        assert_eq!(converted.entries.len(), 1);
+
+        match &converted.entries[0] {
+            StoredEntry::ToolCall { message, .. } => {
+                assert_eq!(message.status, ToolCallStatus::Completed);
+                match &message.arguments {
+                    ToolArguments::Search { query, file_path } => {
+                        assert_eq!(query.as_deref(), Some("#\\[tauri::command\\]"));
+                        assert_eq!(file_path.as_deref(), Some("src/"));
+                    }
+                    other => panic!("expected search arguments, got {:?}", other),
+                }
             }
             other => panic!("expected tool call entry, got {:?}", other),
         }

--- a/packages/desktop/src/lib/acp/components/messages/assistant-message.svelte
+++ b/packages/desktop/src/lib/acp/components/messages/assistant-message.svelte
@@ -279,6 +279,6 @@ $effect(() => {
 	.thinking-content,
 	.thinking-content :global(.markdown-content),
 	.thinking-content :global(.markdown-content *) {
-		font-size: 12px !important;
+		font-size: 14px !important;
 	}
 </style>

--- a/packages/desktop/src/lib/acp/store/services/__tests__/tool-call-manager.test.ts
+++ b/packages/desktop/src/lib/acp/store/services/__tests__/tool-call-manager.test.ts
@@ -347,6 +347,57 @@ describe("ToolCallManager", () => {
 			}
 		});
 
+		it("preserves richer search arguments when duplicate create data is sparse", () => {
+			const existingEntry: SessionEntry = {
+				id: "tc-1",
+				type: "tool_call",
+				message: {
+					id: "tc-1",
+					name: "Search",
+					status: "pending",
+					arguments: {
+						kind: "search",
+						query: "#\\[tauri::command\\]",
+						file_path: "src/",
+					},
+					kind: "search",
+					awaitingPlanApproval: false,
+				},
+				timestamp: new Date(),
+				isStreaming: true,
+			};
+			const entryStore = createMockEntryStore({
+				getEntries: vi.fn(() => [existingEntry]),
+			});
+			const entryIndex = createMockEntryIndex({
+				getToolCallIdIndex: vi.fn(() => 0),
+			});
+			const manager = new ToolCallManager(entryStore, entryIndex);
+
+			const sparseData = createToolCallData("tc-1", {
+				name: "Search",
+				status: "completed",
+				kind: "search",
+				arguments: {
+					kind: "search",
+					query: null,
+					file_path: null,
+				},
+			});
+			const result = manager.createEntry("s1", sparseData);
+
+			expect(result.isOk()).toBe(true);
+			const updatedEntry = (entryStore.updateEntry as ReturnType<typeof vi.fn>).mock
+				.calls[0][2] as SessionEntry;
+			if (updatedEntry.type === "tool_call") {
+				expect(updatedEntry.message.arguments).toEqual({
+					kind: "search",
+					query: "#\\[tauri::command\\]",
+					file_path: "src/",
+				});
+			}
+		});
+
 		it("does not downgrade terminal status when replayed create data is pending", () => {
 			const existingEntry: SessionEntry = {
 				id: "tc-1",
@@ -759,6 +810,55 @@ describe("ToolCallManager", () => {
 			if (updatedEntry.type === "tool_call") {
 				// Structured result should be preserved
 				expect(updatedEntry.message.result).toEqual({ numFiles: 4, pattern: "*.ts" });
+			}
+		});
+
+		it("preserves richer search arguments when a sparse completion update arrives", () => {
+			const existingEntry: SessionEntry = {
+				id: "tc-1",
+				type: "tool_call",
+				message: {
+					id: "tc-1",
+					name: "Search",
+					status: "in_progress",
+					arguments: {
+						kind: "search",
+						query: "#\\[tauri::command\\]",
+						file_path: "src/",
+					},
+					kind: "search",
+					awaitingPlanApproval: false,
+				},
+				timestamp: new Date(),
+				isStreaming: true,
+			};
+			const entryStore = createMockEntryStore({
+				getEntries: vi.fn(() => [existingEntry]),
+			});
+			const entryIndex = createMockEntryIndex({
+				getToolCallIdIndex: vi.fn(() => 0),
+			});
+			const manager = new ToolCallManager(entryStore, entryIndex);
+
+			const update = createToolCallUpdate("tc-1", {
+				status: "completed",
+				arguments: {
+					kind: "search",
+					query: null,
+					file_path: null,
+				},
+			});
+			const result = manager.updateEntry("s1", update);
+
+			expect(result.isOk()).toBe(true);
+			const updatedEntry = (entryStore.updateEntry as ReturnType<typeof vi.fn>).mock
+				.calls[0][2] as SessionEntry;
+			if (updatedEntry.type === "tool_call") {
+				expect(updatedEntry.message.arguments).toEqual({
+					kind: "search",
+					query: "#\\[tauri::command\\]",
+					file_path: "src/",
+				});
 			}
 		});
 

--- a/packages/desktop/src/lib/acp/store/services/tool-call-manager.svelte.ts
+++ b/packages/desktop/src/lib/acp/store/services/tool-call-manager.svelte.ts
@@ -127,15 +127,112 @@ function mergeEditEntries(
 	return merged;
 }
 
+function mergeOptionalField<T>(
+	currentValue: T | null | undefined,
+	incomingValue: T | null | undefined
+): T | null | undefined {
+	return incomingValue ?? currentValue;
+}
+
 function mergeToolArguments(currentArgs: ToolArguments, nextArgs: ToolArguments): ToolArguments {
-	if (currentArgs.kind === "edit" && nextArgs.kind === "edit") {
-		return {
-			kind: "edit",
-			edits: mergeEditEntries(currentArgs.edits, nextArgs.edits),
-		};
+	if (currentArgs.kind !== nextArgs.kind) {
+		return nextArgs;
 	}
 
-	return nextArgs;
+	switch (currentArgs.kind) {
+		case "read":
+			if (nextArgs.kind !== "read") return nextArgs;
+			return {
+				kind: "read",
+				file_path: mergeOptionalField(currentArgs.file_path, nextArgs.file_path),
+			};
+		case "edit":
+			if (nextArgs.kind !== "edit") return nextArgs;
+			return {
+				kind: "edit",
+				edits: mergeEditEntries(currentArgs.edits, nextArgs.edits),
+			};
+		case "execute":
+			if (nextArgs.kind !== "execute") return nextArgs;
+			return {
+				kind: "execute",
+				command: mergeOptionalField(currentArgs.command, nextArgs.command),
+			};
+		case "search":
+			if (nextArgs.kind !== "search") return nextArgs;
+			return {
+				kind: "search",
+				query: mergeOptionalField(currentArgs.query, nextArgs.query),
+				file_path: mergeOptionalField(currentArgs.file_path, nextArgs.file_path),
+			};
+		case "glob":
+			if (nextArgs.kind !== "glob") return nextArgs;
+			return {
+				kind: "glob",
+				pattern: mergeOptionalField(currentArgs.pattern, nextArgs.pattern),
+				path: mergeOptionalField(currentArgs.path, nextArgs.path),
+			};
+		case "fetch":
+			if (nextArgs.kind !== "fetch") return nextArgs;
+			return {
+				kind: "fetch",
+				url: mergeOptionalField(currentArgs.url, nextArgs.url),
+			};
+		case "webSearch":
+			if (nextArgs.kind !== "webSearch") return nextArgs;
+			return {
+				kind: "webSearch",
+				query: mergeOptionalField(currentArgs.query, nextArgs.query),
+			};
+		case "think":
+			if (nextArgs.kind !== "think") return nextArgs;
+			return {
+				kind: "think",
+				description: mergeOptionalField(currentArgs.description, nextArgs.description),
+				prompt: mergeOptionalField(currentArgs.prompt, nextArgs.prompt),
+				subagent_type: mergeOptionalField(currentArgs.subagent_type, nextArgs.subagent_type),
+				skill: mergeOptionalField(currentArgs.skill, nextArgs.skill),
+				skill_args: mergeOptionalField(currentArgs.skill_args, nextArgs.skill_args),
+				raw: mergeOptionalField(currentArgs.raw, nextArgs.raw),
+			};
+		case "taskOutput":
+			if (nextArgs.kind !== "taskOutput") return nextArgs;
+			return {
+				kind: "taskOutput",
+				task_id: mergeOptionalField(currentArgs.task_id, nextArgs.task_id),
+				timeout: mergeOptionalField(currentArgs.timeout, nextArgs.timeout),
+			};
+		case "move":
+			if (nextArgs.kind !== "move") return nextArgs;
+			return {
+				kind: "move",
+				from: mergeOptionalField(currentArgs.from, nextArgs.from),
+				to: mergeOptionalField(currentArgs.to, nextArgs.to),
+			};
+		case "delete":
+			if (nextArgs.kind !== "delete") return nextArgs;
+			return {
+				kind: "delete",
+				file_path: mergeOptionalField(currentArgs.file_path, nextArgs.file_path),
+				file_paths: mergeOptionalField(currentArgs.file_paths, nextArgs.file_paths),
+			};
+		case "planMode":
+			if (nextArgs.kind !== "planMode") return nextArgs;
+			return {
+				kind: "planMode",
+				mode: mergeOptionalField(currentArgs.mode, nextArgs.mode),
+			};
+		case "toolSearch":
+			if (nextArgs.kind !== "toolSearch") return nextArgs;
+			return {
+				kind: "toolSearch",
+				query: mergeOptionalField(currentArgs.query, nextArgs.query),
+				max_results: mergeOptionalField(currentArgs.max_results, nextArgs.max_results),
+			};
+		case "browser":
+		case "other":
+			return nextArgs;
+	}
 }
 
 function hasMaterializedToolUpdateFields(update: ToolCallUpdate): boolean {

--- a/packages/ui/src/components/agent-panel-scene/agent-panel-scene-entry.svelte
+++ b/packages/ui/src/components/agent-panel-scene/agent-panel-scene-entry.svelte
@@ -17,6 +17,7 @@
 	import AgentToolTodo from "../agent-panel/agent-tool-todo.svelte";
 	import AgentToolWebSearch from "../agent-panel/agent-tool-web-search.svelte";
 	import AgentUserMessage from "../agent-panel/agent-user-message.svelte";
+	import { getPlanningPlaceholderLabel } from "../agent-panel/planning-label.js";
 	import { TextShimmer } from "../text-shimmer/index.js";
 
 	interface Props {
@@ -129,7 +130,7 @@
 {:else if entry.type === "assistant"}
 	<AgentAssistantMessage markdown={entry.markdown} isStreaming={entry.isStreaming} {iconBasePath} />
 {:else if entry.type === "thinking"}
-	<AgentToolRow title={getPlanningPlaceholderLabel(entry.durationMs)} status="running" padded={false} />
+	<AgentToolRow title={getPlanningPlaceholderLabel()} status="running" padded={false} />
 {:else if isToolCall(entry) && entry.todos && entry.todos.length > 0}
 	<AgentToolTodo
 		todos={entry.todos.map((todo) => ({

--- a/packages/ui/src/components/agent-panel-scene/agent-panel-scene-entry.svelte
+++ b/packages/ui/src/components/agent-panel-scene/agent-panel-scene-entry.svelte
@@ -129,9 +129,7 @@
 {:else if entry.type === "assistant"}
 	<AgentAssistantMessage markdown={entry.markdown} isStreaming={entry.isStreaming} {iconBasePath} />
 {:else if entry.type === "thinking"}
-	<div class="py-2 text-sm text-muted-foreground">
-		<TextShimmer>Planning next moves…</TextShimmer>
-	</div>
+	<AgentToolRow title={getPlanningPlaceholderLabel(entry.durationMs)} status="running" padded={false} />
 {:else if isToolCall(entry) && entry.todos && entry.todos.length > 0}
 	<AgentToolTodo
 		todos={entry.todos.map((todo) => ({
@@ -232,6 +230,7 @@
 		filePath={entry.filePath}
 		status={entry.status}
 		kind={entry.kind}
+		padded={true}
 		{iconBasePath}
 	/>
 {/if}

--- a/packages/ui/src/components/agent-panel/agent-assistant-message.svelte
+++ b/packages/ui/src/components/agent-panel/agent-assistant-message.svelte
@@ -19,6 +19,6 @@
 			<TextShimmer>Planning next moves…</TextShimmer>
 		</div>
 	{:else}
-		<MarkdownDisplay content={markdown} {iconBasePath} />
+		<MarkdownDisplay content={markdown} textSize="text-sm" {iconBasePath} />
 	{/if}
 </div>

--- a/packages/ui/src/components/agent-panel/agent-panel-conversation-entry.svelte
+++ b/packages/ui/src/components/agent-panel/agent-panel-conversation-entry.svelte
@@ -15,6 +15,7 @@
 	import AgentToolTodo from "./agent-tool-todo.svelte";
 	import AgentToolWebSearch from "./agent-tool-web-search.svelte";
 	import AgentUserMessage from "./agent-user-message.svelte";
+	import { getPlanningPlaceholderLabel } from "./planning-label.js";
 	import { TextShimmer } from "../text-shimmer/index.js";
 
 	interface Props {
@@ -44,7 +45,7 @@
 {:else if entry.type === "assistant"}
 	<AgentAssistantMessage markdown={entry.markdown} isStreaming={entry.isStreaming} {iconBasePath} />
 {:else if entry.type === "thinking"}
-	<AgentToolRow title={getPlanningPlaceholderLabel(entry.durationMs)} status="running" padded={false} />
+	<AgentToolRow title={getPlanningPlaceholderLabel()} status="running" padded={false} />
 {:else if isToolCall(entry) && entry.todos && entry.todos.length > 0}
 	<AgentToolTodo todos={entry.todos} isLive={entry.status === "running"} />
 {:else if isToolCall(entry) && entry.question}

--- a/packages/ui/src/components/agent-panel/agent-panel-conversation-entry.svelte
+++ b/packages/ui/src/components/agent-panel/agent-panel-conversation-entry.svelte
@@ -44,9 +44,7 @@
 {:else if entry.type === "assistant"}
 	<AgentAssistantMessage markdown={entry.markdown} isStreaming={entry.isStreaming} {iconBasePath} />
 {:else if entry.type === "thinking"}
-	<div class="py-2 text-sm text-muted-foreground">
-		<TextShimmer>Planning next moves…</TextShimmer>
-	</div>
+	<AgentToolRow title={getPlanningPlaceholderLabel(entry.durationMs)} status="running" padded={false} />
 {:else if isToolCall(entry) && entry.todos && entry.todos.length > 0}
 	<AgentToolTodo todos={entry.todos} isLive={entry.status === "running"} />
 {:else if isToolCall(entry) && entry.question}
@@ -134,6 +132,7 @@
 		filePath={entry.filePath}
 		status={entry.status}
 		kind={entry.kind}
+		padded={true}
 		{iconBasePath}
 	/>
 {/if}

--- a/packages/ui/src/components/agent-panel/agent-panel-layout.svelte
+++ b/packages/ui/src/components/agent-panel/agent-panel-layout.svelte
@@ -146,6 +146,7 @@
 							subtitle={entry.subtitle}
 							filePath={entry.filePath}
 							status={entry.status}
+							padded={true}
 							{iconBasePath}
 						/>
 					{/if}

--- a/packages/ui/src/components/agent-panel/agent-tool-read.svelte
+++ b/packages/ui/src/components/agent-panel/agent-tool-read.svelte
@@ -52,7 +52,7 @@
 <div>
 	<div class="flex items-start gap-1.5">
 		<div class="flex min-w-0 flex-1 items-center gap-1.5">
-			<div class="flex min-w-0 items-center gap-1.5 text-xs text-muted-foreground">
+			<div class="flex min-w-0 items-center gap-1.5 text-sm text-muted-foreground">
 				<!-- Status label with shimmer when pending -->
 				<ToolLabel {status}>
 					{#if isPending}

--- a/packages/ui/src/components/agent-panel/agent-tool-row.svelte
+++ b/packages/ui/src/components/agent-panel/agent-tool-row.svelte
@@ -9,6 +9,7 @@
 		filePath?: string;
 		status?: AgentToolStatus;
 		durationLabel?: string;
+		padded?: boolean;
 		/** Base path for file type SVG icons (e.g. "/svgs/icons") */
 		iconBasePath?: string;
 		/** Tool kind (e.g. "edit", "think") for styling or analytics; optional. */
@@ -21,15 +22,16 @@
 		filePath,
 		status = "done",
 		durationLabel,
+		padded = false,
 		iconBasePath = "",
 	}: Props = $props();
 
 	const fileName = $derived(filePath ? (filePath.split("/").pop() || filePath) : null);
 </script>
 
-<div class="flex items-start gap-1.5 px-2">
+<div class="flex items-start gap-1.5 {padded ? 'px-2' : ''}">
 	<div class="flex min-w-0 flex-1 items-center gap-1.5">
-		<div class="flex min-w-0 items-center gap-1.5 text-xs text-muted-foreground">
+		<div class="flex min-w-0 items-center gap-1.5 text-sm text-muted-foreground">
 			<!-- Title -->
 			<ToolLabel {status}>{title}</ToolLabel>
 

--- a/packages/ui/src/components/agent-panel/agent-tool-search.svelte
+++ b/packages/ui/src/components/agent-panel/agent-tool-search.svelte
@@ -77,35 +77,39 @@
 <!-- No card: when streaming show content; when done show summary only, click to expand -->
 <div class="flex min-w-0 flex-1 flex-col">
 	<!-- Header: label + query/count/duration; whole row clickable when done to expand -->
-	<button
-		type="button"
-		class="flex min-w-0 flex-1 cursor-pointer items-center justify-between gap-2 border-0 bg-transparent p-0 text-left transition-colors hover:text-foreground"
-		onclick={() => { isCollapsed = !isCollapsed; }}
-		aria-label={isCollapsed ? ariaExpandResults : ariaCollapseResults}
-	>
-		<div class="flex min-w-0 flex-1 items-center gap-1 overflow-hidden">
-			<ToolLabel {status}>{headerLabel}</ToolLabel>
-			{#if query}
-				<code class="min-w-0 max-w-[200px] truncate rounded bg-muted px-1 py-px font-mono text-[10px] text-foreground" title={query}>
-					{query}
-				</code>
-				{#if resultText}
-					<span class="text-muted-foreground/80">·</span>
-					<span class="font-mono text-[10px] text-muted-foreground/80">{resultText}</span>
+	<div class="flex items-start gap-1.5">
+		<button
+			type="button"
+			class="flex min-w-0 flex-1 cursor-pointer items-start justify-between gap-2 border-0 bg-transparent p-0 text-left transition-colors hover:text-foreground"
+			onclick={() => { isCollapsed = !isCollapsed; }}
+			aria-label={isCollapsed ? ariaExpandResults : ariaCollapseResults}
+		>
+			<div class="flex min-w-0 flex-1 items-center gap-1.5 overflow-hidden text-sm text-muted-foreground">
+				<ToolLabel {status}>{headerLabel}</ToolLabel>
+				{#if query}
+					<code class="min-w-0 max-w-[200px] truncate rounded bg-muted px-1 py-px font-mono text-[10px] text-foreground" title={query}>
+						{query}
+					</code>
+					{#if resultText}
+						<span class="text-muted-foreground/80">·</span>
+						<span class="font-mono text-[10px] text-muted-foreground/80">{resultText}</span>
+					{/if}
 				{/if}
-			{/if}
-			{#if durationLabel}
-				<span class="shrink-0 font-mono text-[10px] text-muted-foreground/70">{durationLabel}</span>
-			{/if}
-		</div>
-		{#if hasFiles}
-			<CaretRight
-				size={10}
-				weight="bold"
-				class="shrink-0 text-muted-foreground transition-transform duration-150 {isCollapsed ? '' : 'rotate-90'}"
-			/>
-		{/if}
-	</button>
+			</div>
+			<div class="flex shrink-0 items-center gap-2">
+				{#if durationLabel}
+					<span class="pt-0.5 font-mono text-[10px] text-muted-foreground/70">{durationLabel}</span>
+				{/if}
+				{#if hasFiles}
+					<CaretRight
+						size={10}
+						weight="bold"
+						class="shrink-0 text-muted-foreground transition-transform duration-150 {isCollapsed ? '' : 'rotate-90'}"
+					/>
+				{/if}
+			</div>
+		</button>
+	</div>
 
 	<!-- Body: file list only when expanded (or when streaming) -->
 	{#if !isCollapsed && hasFiles}
@@ -139,4 +143,3 @@
 		</div>
 	{/if}
 </div>
-

--- a/packages/ui/src/components/agent-panel/agent-tool-task.svelte
+++ b/packages/ui/src/components/agent-panel/agent-tool-task.svelte
@@ -188,6 +188,7 @@
 				filePath={lastToolCall.filePath}
 				status={lastToolCall.status}
 				kind={lastToolCall.kind}
+				padded={true}
 				{iconBasePath}
 			/>
 		</div>

--- a/packages/ui/src/components/agent-panel/planning-label.ts
+++ b/packages/ui/src/components/agent-panel/planning-label.ts
@@ -1,0 +1,3 @@
+export function getPlanningPlaceholderLabel(): string {
+	return "Planning next moves…";
+}

--- a/packages/ui/src/components/agent-panel/tool-label.svelte
+++ b/packages/ui/src/components/agent-panel/tool-label.svelte
@@ -16,7 +16,7 @@
 	const isPending = $derived(status === "pending" || status === "running");
 </script>
 
-<span class="shrink-0 text-xs font-normal tracking-normal text-muted-foreground">
+<span class="shrink-0 text-sm font-normal tracking-normal text-muted-foreground">
 	{#if isPending}
 		<TextShimmer>
 			{@render children()}

--- a/packages/ui/src/components/markdown/markdown-display.svelte
+++ b/packages/ui/src/components/markdown/markdown-display.svelte
@@ -9,16 +9,18 @@
 
 	import "./markdown-prose.css";
 
-	interface Props {
-		content: string;
-		class?: string;
-		scrollable?: boolean;
-		/** Custom error message. Defaults to "Error rendering markdown" */
-		errorMessage?: (error: string) => string;
-		/**
-		 * Base path for file type SVG icons (e.g. "/svgs/icons").
-		 * Empty string (default) falls back to extension-colored dots.
-		 */
+interface Props {
+	content: string;
+	class?: string;
+	scrollable?: boolean;
+	/** Text size class for the markdown content (e.g. "text-sm", "text-xs"). Defaults to "text-sm". */
+	textSize?: string;
+	/** Custom error message. Defaults to "Error rendering markdown" */
+	errorMessage?: (error: string) => string;
+	/**
+	 * Base path for file type SVG icons (e.g. "/svgs/icons").
+	 * Empty string (default) falls back to extension-colored dots.
+	 */
 		iconBasePath?: string;
 	}
 
@@ -28,6 +30,7 @@
 		scrollable = false,
 		errorMessage,
 		iconBasePath = getIconBasePath(),
+		textSize = "text-sm",
 	}: Props = $props();
 
 	const api = $derived(getMarkdownRenderApi());
@@ -158,16 +161,16 @@
 			<p class="whitespace-pre-wrap mt-2">{content}</p>
 		</div>
 	{:else if html}
-		<div bind:this={containerRef} class="markdown-content min-w-0 max-w-full p-6 text-sm leading-relaxed text-foreground">
+		<div bind:this={containerRef} class="markdown-content min-w-0 max-w-full p-6 {textSize} leading-relaxed text-foreground">
 			<!-- svelte-ignore a11y_no_static_element_interactions -->
 			{@html html}
 		</div>
 	{:else if isLoading}
-		<div class="markdown-loading text-sm text-foreground whitespace-pre-wrap leading-relaxed p-6">
+		<div class="markdown-loading {textSize} text-foreground whitespace-pre-wrap leading-relaxed p-6">
 			{content}
 		</div>
 	{:else}
-		<p class="text-sm text-foreground whitespace-pre-wrap leading-relaxed p-6">
+		<p class="{textSize} text-foreground whitespace-pre-wrap leading-relaxed p-6">
 			{content}
 		</p>
 	{/if}


### PR DESCRIPTION
## Summary

Normalizes agent-panel tool row typography and fixes sparse tool-call merges so completed grep/search cards keep their query details instead of collapsing to a bare label.

## What changed

- normalized markdown, planning, and tool labels onto the shared `text-sm` treatment and aligned search-row structure with the read-row presentation
- restored the shared planning label helper and kept planning rows flush with the rest of the panel chrome
- taught both the live desktop tool-call store and Copilot history replay merge to preserve known tool arguments when later sparse updates arrive, with regression coverage for search payloads

---

[![Compound Engineering](https://img.shields.io/badge/Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
🤖 Generated with GPT-5.4 (unknown context, standard reasoning) via [GitHub Copilot CLI](https://github.com/features/copilot)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Unifies agent-panel tool row typography and layout, and fixes sparse tool-call merging so grep/search rows keep their query and path details in live sessions and history replay.

- **Bug Fixes**
  - Preserve existing tool arguments when sparse updates arrive in `ToolCallManager` and Tauri `copilot_history` (including `search`, `read`, `execute`, and more), preventing completed grep rows from collapsing to label-only.
  - Add regression tests for sparse search create and completion updates.

- **Refactors**
  - Normalize tool labels and row text to `text-sm`; standardize markdown sizing via `MarkdownDisplay` `textSize` (default `text-sm`).
  - Restore shared planning label with `getPlanningPlaceholderLabel()` and render it via `AgentToolRow`; add `padded` prop for consistent spacing.
  - Tidy search row header layout for better alignment and caret behavior.

<sup>Written for commit 224d6e3b1fcfa8d071453aadf91aed1459d1d6ba. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

