### PR TITLE
feat(streaming): render markdown during reveal

### DIFF
--- a/packages/desktop/src/lib/acp/components/messages/logic/__tests__/live-markdown-promotion.vitest.ts
+++ b/packages/desktop/src/lib/acp/components/messages/logic/__tests__/live-markdown-promotion.vitest.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from "vitest";
+
+import { promoteLiveMarkdownText } from "../live-markdown-promotion.js";
+
+describe("promoteLiveMarkdownText", () => {
+	it("promotes a plain paragraph to live markdown", () => {
+		expect(promoteLiveMarkdownText("Hello world")).toEqual({
+			markdown: "Hello world",
+			presentation: "paragraph",
+		});
+	});
+
+	it("promotes a heading to live markdown", () => {
+		expect(promoteLiveMarkdownText("## Shipping plan")).toEqual({
+			markdown: "## Shipping plan",
+			presentation: "heading",
+		});
+	});
+
+	it("promotes blockquote lines when all revealed lines are quoted", () => {
+		expect(promoteLiveMarkdownText("> quoted\n> still quoted")).toEqual({
+			markdown: "> quoted\n> still quoted",
+			presentation: "blockquote",
+		});
+	});
+
+	it("promotes closed safe markdown links", () => {
+		expect(promoteLiveMarkdownText("[Acepe](https://acepe.dev)")).toEqual({
+			markdown: "[Acepe](https://acepe.dev)",
+			presentation: "paragraph",
+		});
+	});
+
+	it("keeps partial or disallowed links on the fallback path", () => {
+		expect(promoteLiveMarkdownText("[Acepe](https://acepe.dev")).toBeNull();
+		expect(promoteLiveMarkdownText("[bad](javascript:alert(1))")).toBeNull();
+	});
+
+	it("keeps task-list syntax on the fallback path", () => {
+		expect(promoteLiveMarkdownText("- [ ] pending")).toBeNull();
+		expect(promoteLiveMarkdownText("- [x] done")).toBeNull();
+	});
+
+	it("keeps mixed ordered and unordered list markers on the fallback path", () => {
+		expect(promoteLiveMarkdownText("1. one\n- two")).toBeNull();
+	});
+
+	it("keeps ambiguous inline markers on the fallback path", () => {
+		expect(promoteLiveMarkdownText("**bold")).toBeNull();
+		expect(promoteLiveMarkdownText("`snippet")).toBeNull();
+	});
+
+	it("keeps raw html-like content on the fallback path", () => {
+		expect(promoteLiveMarkdownText("<script>alert(1)</script>")).toBeNull();
+	});
+});

--- a/packages/desktop/src/lib/acp/components/messages/logic/__tests__/parse-streaming-tail.vitest.ts
+++ b/packages/desktop/src/lib/acp/components/messages/logic/__tests__/parse-streaming-tail.vitest.ts
@@ -13,7 +13,29 @@ describe("parseStreamingTail", () => {
 		expect(parseStreamingTail("# Title\n\nHello")).toEqual({
 			sections: [
 				{ key: "SETTLED:0", kind: "settled", markdown: "# Title" },
-				{ key: "LIVE:1", kind: "live-text", text: "Hello", source: "Hello" },
+				{
+					key: "LIVE:1",
+					kind: "live-markdown",
+					text: "Hello",
+					markdown: "Hello",
+					presentation: "paragraph",
+					source: "Hello",
+				},
+			],
+		});
+	});
+
+	it("promotes a live list tail when the revealed lines are safe list items", () => {
+		expect(parseStreamingTail("- first\n- second")).toEqual({
+			sections: [
+				{
+					key: "LIVE:0",
+					kind: "live-markdown",
+					text: "- first\n- second",
+					markdown: "- first\n- second",
+					presentation: "list",
+					source: "- first\n- second",
+				},
 			],
 		});
 	});
@@ -70,7 +92,14 @@ describe("parseStreamingTail", () => {
 
 		expect(next.sections).toEqual([
 			{ key: "SETTLED:0", kind: "settled", markdown: "# Title" },
-			{ key: "LIVE:1", kind: "live-text", text: "Hello world", source: "Hello world" },
+			{
+				key: "LIVE:1",
+				kind: "live-markdown",
+				text: "Hello world",
+				markdown: "Hello world",
+				presentation: "paragraph",
+				source: "Hello world",
+			},
 		]);
 		expect(next.sections[0]).toBe(previous.sections[0]);
 	});
@@ -82,8 +111,14 @@ describe("parseStreamingTail", () => {
 		expect(next.sections).toEqual([
 			{ key: "SETTLED:0", kind: "settled", markdown: "# Title" },
 			{ key: "SETTLED:1", kind: "settled", markdown: "Hello" },
-			{ key: "LIVE:2", kind: "live-text", text: "Next", source: "Next" },
-			{ key: "LIVE:2", kind: "live-text", text: "Next", source: "Next" },
+			{
+				key: "LIVE:2",
+				kind: "live-markdown",
+				text: "Next",
+				markdown: "Next",
+				presentation: "paragraph",
+				source: "Next",
+			},
 		]);
 		expect(next.sections[0]).toBe(previous.sections[0]);
 	});

--- a/packages/desktop/src/lib/acp/components/messages/logic/__tests__/parse-streaming-tail.vitest.ts
+++ b/packages/desktop/src/lib/acp/components/messages/logic/__tests__/parse-streaming-tail.vitest.ts
@@ -40,6 +40,29 @@ describe("parseStreamingTail", () => {
 		});
 	});
 
+	it("splits safe mixed blocks in the live tail instead of flattening them", () => {
+		expect(parseStreamingTail("# Title\nBody")).toEqual({
+			sections: [
+				{
+					key: "LIVE:0",
+					kind: "live-markdown",
+					text: "# Title",
+					markdown: "# Title",
+					presentation: "heading",
+					source: "# Title",
+				},
+				{
+					key: "LIVE:1",
+					kind: "live-markdown",
+					text: "Body",
+					markdown: "Body",
+					presentation: "paragraph",
+					source: "Body",
+				},
+			],
+		});
+	});
+
 	it("returns only settled sections when trailing blank lines flush the final buffer", () => {
 		expect(parseStreamingTail("# Title\n\n")).toEqual({
 			sections: [{ key: "SETTLED:0", kind: "settled", markdown: "# Title" }],
@@ -102,6 +125,30 @@ describe("parseStreamingTail", () => {
 			},
 		]);
 		expect(next.sections[0]).toBe(previous.sections[0]);
+	});
+
+	it("keeps an already-revealed heading stable when body text begins underneath it", () => {
+		const previous = parseStreamingTail("# Title");
+		const next = parseStreamingTailIncremental("# Title", previous, "# Title\nBody");
+
+		expect(next.sections).toEqual([
+			{
+				key: "LIVE:0",
+				kind: "live-markdown",
+				text: "# Title",
+				markdown: "# Title",
+				presentation: "heading",
+				source: "# Title",
+			},
+			{
+				key: "LIVE:1",
+				kind: "live-markdown",
+				text: "Body",
+				markdown: "Body",
+				presentation: "paragraph",
+				source: "Body",
+			},
+		]);
 	});
 
 	it("reparses only the previous live tail when reveal growth creates a new block", () => {

--- a/packages/desktop/src/lib/acp/components/messages/logic/__tests__/render-live-markdown.vitest.ts
+++ b/packages/desktop/src/lib/acp/components/messages/logic/__tests__/render-live-markdown.vitest.ts
@@ -55,6 +55,32 @@ describe("renderLiveMarkdownSection", () => {
 		expect(result.html).not.toContain("<a");
 	});
 
+	it("preserves non-1 ordered list starts during reveal", () => {
+		const result = renderLiveMarkdownSection(
+			{
+				key: "LIVE:0",
+				kind: "live-markdown",
+				text: "3. third\n4. fourth",
+				markdown: "3. third\n4. fourth",
+				presentation: "list",
+				source: "3. third\n4. fourth",
+			},
+			{
+				nowMs: (() => {
+					let tick = 15;
+					return () => {
+						tick += 1;
+						return tick;
+					};
+				})(),
+			}
+		);
+
+		expect(result.html).toContain('<ol start="3">');
+		expect(result.html).toContain("<li>third</li>");
+		expect(result.html).toContain("<li>fourth</li>");
+	});
+
 	it("renders a settled fenced code block without using the final renderer", () => {
 		const result = renderLiveMarkdownSection(
 			{

--- a/packages/desktop/src/lib/acp/components/messages/logic/__tests__/render-live-markdown.vitest.ts
+++ b/packages/desktop/src/lib/acp/components/messages/logic/__tests__/render-live-markdown.vitest.ts
@@ -1,0 +1,101 @@
+import { describe, expect, it } from "vitest";
+
+import { renderLiveMarkdownSection } from "../render-live-markdown.js";
+
+describe("renderLiveMarkdownSection", () => {
+	it("renders a live paragraph with inline formatting", () => {
+		const result = renderLiveMarkdownSection(
+			{
+				key: "LIVE:0",
+				kind: "live-markdown",
+				text: "**bold** and `code`",
+				markdown: "**bold** and `code`",
+				presentation: "paragraph",
+				source: "**bold** and `code`",
+			},
+			{
+				nowMs: (() => {
+					let tick = 0;
+					return () => {
+						tick += 1;
+						return tick;
+					};
+				})(),
+			}
+		);
+
+		expect(result.durationMs).toBe(1);
+		expect(result.html).toContain("<p>");
+		expect(result.html).toContain("<strong>bold</strong>");
+		expect(result.html).toContain("<code>code</code>");
+	});
+
+	it("renders safe links in a disabled visual state", () => {
+		const result = renderLiveMarkdownSection(
+			{
+				key: "LIVE:0",
+				kind: "live-markdown",
+				text: "[Acepe](https://acepe.dev)",
+				markdown: "[Acepe](https://acepe.dev)",
+				presentation: "paragraph",
+				source: "[Acepe](https://acepe.dev)",
+			},
+			{
+				nowMs: (() => {
+					let tick = 10;
+					return () => {
+						tick += 1;
+						return tick;
+					};
+				})(),
+			}
+		);
+
+		expect(result.html).toContain('class="streaming-live-link is-disabled"');
+		expect(result.html).not.toContain("<a");
+	});
+
+	it("renders a settled fenced code block without using the final renderer", () => {
+		const result = renderLiveMarkdownSection(
+			{
+				key: "SETTLED:0",
+				kind: "settled",
+				markdown: "```ts\nconst answer = 42;\n```",
+			},
+			{
+				nowMs: (() => {
+					let tick = 20;
+					return () => {
+						tick += 1;
+						return tick;
+					};
+				})(),
+			}
+		);
+
+		expect(result.html).toContain("<pre");
+		expect(result.html).toContain("<code");
+		expect(result.html).toContain("const answer = 42;");
+	});
+
+	it("falls back for settled final-only placeholder output candidates", () => {
+		const result = renderLiveMarkdownSection(
+			{
+				key: "SETTLED:0",
+				kind: "settled",
+				markdown: "```mermaid\ngraph TD;\n```",
+			},
+			{
+				nowMs: (() => {
+					let tick = 30;
+					return () => {
+						tick += 1;
+						return tick;
+					};
+				})(),
+			}
+		);
+
+		expect(result.html).toBeNull();
+	});
+});

--- a/packages/desktop/src/lib/acp/components/messages/logic/live-markdown-promotion.ts
+++ b/packages/desktop/src/lib/acp/components/messages/logic/live-markdown-promotion.ts
@@ -1,0 +1,98 @@
+export type LiveMarkdownPresentation = "paragraph" | "heading" | "blockquote" | "list";
+
+export interface LiveMarkdownPromotion {
+	markdown: string;
+	presentation: LiveMarkdownPresentation;
+}
+
+const SAFE_LINK_PATTERN = /\[([^\]\n]+)\]\(([^)\n]+)\)/g;
+const RAW_HTML_PATTERN = /<\/?[A-Za-z][^>\n]*>/;
+const TASK_LIST_PATTERN = /^\s*[-*+]\s+\[[ xX]\]\s+/;
+const HEADING_PATTERN = /^#{1,6}\s+\S/;
+const BLOCKQUOTE_PATTERN = /^\s*>\s?.+/;
+const UNORDERED_LIST_PATTERN = /^\s*[-*+]\s+(?!\[[ xX]\])\S/;
+const ORDERED_LIST_PATTERN = /^\s*\d+\.\s+\S/;
+const CODE_SPAN_PATTERN = /`[^`\n]+`/g;
+const STRONG_ASTERISK_PATTERN = /\*\*[^*\n]+\*\*/g;
+const EMPHASIS_ASTERISK_PATTERN = /(^|[^*])\*[^*\n]+\*(?!\*)/g;
+
+function classifyPresentation(text: string): LiveMarkdownPresentation {
+	const lines = text.split("\n");
+	const everyLineIsUnorderedList = lines.every((line) => UNORDERED_LIST_PATTERN.test(line));
+	const everyLineIsOrderedList = lines.every((line) => ORDERED_LIST_PATTERN.test(line));
+
+	if (lines.length === 1 && HEADING_PATTERN.test(text)) {
+		return "heading";
+	}
+
+	if (lines.every((line) => BLOCKQUOTE_PATTERN.test(line))) {
+		return "blockquote";
+	}
+
+	if (everyLineIsUnorderedList || everyLineIsOrderedList) {
+		return "list";
+	}
+
+	return "paragraph";
+}
+
+function removeSafeLinks(text: string): string {
+	return text.replaceAll(SAFE_LINK_PATTERN, (_, _label: string, href: string) => {
+		if (href.startsWith("http://") || href.startsWith("https://")) {
+			return "";
+		}
+
+		return `[link](${href})`;
+	});
+}
+
+function removeClosedInlineFormatting(text: string): string {
+	const withoutCode = text.replaceAll(CODE_SPAN_PATTERN, "");
+	const withoutStrong = withoutCode.replaceAll(STRONG_ASTERISK_PATTERN, "");
+	return withoutStrong.replaceAll(EMPHASIS_ASTERISK_PATTERN, (_match: string, prefix: string) => prefix);
+}
+
+function hasUnsafeLinkSyntax(text: string): boolean {
+	const withoutSafeLinks = removeSafeLinks(text);
+
+	if (withoutSafeLinks.includes("javascript:")) {
+		return true;
+	}
+
+	return withoutSafeLinks.includes("[") || withoutSafeLinks.includes("](");
+}
+
+function hasAmbiguousInlineFormatting(text: string): boolean {
+	const withoutClosedFormatting = removeClosedInlineFormatting(text);
+	return withoutClosedFormatting.includes("*") || withoutClosedFormatting.includes("`");
+}
+
+export function promoteLiveMarkdownText(text: string): LiveMarkdownPromotion | null {
+	if (text.length === 0) {
+		return null;
+	}
+
+	if (RAW_HTML_PATTERN.test(text)) {
+		return null;
+	}
+
+	const lines = text.split("\n");
+	const hasAnyUnorderedListLine = lines.some((line) => UNORDERED_LIST_PATTERN.test(line));
+	const hasAnyOrderedListLine = lines.some((line) => ORDERED_LIST_PATTERN.test(line));
+	if (lines.some((line) => TASK_LIST_PATTERN.test(line))) {
+		return null;
+	}
+
+	if (hasAnyUnorderedListLine && hasAnyOrderedListLine) {
+		return null;
+	}
+
+	if (hasUnsafeLinkSyntax(text) || hasAmbiguousInlineFormatting(text)) {
+		return null;
+	}
+
+	return {
+		markdown: text,
+		presentation: classifyPresentation(text),
+	};
+}

--- a/packages/desktop/src/lib/acp/components/messages/logic/parse-streaming-tail.ts
+++ b/packages/desktop/src/lib/acp/components/messages/logic/parse-streaming-tail.ts
@@ -126,6 +126,98 @@ function parseFenceLanguage(line: string): string | null {
 	return language && language.length > 0 ? language : null;
 }
 
+function isHeadingLine(line: string): boolean {
+	return /^#{1,6}\s+\S/.test(line);
+}
+
+function isBlockquoteLine(line: string): boolean {
+	return /^\s*>\s?.+/.test(line);
+}
+
+function getListMarkerFamily(line: string): "ordered" | "unordered" | null {
+	if (/^\s*[-*+]\s+(?!\[[ xX]\])\S/.test(line)) {
+		return "unordered";
+	}
+
+	if (/^\s*\d+\.\s+\S/.test(line)) {
+		return "ordered";
+	}
+
+	return null;
+}
+
+function createLiveTextOrMarkdownSection(index: number, text: string): StreamingTailSection {
+	const promotion = promoteLiveMarkdownText(text);
+	if (promotion === null) {
+		return createLiveTextSection(index, text);
+	}
+
+	return createLiveMarkdownSection(index, text, promotion.markdown, promotion.presentation, text);
+}
+
+function parseLiveMarkdownSections(buffer: string[], startIndex: number): StreamingTailSection[] {
+	const sections: StreamingTailSection[] = [];
+	let sectionIndex = startIndex;
+	let lineIndex = 0;
+
+	while (lineIndex < buffer.length) {
+		const currentLine = buffer[lineIndex];
+		if (isHeadingLine(currentLine)) {
+			sections.push(createLiveTextOrMarkdownSection(sectionIndex, currentLine));
+			sectionIndex += 1;
+			lineIndex += 1;
+			continue;
+		}
+
+		if (isBlockquoteLine(currentLine)) {
+			let nextIndex = lineIndex + 1;
+			while (nextIndex < buffer.length && isBlockquoteLine(buffer[nextIndex])) {
+				nextIndex += 1;
+			}
+
+			sections.push(
+				createLiveTextOrMarkdownSection(sectionIndex, buffer.slice(lineIndex, nextIndex).join("\n"))
+			);
+			sectionIndex += 1;
+			lineIndex = nextIndex;
+			continue;
+		}
+
+		const listMarkerFamily = getListMarkerFamily(currentLine);
+		if (listMarkerFamily !== null) {
+			let nextIndex = lineIndex + 1;
+			while (nextIndex < buffer.length && getListMarkerFamily(buffer[nextIndex]) === listMarkerFamily) {
+				nextIndex += 1;
+			}
+
+			sections.push(
+				createLiveTextOrMarkdownSection(sectionIndex, buffer.slice(lineIndex, nextIndex).join("\n"))
+			);
+			sectionIndex += 1;
+			lineIndex = nextIndex;
+			continue;
+		}
+
+		let nextIndex = lineIndex + 1;
+		while (
+			nextIndex < buffer.length &&
+			!isHeadingLine(buffer[nextIndex]) &&
+			!isBlockquoteLine(buffer[nextIndex]) &&
+			getListMarkerFamily(buffer[nextIndex]) === null
+		) {
+			nextIndex += 1;
+		}
+
+		sections.push(
+			createLiveTextOrMarkdownSection(sectionIndex, buffer.slice(lineIndex, nextIndex).join("\n"))
+		);
+		sectionIndex += 1;
+		lineIndex = nextIndex;
+	}
+
+	return sections;
+}
+
 export function parseStreamingTail(text: string): StreamingTailParseResult {
 	if (text.length === 0) {
 		return { sections: [] };
@@ -193,22 +285,9 @@ export function parseStreamingTail(text: string): StreamingTailParseResult {
 		return { sections };
 	}
 
-	const liveText = buffer.join("\n");
-	const promotion = promoteLiveMarkdownText(liveText);
-	if (promotion) {
-		sections.push(
-			createLiveMarkdownSection(
-				blockIndex,
-				liveText,
-				promotion.markdown,
-				promotion.presentation,
-				liveText
-			)
-		);
-		return { sections };
+	for (const section of parseLiveMarkdownSections(buffer, blockIndex)) {
+		sections.push(section);
 	}
-
-	sections.push(createLiveTextSection(blockIndex, liveText));
 	return { sections };
 }
 

--- a/packages/desktop/src/lib/acp/components/messages/logic/parse-streaming-tail.ts
+++ b/packages/desktop/src/lib/acp/components/messages/logic/parse-streaming-tail.ts
@@ -1,8 +1,19 @@
+import type { LiveMarkdownPresentation } from "./live-markdown-promotion.js";
+import { promoteLiveMarkdownText } from "./live-markdown-promotion.js";
+
 export type StreamingTailSection =
 	| {
 			key: string;
 			kind: "settled";
 			markdown: string;
+	  }
+	| {
+			key: string;
+			kind: "live-markdown";
+			text: string;
+			markdown: string;
+			presentation: LiveMarkdownPresentation;
+			source: string;
 	  }
 	| {
 			key: string;
@@ -31,10 +42,24 @@ function rekeySection(section: StreamingTailSection, index: number): StreamingTa
 		return createLiveCodeSection(index, section.code, section.language, section.source);
 	}
 
+	if (section.kind === "live-markdown") {
+		return createLiveMarkdownSection(
+			index,
+			section.text,
+			section.markdown,
+			section.presentation,
+			section.source
+		);
+	}
+
 	return createLiveTextSection(index, section.text);
 }
 
 function buildReparseSource(section: StreamingTailSection): string | null {
+	if (section.kind === "live-markdown") {
+		return section.source;
+	}
+
 	if (section.kind === "live-text") {
 		return section.source;
 	}
@@ -60,6 +85,23 @@ function createLiveTextSection(index: number, text: string): StreamingTailSectio
 		kind: "live-text",
 		text,
 		source: text,
+	};
+}
+
+function createLiveMarkdownSection(
+	index: number,
+	text: string,
+	markdown: string,
+	presentation: LiveMarkdownPresentation,
+	source: string
+): StreamingTailSection {
+	return {
+		key: `LIVE:${index}`,
+		kind: "live-markdown",
+		text,
+		markdown,
+		presentation,
+		source,
 	};
 }
 
@@ -151,7 +193,22 @@ export function parseStreamingTail(text: string): StreamingTailParseResult {
 		return { sections };
 	}
 
-	sections.push(createLiveTextSection(blockIndex, buffer.join("\n")));
+	const liveText = buffer.join("\n");
+	const promotion = promoteLiveMarkdownText(liveText);
+	if (promotion) {
+		sections.push(
+			createLiveMarkdownSection(
+				blockIndex,
+				liveText,
+				promotion.markdown,
+				promotion.presentation,
+				liveText
+			)
+		);
+		return { sections };
+	}
+
+	sections.push(createLiveTextSection(blockIndex, liveText));
 	return { sections };
 }
 

--- a/packages/desktop/src/lib/acp/components/messages/logic/render-live-markdown.ts
+++ b/packages/desktop/src/lib/acp/components/messages/logic/render-live-markdown.ts
@@ -145,6 +145,11 @@ function renderList(markdown: string): string {
 	const lines = markdown.split("\n");
 	const isOrdered = ORDERED_LIST_PREFIX_PATTERN.test(lines[0]);
 	const tagName = isOrdered ? "ol" : "ul";
+	const orderedListStartMatch = isOrdered ? /^\s*(\d+)\.\s+/.exec(lines[0]) : null;
+	const startAttribute =
+		orderedListStartMatch !== null && orderedListStartMatch[1] !== "1"
+			? ` start="${escapeHtml(orderedListStartMatch[1])}"`
+			: "";
 	const itemsHtml = lines
 		.map((line) => {
 			const itemText = isOrdered
@@ -153,7 +158,7 @@ function renderList(markdown: string): string {
 			return `<li>${renderInlineMarkdown(itemText)}</li>`;
 		})
 		.join("");
-	return `<${tagName}>${itemsHtml}</${tagName}>`;
+	return `<${tagName}${startAttribute}>${itemsHtml}</${tagName}>`;
 }
 
 function renderPresentation(markdown: string, presentation: LiveMarkdownPresentation): string | null {

--- a/packages/desktop/src/lib/acp/components/messages/logic/render-live-markdown.ts
+++ b/packages/desktop/src/lib/acp/components/messages/logic/render-live-markdown.ts
@@ -1,0 +1,211 @@
+import { promoteLiveMarkdownText, type LiveMarkdownPresentation } from "./live-markdown-promotion.js";
+import type { StreamingTailSection } from "./parse-streaming-tail.js";
+
+export const LIVE_MARKDOWN_RENDER_BUDGET_MS = 8;
+export const LIVE_MARKDOWN_RENDER_BREACH_LIMIT = 2;
+
+type RenderableStreamingSection = Extract<
+	StreamingTailSection,
+	{ kind: "settled" | "live-markdown" }
+>;
+
+export interface LiveMarkdownRenderResult {
+	html: string | null;
+	durationMs: number;
+}
+
+interface RenderLiveMarkdownOptions {
+	nowMs?: () => number;
+}
+
+const SAFE_LINK_PATTERN = /\[([^\]\n]+)\]\(([^)\n]+)\)/g;
+const CODE_SPAN_PATTERN = /`([^`\n]+)`/g;
+const STRONG_ASTERISK_PATTERN = /\*\*([^*\n]+)\*\*/g;
+const EMPHASIS_ASTERISK_PATTERN = /(^|[^*])\*([^*\n]+)\*(?!\*)/g;
+const HEADING_PATTERN = /^(#{1,6})\s+(.*)$/;
+const BLOCKQUOTE_PREFIX_PATTERN = /^\s*>\s?/;
+const UNORDERED_LIST_PREFIX_PATTERN = /^\s*[-*+]\s+/;
+const ORDERED_LIST_PREFIX_PATTERN = /^\s*\d+\.\s+/;
+const FENCE_START_PATTERN = /^```([^\s`]+)?$/;
+const FENCE_END = "```";
+
+function getNowMs(): number {
+	return performance.now();
+}
+
+function escapeHtml(text: string): string {
+	return text
+		.replaceAll("&", "&amp;")
+		.replaceAll("<", "&lt;")
+		.replaceAll(">", "&gt;")
+		.replaceAll('"', "&quot;")
+		.replaceAll("'", "&#39;");
+}
+
+function createTokenHtml(htmlByToken: Map<string, string>, html: string): string {
+	const token = `@@LIVE_MD_${htmlByToken.size}@@`;
+	htmlByToken.set(token, html);
+	return token;
+}
+
+function restoreTokenHtml(text: string, htmlByToken: ReadonlyMap<string, string>): string {
+	let restored = text;
+	for (const [token, html] of htmlByToken.entries()) {
+		restored = restored.replaceAll(token, html);
+	}
+	return restored;
+}
+
+function isSafeExternalHref(href: string): boolean {
+	return href.startsWith("https://") || href.startsWith("http://");
+}
+
+function renderInlineMarkdown(text: string): string {
+	const htmlByToken = new Map<string, string>();
+
+	let templated = text.replaceAll(CODE_SPAN_PATTERN, (_match: string, content: string) =>
+		createTokenHtml(htmlByToken, `<code>${escapeHtml(content)}</code>`)
+	);
+
+	templated = templated.replaceAll(
+		SAFE_LINK_PATTERN,
+		(match: string, label: string, href: string) => {
+			if (!isSafeExternalHref(href)) {
+				return match;
+			}
+
+			return createTokenHtml(
+				htmlByToken,
+				`<span class="streaming-live-link is-disabled" data-streaming-link-state="disabled">${escapeHtml(label)}</span>`
+			);
+		}
+	);
+
+	templated = templated.replaceAll(STRONG_ASTERISK_PATTERN, (_match: string, content: string) =>
+		createTokenHtml(htmlByToken, `<strong>${escapeHtml(content)}</strong>`)
+	);
+
+	templated = templated.replaceAll(
+		EMPHASIS_ASTERISK_PATTERN,
+		(_match: string, prefix: string, content: string) =>
+			`${prefix}${createTokenHtml(htmlByToken, `<em>${escapeHtml(content)}</em>`)}`
+	);
+
+	return restoreTokenHtml(escapeHtml(templated), htmlByToken);
+}
+
+function parseFencedCodeBlock(markdown: string): { language: string | null; code: string } | null {
+	const lines = markdown.split("\n");
+	if (lines.length < 2) {
+		return null;
+	}
+
+	const openingFenceMatch = FENCE_START_PATTERN.exec(lines[0]);
+	if (!openingFenceMatch) {
+		return null;
+	}
+
+	if (lines[lines.length - 1] !== FENCE_END) {
+		return null;
+	}
+
+	const language = openingFenceMatch[1] && openingFenceMatch[1].length > 0 ? openingFenceMatch[1] : null;
+	if (language === "mermaid") {
+		return null;
+	}
+
+	return {
+		language,
+		code: lines.slice(1, -1).join("\n"),
+	};
+}
+
+function renderParagraph(markdown: string): string {
+	return `<p>${renderInlineMarkdown(markdown)}</p>`;
+}
+
+function renderHeading(markdown: string): string | null {
+	const match = HEADING_PATTERN.exec(markdown);
+	if (!match) {
+		return null;
+	}
+
+	const level = match[1].length;
+	return `<h${level}>${renderInlineMarkdown(match[2])}</h${level}>`;
+}
+
+function renderBlockquote(markdown: string): string {
+	const lines = markdown
+		.split("\n")
+		.map((line) => line.replace(BLOCKQUOTE_PREFIX_PATTERN, ""));
+	return `<blockquote><p>${lines.map((line) => renderInlineMarkdown(line)).join("<br>")}</p></blockquote>`;
+}
+
+function renderList(markdown: string): string {
+	const lines = markdown.split("\n");
+	const isOrdered = ORDERED_LIST_PREFIX_PATTERN.test(lines[0]);
+	const tagName = isOrdered ? "ol" : "ul";
+	const itemsHtml = lines
+		.map((line) => {
+			const itemText = isOrdered
+				? line.replace(ORDERED_LIST_PREFIX_PATTERN, "")
+				: line.replace(UNORDERED_LIST_PREFIX_PATTERN, "");
+			return `<li>${renderInlineMarkdown(itemText)}</li>`;
+		})
+		.join("");
+	return `<${tagName}>${itemsHtml}</${tagName}>`;
+}
+
+function renderPresentation(markdown: string, presentation: LiveMarkdownPresentation): string | null {
+	if (presentation === "heading") {
+		return renderHeading(markdown);
+	}
+
+	if (presentation === "blockquote") {
+		return renderBlockquote(markdown);
+	}
+
+	if (presentation === "list") {
+		return renderList(markdown);
+	}
+
+	return renderParagraph(markdown);
+}
+
+export function renderLiveMarkdownSection(
+	section: RenderableStreamingSection,
+	options: RenderLiveMarkdownOptions = {}
+): LiveMarkdownRenderResult {
+	const nowMs = options.nowMs ?? getNowMs;
+	const startedAt = nowMs();
+
+	const fencedCodeBlock =
+		section.kind === "settled" ? parseFencedCodeBlock(section.markdown) : null;
+	if (fencedCodeBlock) {
+		const languageAttribute =
+			fencedCodeBlock.language === null
+				? ""
+				: ` data-language="${escapeHtml(fencedCodeBlock.language)}"`;
+		return {
+			html: `<pre class="streaming-live-code"><code${languageAttribute}>${escapeHtml(fencedCodeBlock.code)}</code></pre>`,
+			durationMs: nowMs() - startedAt,
+		};
+	}
+
+	const promotion =
+		section.kind === "live-markdown"
+			? {
+					markdown: section.markdown,
+					presentation: section.presentation,
+				}
+			: promoteLiveMarkdownText(section.markdown);
+
+	if (promotion === null) {
+		return { html: null, durationMs: nowMs() - startedAt };
+	}
+
+	return {
+		html: renderPresentation(promotion.markdown, promotion.presentation),
+		durationMs: nowMs() - startedAt,
+	};
+}

--- a/packages/desktop/src/lib/acp/components/messages/markdown-text.svelte
+++ b/packages/desktop/src/lib/acp/components/messages/markdown-text.svelte
@@ -37,6 +37,11 @@ import {
 	parseStreamingTailIncremental,
 	type StreamingTailParseResult,
 } from "./logic/parse-streaming-tail.js";
+import {
+	LIVE_MARKDOWN_RENDER_BREACH_LIMIT,
+	LIVE_MARKDOWN_RENDER_BUDGET_MS,
+	renderLiveMarkdownSection,
+} from "./logic/render-live-markdown.js";
 import { streamingTailRefresh } from "./logic/streaming-tail-refresh.js";
 import {
 	DEFAULT_STREAMING_ANIMATION_MODE,
@@ -324,7 +329,17 @@ const visibleHtml = $derived.by(() => {
 });
 const error = $derived(asyncError);
 const isLoading = $derived(syncResult.needsAsync && asyncPending);
+
+interface StreamingLiveMarkdownState {
+	html: string;
+	renderedText: string;
+	overBudgetStreak: number;
+	isFrozen: boolean;
+	tailText: string;
+}
+
 let streamingSettledHtmlByKey = $state<ReadonlyMap<string, string>>(new Map());
+let streamingLiveMarkdownByKey = $state<ReadonlyMap<string, StreamingLiveMarkdownState>>(new Map());
 const hasLiveStreamingSection = $derived(
 	streamingTail.sections.some((section) => section.kind !== "settled")
 );
@@ -386,29 +401,80 @@ $effect(() => {
 $effect(() => {
 	if (!isRenderingReveal) {
 		streamingSettledHtmlByKey = new Map();
+		streamingLiveMarkdownByKey = new Map();
 		return;
 	}
 
 	const previousSettledHtmlByKey = untrack(() => streamingSettledHtmlByKey);
+	const previousLiveMarkdownByKey = untrack(() => streamingLiveMarkdownByKey);
 	const nextSettledHtmlByKey = new Map<string, string>();
+	const nextLiveMarkdownByKey = new Map<string, StreamingLiveMarkdownState>();
 	for (const section of streamingTail.sections) {
-		if (section.kind !== "settled") {
+		if (section.kind === "settled") {
+			const cachedHtml = previousSettledHtmlByKey.get(section.key);
+			if (cachedHtml !== undefined) {
+				nextSettledHtmlByKey.set(section.key, cachedHtml);
+				continue;
+			}
+
+			const result = renderLiveMarkdownSection(section);
+			if (result.html !== null) {
+				nextSettledHtmlByKey.set(section.key, result.html);
+			}
 			continue;
 		}
 
-		const cachedHtml = previousSettledHtmlByKey.get(section.key);
-		if (cachedHtml !== undefined) {
-			nextSettledHtmlByKey.set(section.key, cachedHtml);
+		if (section.kind !== "live-markdown") {
 			continue;
 		}
 
-		const result = renderMarkdownSync(section.markdown);
-		if (result.html !== null && !htmlNeedsBadgeMount(result.html)) {
-			nextSettledHtmlByKey.set(section.key, result.html);
+		const previousState = previousLiveMarkdownByKey.get(section.key);
+		if (previousState?.isFrozen) {
+			nextLiveMarkdownByKey.set(section.key, {
+				html: previousState.html,
+				renderedText: previousState.renderedText,
+				overBudgetStreak: previousState.overBudgetStreak,
+				isFrozen: true,
+				tailText: section.text.slice(previousState.renderedText.length),
+			});
+			continue;
 		}
+
+		const result = renderLiveMarkdownSection(section);
+		if (result.html === null) {
+			continue;
+		}
+
+		const overBudgetStreak =
+			result.durationMs > LIVE_MARKDOWN_RENDER_BUDGET_MS
+				? (previousState?.overBudgetStreak ?? 0) + 1
+				: 0;
+		const shouldFreeze =
+			previousState !== undefined &&
+			overBudgetStreak >= LIVE_MARKDOWN_RENDER_BREACH_LIMIT;
+
+		if (shouldFreeze) {
+			nextLiveMarkdownByKey.set(section.key, {
+				html: previousState.html,
+				renderedText: previousState.renderedText,
+				overBudgetStreak,
+				isFrozen: true,
+				tailText: section.text.slice(previousState.renderedText.length),
+			});
+			continue;
+		}
+
+		nextLiveMarkdownByKey.set(section.key, {
+			html: result.html,
+			renderedText: section.text,
+			overBudgetStreak,
+			isFrozen: false,
+			tailText: "",
+		});
 	}
 
 	streamingSettledHtmlByKey = nextSettledHtmlByKey;
+	streamingLiveMarkdownByKey = nextLiveMarkdownByKey;
 });
 
 /**
@@ -570,6 +636,22 @@ function handleKeydown(event: KeyboardEvent) {
 					{/if}
 				{:else if section.kind === "live-code"}
 					<pre class="streaming-live-code"><code>{section.code}{#if showStreamingCursor && isLastSection}<span class="streaming-live-cursor" aria-hidden="true"></span>{/if}</code></pre>
+				{:else if section.kind === "live-markdown"}
+					{@const liveMarkdown = streamingLiveMarkdownByKey.get(section.key)}
+					{#if liveMarkdown}
+						{@html liveMarkdown.html}
+						{#if liveMarkdown.tailText.length > 0}
+							<div class="streaming-live-fallback-tail whitespace-pre-wrap">
+								{liveMarkdown.tailText}{#if showStreamingCursor && isLastSection}<span class="streaming-live-cursor" aria-hidden="true"></span>{/if}
+							</div>
+						{:else if showStreamingCursor && isLastSection}
+							<div class="streaming-live-cursor-shell" aria-hidden="true">
+								<span class="streaming-live-cursor"></span>
+							</div>
+						{/if}
+					{:else}
+						<div class="streaming-live-text whitespace-pre-wrap">{section.text}{#if showStreamingCursor && isLastSection}<span class="streaming-live-cursor" aria-hidden="true"></span>{/if}</div>
+					{/if}
 				{:else}
 					<div class="streaming-live-text whitespace-pre-wrap">{section.text}{#if showStreamingCursor && isLastSection}<span class="streaming-live-cursor" aria-hidden="true"></span>{/if}</div>
 				{/if}
@@ -624,6 +706,19 @@ function handleKeydown(event: KeyboardEvent) {
 
 	:global(.streaming-section.streaming-smooth-fade) {
 		animation: smoothFadeIn 300ms ease-out;
+	}
+
+	:global(.streaming-live-link.is-disabled) {
+		color: var(--color-primary);
+		cursor: text;
+		opacity: 0.85;
+		pointer-events: none;
+		text-decoration: underline;
+	}
+
+	.streaming-live-fallback-tail,
+	.streaming-live-cursor-shell {
+		display: inline;
 	}
 
 	@keyframes smoothFadeIn {

--- a/packages/desktop/src/lib/acp/components/messages/markdown-text.svelte.vitest.ts
+++ b/packages/desktop/src/lib/acp/components/messages/markdown-text.svelte.vitest.ts
@@ -441,6 +441,29 @@ describe("MarkdownText", () => {
 		expect(mountGitHubBadgesMock).not.toHaveBeenCalled();
 	});
 
+	it("renders a live heading and following paragraph as separate reveal-safe blocks", async () => {
+		renderMarkdownSyncMock.mockImplementation((text) => ({
+			html: `<p>${text}</p>`,
+			fromCache: false,
+			needsAsync: false,
+		}));
+
+		const view = render(MarkdownText, {
+			text: "# Title\nBody",
+			isStreaming: true,
+			streamingAnimationMode: "instant",
+		});
+
+		await new Promise<void>((resolve) => setTimeout(resolve, 0));
+
+		expect(view.container.querySelector('[data-streaming-section-key="LIVE:0"] h1')?.textContent).toBe(
+			"Title"
+		);
+		expect(view.container.querySelector('[data-streaming-section-key="LIVE:1"] p')?.textContent).toBe(
+			"Body"
+		);
+	});
+
 	it("reveals streaming text over animation frames instead of immediate raw bursts", async () => {
 		renderMarkdownSyncMock.mockImplementation((text) => ({
 			html: `<p>${text}</p>`,

--- a/packages/desktop/src/lib/acp/components/messages/markdown-text.svelte.vitest.ts
+++ b/packages/desktop/src/lib/acp/components/messages/markdown-text.svelte.vitest.ts
@@ -15,8 +15,10 @@ vi.mock("svelte", async () => {
 	return import(/* @vite-ignore */ svelteClientPath);
 });
 
+const openUrlMock = vi.fn();
+
 vi.mock("@tauri-apps/plugin-opener", () => ({
-	openUrl: vi.fn(),
+	openUrl: openUrlMock,
 }));
 
 vi.mock("$lib/messages.js", () => ({
@@ -107,8 +109,10 @@ vi.mock("./logic/mount-github-badges.js", () => ({
 	) => mountGitHubBadgesMock(container, options),
 }));
 
+const parseContentBlocksMock = vi.fn(() => []);
+
 vi.mock("./logic/parse-content-blocks.js", () => ({
-	parseContentBlocks: vi.fn(() => []),
+	parseContentBlocks: () => parseContentBlocksMock(),
 }));
 
 const pendingAsyncRenders = new Map<
@@ -131,6 +135,7 @@ type QueuedAnimationFrame = {
 
 let queuedAnimationFrames: QueuedAnimationFrame[] = [];
 let nextAnimationFrameId = 1;
+let performanceNowSequence: number[] = [];
 
 async function flushAnimationFrames(frameCount = 1, startTime = 16): Promise<void> {
 	for (let frameIndex = 0; frameIndex < frameCount; frameIndex += 1) {
@@ -160,10 +165,16 @@ async function flushAllAnimationFrames(startTime = 16): Promise<void> {
 
 const { default: MarkdownText } = await import("./markdown-text.svelte");
 
+function setPerformanceNowSequence(values: number[]) {
+	performanceNowSequence = [...values];
+}
+
 beforeEach(() => {
 	queuedAnimationFrames = [];
 	nextAnimationFrameId = 1;
+	performanceNowSequence = [];
 	pendingAsyncRenders.clear();
+	openUrlMock.mockReset();
 	getRepoContextMock.mockReset();
 	getProjectGitStatusMapMock.mockReset();
 	getProjectGitStatusMapMock.mockReturnValue({
@@ -171,6 +182,8 @@ beforeEach(() => {
 	});
 	mountFileBadgesMock.mockClear();
 	mountGitHubBadgesMock.mockClear();
+	parseContentBlocksMock.mockReset();
+	parseContentBlocksMock.mockReturnValue([]);
 	renderMarkdownMock.mockClear();
 	renderMarkdownSyncMock.mockReset();
 	vi.stubGlobal("requestAnimationFrame", (callback: FrameRequestCallback): number => {
@@ -182,10 +195,14 @@ beforeEach(() => {
 	vi.stubGlobal("cancelAnimationFrame", (id: number): void => {
 		queuedAnimationFrames = queuedAnimationFrames.filter((frame) => frame.id !== id);
 	});
+	vi.spyOn(performance, "now").mockImplementation(
+		() => performanceNowSequence.shift() ?? queuedAnimationFrames.length * 16
+	);
 });
 
 afterEach(() => {
 	cleanup();
+	vi.restoreAllMocks();
 	vi.unstubAllGlobals();
 });
 
@@ -414,11 +431,12 @@ describe("MarkdownText", () => {
 			expect(view.container.querySelector(".markdown-content h1")?.textContent).toBe(
 				"Hello streaming"
 			);
-			expect(view.container.querySelector(".streaming-live-text")?.textContent).toContain("Body");
+			expect(
+				view.container.querySelector('[data-streaming-section-key="LIVE:1"] p')?.textContent
+			).toContain("Body");
 		});
 
-		expect(renderMarkdownSyncMock).toHaveBeenCalledTimes(1);
-		expect(renderMarkdownSyncMock).toHaveBeenCalledWith("# Hello streaming");
+		expect(renderMarkdownSyncMock).not.toHaveBeenCalled();
 		expect(mountFileBadgesMock).not.toHaveBeenCalled();
 		expect(mountGitHubBadgesMock).not.toHaveBeenCalled();
 	});
@@ -448,7 +466,7 @@ describe("MarkdownText", () => {
 			return section;
 		});
 
-		expect(view.container.querySelector(".streaming-live-text")).not.toBeNull();
+		expect(firstLiveSection?.textContent).not.toBe("");
 		expect(renderMarkdownSyncMock).not.toHaveBeenCalled();
 
 		await view.rerender({
@@ -581,7 +599,143 @@ describe("MarkdownText", () => {
 			settledSection
 		);
 		expect(view.container.querySelector('[data-streaming-section-key="LIVE:1"]')).toBe(liveSection);
-		expect(renderMarkdownSyncMock).toHaveBeenCalledTimes(1);
+		expect(renderMarkdownSyncMock).not.toHaveBeenCalled();
+	});
+
+	it("renders reveal-time links as disabled text instead of interactive anchors", async () => {
+		renderMarkdownSyncMock.mockImplementation((text) => ({
+			html: `<p>${text}</p>`,
+			fromCache: false,
+			needsAsync: false,
+		}));
+
+		const view = render(MarkdownText, {
+			text: "[Acepe](https://acepe.dev)",
+			isStreaming: true,
+			streamingAnimationMode: "instant",
+		});
+
+		await new Promise<void>((resolve) => setTimeout(resolve, 0));
+
+		await waitFor(() => {
+			const disabledLink = view.container.querySelector(".streaming-live-link.is-disabled");
+			expect(disabledLink).toBeTruthy();
+			expect(disabledLink?.textContent).toBe("Acepe");
+		});
+
+		expect(view.container.querySelector("a")).toBeNull();
+		expect(renderMarkdownSyncMock).not.toHaveBeenCalled();
+		expect(renderMarkdownMock).not.toHaveBeenCalled();
+	});
+
+	it("freezes promoted live markdown after consecutive over-budget renders and appends new text as fallback", async () => {
+		renderMarkdownSyncMock.mockImplementation((text) => ({
+			html: `<p>${text}</p>`,
+			fromCache: false,
+			needsAsync: false,
+		}));
+		setPerformanceNowSequence([0, 10, 10, 20]);
+
+		const view = render(MarkdownText, {
+			text: "Hello",
+			isStreaming: true,
+			streamingAnimationMode: "instant",
+		});
+
+		await new Promise<void>((resolve) => setTimeout(resolve, 0));
+
+		await waitFor(() => {
+			expect(
+				view.container.querySelector('[data-streaming-section-key="LIVE:0"] p')?.textContent
+			).toBe("Hello");
+		});
+
+		await view.rerender({
+			text: "Hello world",
+			isStreaming: true,
+			streamingAnimationMode: "instant",
+		});
+		await new Promise<void>((resolve) => setTimeout(resolve, 0));
+
+		await waitFor(() => {
+			expect(
+				view.container.querySelector('[data-streaming-section-key="LIVE:0"] p')?.textContent
+			).toBe("Hello");
+			expect(
+				view.container.querySelector(".streaming-live-fallback-tail")?.textContent
+			).toContain(" world");
+		});
+	});
+
+	it("keeps final-only settled blocks on plain fallback during reveal and upgrades them after settle", async () => {
+		renderMarkdownSyncMock.mockImplementation((text) => ({
+			html:
+				text === "```mermaid\ngraph TD;\n```"
+					? '<div class="mermaid">graph TD;</div>'
+					: `<p>${text}</p>`,
+			fromCache: false,
+			needsAsync: false,
+		}));
+
+		const text = "```mermaid\ngraph TD;\n```";
+		const view = render(MarkdownText, {
+			text,
+			isStreaming: true,
+			streamingAnimationMode: "instant",
+		});
+
+		await new Promise<void>((resolve) => setTimeout(resolve, 0));
+
+		expect(view.container.textContent).toContain(text);
+		expect(view.container.querySelector(".mermaid")).toBeNull();
+		expect(renderMarkdownSyncMock).not.toHaveBeenCalled();
+
+		await view.rerender({
+			text,
+			isStreaming: false,
+			streamingAnimationMode: "instant",
+		});
+
+		await waitFor(() => {
+			expect(view.container.querySelector(".mermaid")?.textContent).toContain("graph TD;");
+		});
+	});
+
+	it("upgrades reveal-time disabled links into interactive anchors after settle", async () => {
+		renderMarkdownSyncMock.mockReturnValue({
+			html: '<p><a href="https://acepe.dev">Acepe</a></p>',
+			fromCache: false,
+			needsAsync: false,
+		});
+
+		const text = "[Acepe](https://acepe.dev)";
+		const view = render(MarkdownText, {
+			text,
+			isStreaming: true,
+			streamingAnimationMode: "instant",
+		});
+
+		await new Promise<void>((resolve) => setTimeout(resolve, 0));
+
+		expect(view.container.querySelector(".streaming-live-link.is-disabled")?.textContent).toBe("Acepe");
+		expect(view.container.querySelector("a")).toBeNull();
+
+		await view.rerender({
+			text,
+			isStreaming: false,
+			streamingAnimationMode: "instant",
+		});
+
+		await waitFor(() => {
+			expect(view.container.querySelector('a[href="https://acepe.dev"]')?.textContent).toBe(
+				"Acepe"
+			);
+		});
+
+		const anchor = view.container.querySelector('a[href="https://acepe.dev"]');
+		anchor?.dispatchEvent(new MouseEvent("click", { bubbles: true, cancelable: true }));
+
+		expect(openUrlMock).toHaveBeenCalledWith("https://acepe.dev");
 	});
 
 	describe("streaming animation modes", () => {
@@ -633,9 +787,10 @@ describe("MarkdownText", () => {
 
 			await new Promise<void>((resolve) => setTimeout(resolve, 0));
 
-			expect(view.container.textContent).toContain(text);
+			expect(view.container.textContent).toContain("bold text");
 			expect(view.container.querySelector(".streaming-section")).toBeTruthy();
-			expect(view.container.querySelector("strong")).toBeNull();
+			expect(view.container.querySelector(".streaming-section strong")?.textContent).toBe("bold");
+			expect(renderMarkdownSyncMock).not.toHaveBeenCalled();
 
 			await view.rerender({
 				text,
@@ -670,11 +825,12 @@ describe("MarkdownText", () => {
 				expect(view.container.querySelector(".markdown-content h1")?.textContent).toBe(
 					"Hello streaming"
 				);
-				expect(view.container.querySelector(".streaming-live-text")?.textContent).toContain("Body");
+				expect(
+					view.container.querySelector('[data-streaming-section-key="LIVE:1"] p')?.textContent
+				).toContain("Body");
 			});
 
-			expect(renderMarkdownSyncMock).toHaveBeenCalledTimes(1);
-			expect(renderMarkdownSyncMock).toHaveBeenCalledWith("# Hello streaming");
+			expect(renderMarkdownSyncMock).not.toHaveBeenCalled();
 		});
 
 		it("reveals smooth mode text in buffered chunks instead of character-by-character", async () => {


### PR DESCRIPTION
## Summary
Enable progressive markdown rendering while assistant messages are still revealing so reveal-safe markdown appears live instead of waiting for the final settled render.

## What changed
- add live markdown promotion and a bounded reveal-time renderer for headings, blockquotes, list items, inline emphasis, inline code, safe links, and fenced code blocks
- keep final-only constructs on plain-text fallback during reveal, disable reveal-time links, and freeze over-budget live tails instead of snapping in whole blocks later
- expand parser and integration coverage for promotion rules, freeze behavior, disabled-link rendering, and settle-time upgrades

## Test plan
- bunx vitest run src/lib/acp/components/messages/logic/__tests__/live-markdown-promotion.vitest.ts src/lib/acp/components/messages/logic/__tests__/render-live-markdown.vitest.ts src/lib/acp/components/messages/logic/__tests__/parse-streaming-tail.vitest.ts src/lib/acp/components/messages/markdown-text.svelte.vitest.ts

---

[![Compound Engineering](https://img.shields.io/badge/Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
🤖 Generated with GPT-5.4 (unknown context, standard reasoning) via GitHub Copilot CLI(https://github.com/features/copilot)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Render markdown progressively while assistant messages stream so safe formatting shows up live with disabled links. Adds a budgeted live renderer that can freeze over‑budget updates to keep reveals smooth and stable.

- **New Features**
  - Promote and render live markdown for headings, blockquotes, lists (preserves ordered list starts), inline bold/emphasis/code, and safe links; split mixed live tails into separate blocks so earlier blocks stay stable; render fenced code blocks when settled; links upgrade from disabled text to anchors on settle.
  - Budgeted live renderer (8ms/frame; freezes after 2 breaches) to prevent jank; when frozen, keep the rendered block and append the new tail as plain text until settle.
  - Parser now emits `live-markdown` sections with presentation metadata; `markdown-text.svelte` uses a lightweight reveal-time renderer and caches per‑section HTML while styling disabled links.

- **Bug Fixes**
  - Improve incremental parsing: share grapheme utils with O(suffix) updates, reparse only the previous live tail, and keep already‑revealed headings stable as body text arrives.
  - Stop smooth fade re-trigger flicker; move from forced reflow to RAF; guard CSS classes by mode; halve reveal speed for readability.
  - Show turn errors in the composer with title/summary/details; store error type and filter the duplicate trailing error in the thread.
  - Pin `@tauri-apps/api`, `@tauri-apps/cli`, and `@tauri-apps/plugin-updater` to 2.10.1 and align Rust `tauri`/`tauri-plugin-updater` 2.10 to fix updater/API mismatches.

<sup>Written for commit 5fd1b1575f81545fcefc17e7e210a8ba5fe3f591. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

