### PR TITLE
fix(worktree): align branch naming and session sequence ids

### DIFF
--- a/packages/desktop/src-tauri/src/db/repository.rs
+++ b/packages/desktop/src-tauri/src/db/repository.rs
@@ -1153,7 +1153,7 @@ impl SessionMetadataRepository {
         db: &impl sea_orm::ConnectionTrait,
         project_path: &str,
     ) -> Result<i32> {
-        let max_seq: Option<i32> = AcepeSessionState::find()
+        let max_state_seq: Option<i32> = AcepeSessionState::find()
             .select_only()
             .column_as(acepe_session_state::Column::SequenceId.max(), "max_seq")
             .filter(acepe_session_state::Column::ProjectPath.eq(project_path))
@@ -1163,7 +1163,57 @@ impl SessionMetadataRepository {
             .await?
             .flatten();
 
+        let max_metadata_seq: Option<i32> = SessionMetadata::find()
+            .select_only()
+            .column_as(session_metadata::Column::SequenceId.max(), "max_seq")
+            .filter(session_metadata::Column::ProjectPath.eq(project_path))
+            .filter(session_metadata::Column::SequenceId.is_not_null())
+            .into_tuple::<Option<i32>>()
+            .one(db)
+            .await?
+            .flatten();
+
+        let max_seq = match (max_state_seq, max_metadata_seq) {
+            (Some(state), Some(metadata)) => Some(state.max(metadata)),
+            (Some(state), None) => Some(state),
+            (None, Some(metadata)) => Some(metadata),
+            (None, None) => None,
+        };
+
         Ok(max_seq.map_or(1, |max| max + 1))
+    }
+
+    async fn sequence_id_taken_by_other_session(
+        db: &impl sea_orm::ConnectionTrait,
+        project_path: &str,
+        session_id: &str,
+        sequence_id: i32,
+    ) -> Result<bool> {
+        let state_conflict = AcepeSessionState::find()
+            .filter(
+                Condition::all()
+                    .add(acepe_session_state::Column::ProjectPath.eq(project_path))
+                    .add(acepe_session_state::Column::SequenceId.eq(sequence_id))
+                    .add(acepe_session_state::Column::SessionId.ne(session_id)),
+            )
+            .one(db)
+            .await?;
+
+        if state_conflict.is_some() {
+            return Ok(true);
+        }
+
+        let metadata_conflict = SessionMetadata::find()
+            .filter(
+                Condition::all()
+                    .add(session_metadata::Column::ProjectPath.eq(project_path))
+                    .add(session_metadata::Column::SequenceId.eq(sequence_id))
+                    .add(session_metadata::Column::Id.ne(session_id)),
+            )
+            .one(db)
+            .await?;
+
+        Ok(metadata_conflict.is_some())
     }
 
     fn is_non_persisted_session_file_path(file_path: &str) -> bool {
@@ -1609,11 +1659,25 @@ impl SessionMetadataRepository {
                 }
             }
 
-            let next_sequence_id =
-                Self::next_sequence_id_for_project(&txn, &latest_model.project_path).await?;
+            let assigned_sequence_id = if let Some(existing_sequence_id) = latest_model.sequence_id {
+                if Self::sequence_id_taken_by_other_session(
+                    &txn,
+                    &latest_model.project_path,
+                    &latest_model.id,
+                    existing_sequence_id,
+                )
+                .await?
+                {
+                    Self::next_sequence_id_for_project(&txn, &latest_model.project_path).await?
+                } else {
+                    existing_sequence_id
+                }
+            } else {
+                Self::next_sequence_id_for_project(&txn, &latest_model.project_path).await?
+            };
             let mut active: session_metadata::ActiveModel = latest_model.into();
             active.is_acepe_managed = Set(1);
-            active.sequence_id = Set(Some(next_sequence_id));
+            active.sequence_id = Set(Some(assigned_sequence_id));
             active.updated_at = Set(Utc::now());
             let state_project_path = active.project_path.as_ref().clone();
             let state_worktree_path = active.worktree_path.as_ref().clone();
@@ -1628,9 +1692,15 @@ impl SessionMetadataRepository {
                             Set(AcepeSessionRelationship::Opened.as_str().to_string());
                         state_active.project_path = Set(state_project_path.clone());
                         state_active.worktree_path = Set(state_worktree_path.clone());
-                        state_active.sequence_id = Set(Some(next_sequence_id));
+                        state_active.sequence_id = Set(Some(assigned_sequence_id));
                         state_active.updated_at = Set(now);
-                        state_active.update(&txn).await?;
+                        if let Err(error) = state_active.update(&txn).await {
+                            if Self::is_sequence_constraint_violation(&error) {
+                                txn.rollback().await?;
+                                continue;
+                            }
+                            return Err(error.into());
+                        }
                     } else {
                         let state = acepe_session_state::ActiveModel {
                             session_id: Set(existing_model.id.clone()),
@@ -1641,14 +1711,20 @@ impl SessionMetadataRepository {
                             title_override: Set(None),
                             worktree_path: Set(state_worktree_path),
                             pr_number: Set(state_pr_number),
-                            sequence_id: Set(Some(next_sequence_id)),
+                            sequence_id: Set(Some(assigned_sequence_id)),
                             created_at: Set(now),
                             updated_at: Set(now),
                         };
-                        state.insert(&txn).await?;
+                        if let Err(error) = state.insert(&txn).await {
+                            if Self::is_sequence_constraint_violation(&error) {
+                                txn.rollback().await?;
+                                continue;
+                            }
+                            return Err(error.into());
+                        }
                     }
                     txn.commit().await?;
-                    return Ok(Some(next_sequence_id));
+                    return Ok(Some(assigned_sequence_id));
                 }
                 Err(error) => {
                     if Self::is_sequence_constraint_violation(&error) {

--- a/packages/desktop/src-tauri/src/db/repository_test.rs
+++ b/packages/desktop/src-tauri/src/db/repository_test.rs
@@ -1816,6 +1816,77 @@ mod session_metadata_tests {
     }
 
     #[tokio::test]
+    async fn test_reserving_worktree_launch_advances_past_metadata_only_sequence_ids() {
+        let db = setup_test_db().await;
+
+        SessionMetadataRepository::ensure_exists(
+            &db,
+            "session-placeholder",
+            "/project",
+            "claude-code",
+            Some("/project/.worktrees/feature-a"),
+        )
+        .await
+        .unwrap();
+
+        AcepeSessionState::delete_by_id("session-placeholder")
+            .exec(&db)
+            .await
+            .unwrap();
+        db.execute(Statement::from_string(
+            sea_orm::DatabaseBackend::Sqlite,
+            "UPDATE session_metadata SET file_path = '__worktree__/legacy-session', sequence_id = 49 WHERE id = 'session-placeholder'".to_string(),
+        ))
+        .await
+        .unwrap();
+
+        let reserved = SessionMetadataRepository::reserve_worktree_launch(&db, "/project", "copilot")
+            .await
+            .unwrap();
+
+        assert_eq!(reserved.sequence_id, 50);
+    }
+
+    #[tokio::test]
+    async fn test_mark_as_acepe_managed_preserves_metadata_only_sequence_id() {
+        let db = setup_test_db().await;
+
+        SessionMetadataRepository::ensure_exists(
+            &db,
+            "session-placeholder",
+            "/project",
+            "claude-code",
+            Some("/project/.worktrees/feature-a"),
+        )
+        .await
+        .unwrap();
+
+        AcepeSessionState::delete_by_id("session-placeholder")
+            .exec(&db)
+            .await
+            .unwrap();
+        db.execute(Statement::from_string(
+            sea_orm::DatabaseBackend::Sqlite,
+            "UPDATE session_metadata SET file_path = '__worktree__/legacy-session', sequence_id = 49 WHERE id = 'session-placeholder'".to_string(),
+        ))
+        .await
+        .unwrap();
+
+        let sequence_id =
+            SessionMetadataRepository::mark_as_acepe_managed(&db, "session-placeholder")
+                .await
+                .unwrap();
+        let state = AcepeSessionState::find_by_id("session-placeholder")
+            .one(&db)
+            .await
+            .unwrap()
+            .unwrap();
+
+        assert_eq!(sequence_id, Some(49));
+        assert_eq!(state.sequence_id, Some(49));
+    }
+
+    #[tokio::test]
     async fn test_ensure_exists_preserves_existing_session_metadata() {
         let db = setup_test_db().await;
 

--- a/packages/desktop/src-tauri/src/git/worktree.rs
+++ b/packages/desktop/src-tauri/src/git/worktree.rs
@@ -2,7 +2,7 @@
 //!
 //! This module provides functionality to create, manage, and cleanup git worktrees
 //! that isolate agent work from the main repository. Each worktree gets a fun
-//! adjective-noun branch name like "clever-falcon" or "cosmic-harbor".
+//! adjective-noun name like "clever-falcon" or "cosmic-harbor".
 
 use crate::db::repository::SessionMetadataRepository;
 use crate::git::worktree_config;
@@ -46,7 +46,7 @@ pub enum WorktreeOrigin {
 pub struct WorktreeInfo {
     /// The worktree name (e.g., "clever-falcon")
     pub name: String,
-    /// The git branch name (e.g., "acepe/clever-falcon")
+    /// The git branch name (matches the worktree name, e.g., "clever-falcon")
     pub branch: String,
     /// The full path to the worktree directory
     pub directory: String,
@@ -66,7 +66,7 @@ pub struct PreparedWorktreeLaunch {
 pub struct WorktreeListItem {
     /// The worktree name (e.g., "clever-falcon")
     pub name: String,
-    /// The git branch name (e.g., "acepe/clever-falcon")
+    /// The git branch name (matches the worktree name, e.g., "clever-falcon")
     pub branch: String,
     /// The full path to the worktree directory
     pub path: String,
@@ -216,7 +216,51 @@ fn format_reserved_worktree_relative_path(
 }
 
 fn worktree_branch_name(name: &str) -> String {
-    format!("acepe/{}", name.replace(':', "-"))
+    name.replace(':', "-")
+}
+
+fn worktree_relative_name(worktree_path: &Path) -> Result<String, String> {
+    let root = get_worktrees_root()?;
+    let within_root = worktree_path
+        .strip_prefix(&root)
+        .map_err(|_| "Worktree path does not belong to the Acepe worktrees root".to_string())?;
+    let mut components = within_root.components();
+    let _project_id = components
+        .next()
+        .ok_or("Could not determine project worktrees directory")?;
+    let relative = components.as_path();
+    if relative.as_os_str().is_empty() {
+        return Err("Could not determine worktree relative name".to_string());
+    }
+
+    Ok(relative.to_string_lossy().replace('\\', "/"))
+}
+
+fn managed_worktree_branch_name(worktree_path: &Path) -> Result<String, String> {
+    let relative_name = worktree_relative_name(worktree_path)?;
+    Ok(worktree_branch_name(&relative_name))
+}
+
+fn legacy_managed_worktree_branch_name(worktree_path: &Path) -> Result<String, String> {
+    let relative_name = worktree_relative_name(worktree_path)?;
+    Ok(format!("acepe/{}", worktree_branch_name(&relative_name)))
+}
+
+fn resolve_existing_managed_worktree_branch_name(
+    repo_path: &Path,
+    worktree_path: &Path,
+) -> Result<Option<String>, String> {
+    let managed_branch = managed_worktree_branch_name(worktree_path)?;
+    if branch_exists(repo_path, &managed_branch)? {
+        return Ok(Some(managed_branch));
+    }
+
+    let legacy_branch = legacy_managed_worktree_branch_name(worktree_path)?;
+    if branch_exists(repo_path, &legacy_branch)? {
+        return Ok(Some(legacy_branch));
+    }
+
+    Ok(None)
 }
 
 /// Get the worktrees root directory (~/.acepe/worktrees/)
@@ -443,14 +487,6 @@ fn generate_unique_candidate_from_basename(
     }
 
     Err("Failed to generate unique deterministic worktree name after 99 attempts".to_string())
-}
-
-fn rename_acepe_branch_name(current_branch: &str, new_name: &str) -> String {
-    if current_branch.starts_with("acepe/") {
-        return format!("acepe/{}", new_name);
-    }
-
-    new_name.to_string()
 }
 
 fn build_renamed_worktree_path(current_path: &Path, new_name: &str) -> Result<PathBuf, String> {
@@ -728,22 +764,12 @@ pub async fn git_worktree_remove(worktree_path: String, force: bool) -> Result<(
     let worktree_path_buf = worktree_config::validate_worktree_path(&worktree_path_buf)
         .map_err(|e| format!("Invalid worktree path: {}", e))?;
 
-    // Extract the worktree name to determine the branch
-    let worktree_name = worktree_path_buf
-        .file_name()
-        .and_then(|n| n.to_str())
-        .ok_or("Could not determine worktree name")?;
-    let branch_name = format!("acepe/{}", worktree_name);
-
     // Find the main repository by going up the directory tree
     // Worktrees are in ~/.acepe/worktrees/<project-id>/<name>
     // We need to find the original repo to run git commands
-    let _parent_dir = worktree_path_buf
-        .parent()
-        .ok_or("Could not determine parent directory")?;
-
     // Read the gitdir file to find the main repo
     let main_repo = get_main_repo_from_worktree_path(&worktree_path_buf)?;
+    let branch_name = resolve_existing_managed_worktree_branch_name(&main_repo, &worktree_path_buf)?;
 
     // Remove the worktree
     let mut args = vec!["worktree", "remove"];
@@ -769,21 +795,23 @@ pub async fn git_worktree_remove(worktree_path: String, force: bool) -> Result<(
     }
 
     // Delete the branch
-    let output = Command::new("git")
-        .args(["branch", "-D", &branch_name])
-        .current_dir(&main_repo)
-        .output()
-        .map_err(|e| format!("Failed to execute git branch delete: {}", e))?;
+    if let Some(branch_name) = branch_name.as_ref() {
+        let output = Command::new("git")
+            .args(["branch", "-D", branch_name])
+            .current_dir(&main_repo)
+            .output()
+            .map_err(|e| format!("Failed to execute git branch delete: {}", e))?;
 
-    if !output.status.success() {
-        let stderr = String::from_utf8_lossy(&output.stderr);
-        // Branch might already be deleted, just log warning
-        tracing::warn!(stderr = %stderr, "Failed to delete branch (may already be deleted)");
+        if !output.status.success() {
+            let stderr = String::from_utf8_lossy(&output.stderr);
+            // Branch might already be deleted, just log warning
+            tracing::warn!(stderr = %stderr, "Failed to delete branch (may already be deleted)");
+        }
     }
 
     tracing::info!(
         worktree_path = %worktree_path,
-        branch = %branch_name,
+        branch = ?branch_name,
         "Worktree and branch removed successfully"
     );
 
@@ -836,10 +864,10 @@ pub async fn git_worktree_rename(
         return Err(format!("A worktree named '{}' already exists", new_name));
     }
 
-    let current_branch = get_current_branch(&worktree_path_buf)?;
-    let renamed_branch = rename_acepe_branch_name(&current_branch, &new_name);
-
     let main_repo = get_main_repo_from_worktree_path(&worktree_path_buf)?;
+    let current_branch = resolve_existing_managed_worktree_branch_name(&main_repo, &worktree_path_buf)?
+        .ok_or("Could not determine managed branch for worktree")?;
+    let renamed_branch = managed_worktree_branch_name(&validated_renamed_path)?;
 
     if current_branch != renamed_branch {
         if branch_exists(&main_repo, &renamed_branch)? {
@@ -850,8 +878,8 @@ pub async fn git_worktree_rename(
         }
 
         let output = Command::new("git")
-            .args(["branch", "-m", &renamed_branch])
-            .current_dir(&worktree_path_buf)
+            .args(["branch", "-m", &current_branch, &renamed_branch])
+            .current_dir(&main_repo)
             .output()
             .map_err(|e| format!("Failed to execute git branch rename: {}", e))?;
 
@@ -965,11 +993,8 @@ pub async fn git_worktree_reset(worktree_path: String) -> Result<(), String> {
 }
 
 /// Determine the origin of a worktree based on its path and branch name.
-fn determine_worktree_origin(directory: &str, branch: &str) -> WorktreeOrigin {
-    // Acepe-created worktrees live under ~/.acepe/worktrees/ and use acepe/ branch prefix
-    if branch.starts_with("acepe/") {
-        return WorktreeOrigin::Acepe;
-    }
+fn determine_worktree_origin(directory: &str, _branch: &str) -> WorktreeOrigin {
+    // Acepe-created worktrees live under ~/.acepe/worktrees/
     if let Ok(root) = get_worktrees_root() {
         if Path::new(directory).starts_with(&root) {
             return WorktreeOrigin::Acepe;
@@ -1472,7 +1497,7 @@ mod tests {
         let branch =
             worktree_branch_name("14-april-2026-14:35/my-project/41/claude-code");
 
-        assert_eq!(branch, "acepe/14-april-2026-14-35/my-project/41/claude-code");
+        assert_eq!(branch, "14-april-2026-14-35/my-project/41/claude-code");
     }
 
     fn commit_all(repo_path: &Path, message: &str) {
@@ -1604,11 +1629,11 @@ branch refs/heads/main
 
 worktree /nonexistent-acepe-test/wt-last
 HEAD def456
-branch refs/heads/acepe/clever-falcon";
+branch refs/heads/clever-falcon";
         let result =
             parse_worktree_list_porcelain(output, Path::new("/nonexistent-acepe-test/main-repo"));
         assert_eq!(result.len(), 1);
-        assert_eq!(result[0].branch, "acepe/clever-falcon");
+        assert_eq!(result[0].branch, "clever-falcon");
     }
 
     #[test]
@@ -1619,9 +1644,10 @@ branch refs/heads/acepe/clever-falcon";
 
     #[test]
     fn test_determine_origin_acepe_branch() {
+        // Origin is now determined by path, not branch prefix
         assert_eq!(
-            determine_worktree_origin("/some/path", "acepe/cool-name"),
-            WorktreeOrigin::Acepe
+            determine_worktree_origin("/some/path", "cool-name"),
+            WorktreeOrigin::External
         );
     }
 
@@ -1634,10 +1660,39 @@ branch refs/heads/acepe/clever-falcon";
     }
 
     #[test]
-    fn test_rename_acepe_branch_name_updates_prefix() {
+    fn test_worktree_relative_name_preserves_nested_segments() {
+        let worktree_dir = get_project_worktrees_dir("/Users/example/code/acepe")
+            .expect("worktrees dir should resolve");
+        let worktree_path = worktree_dir.join("15-april-2026-20:22/acepe/50/copilot");
+
         assert_eq!(
-            rename_acepe_branch_name("acepe/happy-canyon", "brave-river"),
-            "acepe/brave-river"
+            worktree_relative_name(&worktree_path).expect("relative name should resolve"),
+            "15-april-2026-20:22/acepe/50/copilot"
+        );
+    }
+
+    #[test]
+    fn test_managed_worktree_branch_name_sanitizes_nested_relative_path() {
+        let worktree_dir = get_project_worktrees_dir("/Users/example/code/acepe")
+            .expect("worktrees dir should resolve");
+        let worktree_path = worktree_dir.join("15-april-2026-20:22/acepe/50/copilot");
+
+        assert_eq!(
+            managed_worktree_branch_name(&worktree_path).expect("managed branch name should resolve"),
+            "15-april-2026-20-22/acepe/50/copilot"
+        );
+    }
+
+    #[test]
+    fn test_legacy_managed_worktree_branch_name_preserves_acepe_prefix() {
+        let worktree_dir = get_project_worktrees_dir("/Users/example/code/acepe")
+            .expect("worktrees dir should resolve");
+        let worktree_path = worktree_dir.join("15-april-2026-20:22/acepe/50/copilot");
+
+        assert_eq!(
+            legacy_managed_worktree_branch_name(&worktree_path)
+                .expect("legacy managed branch name should resolve"),
+            "acepe/15-april-2026-20-22/acepe/50/copilot"
         );
     }
 

--- a/packages/desktop/src/lib/acp/types/worktree-info.ts
+++ b/packages/desktop/src/lib/acp/types/worktree-info.ts
@@ -4,7 +4,7 @@
 export interface WorktreeInfo {
 	/** The worktree name (e.g., "clever-falcon") */
 	readonly name: string;
-	/** The git branch name (e.g., "acepe/clever-falcon") */
+	/** The git branch name (matches the worktree name, e.g., "clever-falcon") */
 	readonly branch: string;
 	/** The full path to the worktree directory */
 	readonly directory: string;

--- a/packages/desktop/src/lib/components/main-app-view/components/content/empty-states.svelte
+++ b/packages/desktop/src/lib/components/main-app-view/components/content/empty-states.svelte
@@ -219,7 +219,7 @@ function handleEmptyStateSessionCreated(sessionId: string) {
 }
 </script>
 
-<div class="flex flex-col items-center justify-center h-full w-full max-w-2xl mx-auto px-6 py-12">
+<div class="flex flex-col items-center justify-center h-full w-full max-w-[29.4rem] mx-auto px-6 py-12">
 	<h1 class="mb-8 text-center font-sans text-[1.9rem] font-semibold tracking-tight text-foreground sm:text-4xl">
 		What do you want to build?
 	</h1>


### PR DESCRIPTION
## Summary
This keeps prepared worktrees aligned with the session identity Acepe shows in the UI, and narrows the empty-state composer so the landing layout feels less oversized.

## What changed
- worktree branches now use the managed worktree name directly instead of prepending `acepe/`, while rename/remove still detect and handle legacy `acepe/...` branches
- managed branch derivation now comes from the actual path under `~/.acepe/worktrees/<project-id>/...`, so cleanup and rename stay correct even when the project was opened through a symlinked path
- per-project sequence allocation now considers metadata-only legacy `sequence_id` values and preserves them when promoting sessions, so prepared worktrees stop lagging the visible session number
- the empty state composer max width is reduced by 30%

## Testing
- `cd packages/desktop && bun run check`
- `cd packages/desktop/src-tauri && cargo test --lib git::worktree::tests`
- `cd packages/desktop/src-tauri && cargo test --lib test_reserving_worktree_launch_advances_past_metadata_only_sequence_ids`
- `cd packages/desktop/src-tauri && cargo test --lib test_mark_as_acepe_managed_preserves_metadata_only_sequence_id`
- `cd packages/desktop/src-tauri && cargo clippy -- -W clippy::all`

## Post-Deploy Monitoring & Validation
No additional operational monitoring required — this only affects local desktop worktree/session metadata behavior and a layout width tweak.

---

[![Compound Engineering](https://img.shields.io/badge/Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
🤖 Generated with GPT-5.4 (unknown context, standard reasoning) via [GitHub Copilot CLI](https://github.com/features/copilot)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Aligns worktree branch naming with managed paths and fixes per-project session sequence IDs so prepared worktrees match the session number shown in the UI. Also narrows the empty-state composer for a tighter layout.

- **Bug Fixes**
  - Worktrees: branch now matches the sanitized worktree name/path (no `acepe/` prefix); rename/remove still handle legacy `acepe/...` branches.
  - Reliability: derive managed branch from the real `~/.acepe/worktrees/<project-id>/...` path; origin detection now uses path instead of branch prefix, making rename/cleanup robust even with symlinked projects.
  - Sessions: next sequence ID considers both `acepe_session_state` and `session_metadata`; preserves existing metadata-only sequence IDs on promotion and retries on conflicts, keeping worktree numbers in sync with the UI.
  - UI: reduce empty-state composer max width by ~30% (to 29.4rem).

<sup>Written for commit ca7a8e68b1ce2a42e17f3ef91e2d63ab5dce7800. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

