### PR TITLE
refactor(session): canonicalize turn failure state

### DIFF
--- a/packages/desktop/src-tauri/src/acp/client/cc_sdk_client.rs
+++ b/packages/desktop/src-tauri/src/acp/client/cc_sdk_client.rs
@@ -1230,7 +1230,7 @@ impl ClaudeCcSdkClient {
         ));
 
         if let Some(model_id) = &self.pending_model_id {
-            builder = builder.model(resolve_claude_api_model_id(model_id));
+            builder = builder.model(model_id.clone());
         }
 
         if let Some(session_id) = resume {
@@ -1268,31 +1268,14 @@ impl ClaudeCcSdkClient {
         // Stop any existing bridge first.
         self.stop_bridge();
 
-        let mut raw_client = cc_sdk::ClaudeSDKClient::new(options.clone());
+        let mut raw_client = cc_sdk::ClaudeSDKClient::new(options);
 
         // Connect (starts the subprocess / transport).
         tracing::info!(session_id = %session_id, has_prompt = initial_prompt.is_some(), "cc-sdk: connecting to Claude CLI...");
-        if let Err(error) = raw_client.connect(initial_prompt.clone()).await {
-            let error_message = error.to_string();
-            let Some(fallback_options) =
-                fallback_claude_1m_launch_options(&options, &error_message)
-            else {
-                return Err(AcpError::ProtocolError(error_message));
-            };
-
-            tracing::warn!(
-                session_id = %session_id,
-                requested_model = ?options.model,
-                fallback_model = ?fallback_options.model,
-                "Claude 1M launch request was rejected; retrying with standard Sonnet"
-            );
-
-            raw_client = cc_sdk::ClaudeSDKClient::new(fallback_options);
-            raw_client
-                .connect(initial_prompt)
-                .await
-                .map_err(|fallback_error| AcpError::ProtocolError(fallback_error.to_string()))?;
-        }
+        raw_client
+            .connect(initial_prompt)
+            .await
+            .map_err(|e| AcpError::ProtocolError(e.to_string()))?;
         tracing::info!(session_id = %session_id, "cc-sdk: connected, obtaining message stream...");
 
         // Obtain the message stream while we still have exclusive access to raw_client.
@@ -1533,12 +1516,12 @@ impl ClaudeCcSdkClient {
             return Ok(());
         };
 
-        let mut sdk_client = sdk_client.lock().await;
-        set_claude_runtime_model_with_fallback(
-            &mut sdk_client,
-            &resolve_claude_api_model_id(model_id),
-        )
-        .await
+        sdk_client
+            .lock()
+            .await
+            .set_model(Some(model_id.to_string()))
+            .await
+            .map_err(|error| AcpError::ProtocolError(error.to_string()))
     }
 
     async fn send_user_message_text(&self, text: String) -> AcpResult<()> {
@@ -1579,78 +1562,6 @@ fn provider_models(provider: &dyn AgentProvider) -> Vec<AvailableModel> {
             description: candidate.description,
         })
         .collect()
-}
-
-fn is_claude_sonnet_model_id(model_id: &str) -> bool {
-    model_id.starts_with("claude-sonnet-")
-}
-
-fn resolve_claude_api_model_id(model_id: &str) -> String {
-    if is_claude_sonnet_model_id(model_id) && !model_id.ends_with("[1m]") {
-        return format!("{model_id}[1m]");
-    }
-
-    model_id.to_string()
-}
-
-fn claude_1m_fallback_model_id(model_id: &str) -> Option<String> {
-    if model_id.ends_with("[1m]") {
-        return Some(model_id.trim_end_matches("[1m]").to_string());
-    }
-
-    None
-}
-
-fn is_claude_1m_entitlement_error(message: &str) -> bool {
-    message.contains("Extra usage is required for 1M context")
-        && message.contains("use --model to switch to standard context")
-}
-
-fn fallback_claude_1m_model_for_error(model_id: &str, error_message: &str) -> Option<String> {
-    if !is_claude_1m_entitlement_error(error_message) {
-        return None;
-    }
-
-    claude_1m_fallback_model_id(model_id)
-}
-
-fn fallback_claude_1m_launch_options(
-    options: &cc_sdk::ClaudeCodeOptions,
-    error_message: &str,
-) -> Option<cc_sdk::ClaudeCodeOptions> {
-    let requested_model = options.model.as_deref()?;
-    let fallback_model = fallback_claude_1m_model_for_error(requested_model, error_message)?;
-    let mut fallback_options = options.clone();
-    fallback_options.model = Some(fallback_model);
-    Some(fallback_options)
-}
-
-async fn set_claude_runtime_model_with_fallback(
-    sdk_client: &mut cc_sdk::ClaudeSDKClient,
-    model_id: &str,
-) -> AcpResult<()> {
-    match sdk_client.set_model(Some(model_id.to_string())).await {
-        Ok(()) => Ok(()),
-        Err(error) => {
-            let error_message = error.to_string();
-            let Some(fallback_model_id) =
-                fallback_claude_1m_model_for_error(model_id, &error_message)
-            else {
-                return Err(AcpError::ProtocolError(error_message));
-            };
-
-            tracing::warn!(
-                requested_model = model_id,
-                fallback_model = %fallback_model_id,
-                "Claude 1M model request was rejected; falling back to standard Sonnet"
-            );
-
-            sdk_client
-                .set_model(Some(fallback_model_id))
-                .await
-                .map_err(|fallback_error| AcpError::ProtocolError(fallback_error.to_string()))
-        }
-    }
 }
 
 fn map_to_claude_permission_mode(mode_id: &str) -> cc_sdk::PermissionMode {
@@ -1916,6 +1827,7 @@ async fn run_streaming_bridge(
                 dispatcher.enqueue(AcpUiEvent::session_update(SessionUpdate::TurnError {
                     error,
                     session_id: Some(session_id.clone()),
+                    turn_id: None,
                 }));
                 break;
             }
@@ -2606,13 +2518,6 @@ impl AgentClient for ClaudeCcSdkClient {
 
     async fn set_session_model(&mut self, _session_id: String, _model_id: String) -> AcpResult<()> {
         self.pending_model_id = Some(_model_id.clone());
-        if self.sdk_client.is_none() && self.pending_options.is_some() {
-            if let Some(cwd_buf) = self.current_cwd.clone() {
-                let cwd_str = cwd_buf.to_string_lossy().into_owned();
-                self.pending_options = Some(self.build_options(&cwd_str, &_session_id, None, false));
-            }
-            return Ok(());
-        }
         self.apply_runtime_model(&_model_id).await?;
         Ok(())
     }
@@ -2788,6 +2693,7 @@ impl AgentClient for ClaudeCcSdkClient {
                 self.dispatcher
                     .enqueue(AcpUiEvent::session_update(SessionUpdate::TurnComplete {
                         session_id: Some(stream_only_question.session_id),
+                        turn_id: None,
                     }));
                 return Ok(true);
             }
@@ -3257,16 +3163,6 @@ mod tests {
     }
 
     #[test]
-    fn build_options_maps_pending_sonnet_model_to_1m_api_model() {
-        let mut client = make_test_client();
-        client.pending_model_id = Some("claude-sonnet-4-6".to_string());
-
-        let options = client.build_options("/tmp", "session-1", None, false);
-
-        assert_eq!(options.model.as_deref(), Some("claude-sonnet-4-6[1m]"));
-    }
-
-    #[test]
     fn build_options_respects_bypass_permissions_from_claude_user_settings_when_mode_unset() {
         let _guard = HOME_ENV_LOCK.lock().expect("lock HOME env");
         let previous_home = std::env::var_os("HOME");
@@ -3391,74 +3287,6 @@ mod tests {
                 .permission_mode,
             cc_sdk::PermissionMode::BypassPermissions
         );
-    }
-
-    #[tokio::test]
-    async fn set_session_model_rebuilds_pending_options_on_deferred_connection() {
-        let temp = tempfile::tempdir().expect("temp dir");
-        let mut client = make_test_client();
-
-        let new_response = client
-            .new_session(temp.path().to_string_lossy().into_owned())
-            .await
-            .expect("new_session should succeed");
-
-        client
-            .set_session_model(new_response.session_id, "claude-sonnet-4-5".to_string())
-            .await
-            .expect("set_session_model should succeed on deferred client");
-
-        assert_eq!(client.pending_model_id.as_deref(), Some("claude-sonnet-4-5"));
-        assert_eq!(
-            client
-                .pending_options
-                .as_ref()
-                .and_then(|options| options.model.as_deref()),
-            Some("claude-sonnet-4-5[1m]")
-        );
-    }
-
-    #[test]
-    fn resolve_claude_api_model_id_maps_sonnet_family_only() {
-        assert_eq!(
-            resolve_claude_api_model_id("claude-sonnet-4"),
-            "claude-sonnet-4[1m]"
-        );
-        assert_eq!(
-            resolve_claude_api_model_id("claude-sonnet-4-5"),
-            "claude-sonnet-4-5[1m]"
-        );
-        assert_eq!(
-            resolve_claude_api_model_id("claude-opus-4-6"),
-            "claude-opus-4-6"
-        );
-        assert_eq!(
-            resolve_claude_api_model_id("claude-haiku-4-5-20251001"),
-            "claude-haiku-4-5-20251001"
-        );
-    }
-
-    #[test]
-    fn detects_known_claude_1m_entitlement_error() {
-        assert!(is_claude_1m_entitlement_error(
-            "API Error: Extra usage is required for 1M context · enable extra usage at claude.ai/settings/usage, or use --model to switch to standard context"
-        ));
-    }
-
-    #[test]
-    fn fallback_claude_1m_launch_options_rewrites_launch_model_once() {
-        let options = cc_sdk::ClaudeCodeOptions::builder()
-            .model("claude-sonnet-4-6[1m]".to_string())
-            .build();
-
-        let fallback_options = fallback_claude_1m_launch_options(
-            &options,
-            "API Error: Extra usage is required for 1M context · enable extra usage at claude.ai/settings/usage, or use --model to switch to standard context",
-        )
-        .expect("fallback options");
-
-        assert_eq!(options.model.as_deref(), Some("claude-sonnet-4-6[1m]"));
-        assert_eq!(fallback_options.model.as_deref(), Some("claude-sonnet-4-6"));
     }
 
     #[tokio::test]

--- a/packages/desktop/src-tauri/src/acp/client/codex_native_client.rs
+++ b/packages/desktop/src-tauri/src/acp/client/codex_native_client.rs
@@ -45,6 +45,7 @@ const THREAD_RESUME_TIMEOUT_SNIPPET: &str = "timed out waiting for server";
 
 type ChildHandle = StdArc<std::sync::Mutex<Option<Child>>>;
 type PendingCodexRequests = StdArc<Mutex<HashMap<u64, oneshot::Sender<Value>>>>;
+type ActiveTurnId = StdArc<Mutex<Option<String>>>;
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 struct CodexRuntimeIdentity {
@@ -70,7 +71,7 @@ pub struct CodexNativeClient {
     pending_question_ids: StdArc<Mutex<HashMap<String, Vec<String>>>>,
     session_id: Option<String>,
     provider_thread_id: Option<String>,
-    current_turn_id: Option<String>,
+    current_turn_id: ActiveTurnId,
     execution_profile: CodexExecutionProfile,
     config_state: CodexNativeConfigState,
     current_mode_id: String,
@@ -108,7 +109,7 @@ impl CodexNativeClient {
             pending_question_ids: StdArc::new(Mutex::new(HashMap::new())),
             session_id: None,
             provider_thread_id: None,
-            current_turn_id: None,
+            current_turn_id: StdArc::new(Mutex::new(None)),
             execution_profile: CodexExecutionProfile::Standard,
             config_state,
             current_mode_id: "build".to_string(),
@@ -276,6 +277,7 @@ impl AgentClient for CodexNativeClient {
         let dispatcher = self.dispatcher.clone();
         let cancel = self.stdout_reader_cancel.clone();
         let active_session_id = self.active_session_id.clone();
+        let current_turn_id = self.current_turn_id.clone();
         let pending_question_ids = self.pending_question_ids.clone();
         let stdin_writer = self.stdin_writer.clone();
         let db = self.db.clone();
@@ -296,7 +298,14 @@ impl AgentClient for CodexNativeClient {
                                     Err(error) => {
                                         let reason = format!("Received invalid JSON from codex app-server: {error}");
                                         fail_pending_requests(&pending_requests, &reason).await;
-                                        dispatch_transport_error(&dispatcher, &active_session_id, &reason, crate::acp::session_update::TurnErrorSource::Transport).await;
+                                        dispatch_transport_error(
+                                            &dispatcher,
+                                            &active_session_id,
+                                            &current_turn_id,
+                                            &reason,
+                                            crate::acp::session_update::TurnErrorSource::Transport,
+                                        )
+                                        .await;
                                         break;
                                     }
                                 };
@@ -363,6 +372,8 @@ impl AgentClient for CodexNativeClient {
                                 if auto_accepted_permission {
                                     mark_permission_updates_auto_accepted(&mut updates);
                                 }
+                                clear_active_turn_id_for_terminal_updates(&current_turn_id, &updates)
+                                    .await;
                                 for update in updates {
                                     log_emitted_event(&session_id, &update);
                                     dispatcher.enqueue(AcpUiEvent::session_update(update));
@@ -376,13 +387,27 @@ impl AgentClient for CodexNativeClient {
                                     .map(|stderr| format!("Codex app-server exited unexpectedly:\n{stderr}"))
                                     .unwrap_or_else(|| "Codex app-server exited unexpectedly".to_string());
                                 fail_pending_requests(&pending_requests, &reason).await;
-                                dispatch_transport_error(&dispatcher, &active_session_id, &reason, crate::acp::session_update::TurnErrorSource::Process).await;
+                                dispatch_transport_error(
+                                    &dispatcher,
+                                    &active_session_id,
+                                    &current_turn_id,
+                                    &reason,
+                                    crate::acp::session_update::TurnErrorSource::Process,
+                                )
+                                .await;
                                 break;
                             }
                             Err(error) => {
                                 let reason = format!("Failed reading Codex stdout: {error}");
                                 fail_pending_requests(&pending_requests, &reason).await;
-                                dispatch_transport_error(&dispatcher, &active_session_id, &reason, crate::acp::session_update::TurnErrorSource::Transport).await;
+                                dispatch_transport_error(
+                                    &dispatcher,
+                                    &active_session_id,
+                                    &current_turn_id,
+                                    &reason,
+                                    crate::acp::session_update::TurnErrorSource::Transport,
+                                )
+                                .await;
                                 break;
                             }
                         }
@@ -490,7 +515,7 @@ impl AgentClient for CodexNativeClient {
         );
         let payload = serde_json::to_value(params).map_err(AcpError::SerializationError)?;
         let response = self.send_request("turn/start", payload).await?;
-        self.current_turn_id = Some(parse_turn_id(&response).ok_or_else(|| {
+        *self.current_turn_id.lock().await = Some(parse_turn_id(&response).ok_or_else(|| {
             AcpError::ProtocolError("turn/start response did not include a turn id".to_string())
         })?);
         Ok(response)
@@ -504,7 +529,7 @@ impl AgentClient for CodexNativeClient {
         let provider_thread_id = self.provider_thread_id.clone().ok_or_else(|| {
             AcpError::InvalidState("Codex session is missing a provider thread id".to_string())
         })?;
-        let turn_id = self.current_turn_id.clone().ok_or_else(|| {
+        let turn_id = self.current_turn_id.lock().await.clone().ok_or_else(|| {
             AcpError::InvalidState("Codex session is missing an active turn id".to_string())
         })?;
         self.send_request(
@@ -513,7 +538,9 @@ impl AgentClient for CodexNativeClient {
         )
         .await
         .map(|_| {
-            self.current_turn_id = None;
+            if let Ok(mut active_turn_id) = self.current_turn_id.try_lock() {
+                *active_turn_id = None;
+            }
         })
     }
 
@@ -593,6 +620,9 @@ impl AgentClient for CodexNativeClient {
 
         if let Ok(mut question_ids) = self.pending_question_ids.try_lock() {
             question_ids.clear();
+        }
+        if let Ok(mut active_turn_id) = self.current_turn_id.try_lock() {
+            *active_turn_id = None;
         }
 
         self.session_id = None;
@@ -1088,28 +1118,59 @@ async fn fail_pending_requests(pending_requests: &PendingCodexRequests, reason: 
     }
 }
 
+fn build_transport_turn_error(
+    session_id: String,
+    turn_id: Option<String>,
+    reason: &str,
+    source: crate::acp::session_update::TurnErrorSource,
+) -> crate::acp::session_update::SessionUpdate {
+    crate::acp::session_update::SessionUpdate::TurnError {
+        error: crate::acp::session_update::TurnErrorData::Structured(
+            crate::acp::session_update::TurnErrorInfo {
+                message: reason.to_string(),
+                kind: crate::acp::session_update::TurnErrorKind::Fatal,
+                code: None,
+                source: Some(source),
+            },
+        ),
+        session_id: Some(session_id),
+        turn_id,
+    }
+}
+
 async fn dispatch_transport_error(
     dispatcher: &AcpUiEventDispatcher,
     active_session_id: &StdArc<Mutex<Option<String>>>,
+    current_turn_id: &ActiveTurnId,
     reason: &str,
     source: crate::acp::session_update::TurnErrorSource,
 ) {
     let session_id = active_session_id.lock().await.clone();
     if let Some(session_id) = session_id {
-        dispatcher.enqueue(AcpUiEvent::session_update(
-            crate::acp::session_update::SessionUpdate::TurnError {
-                error: crate::acp::session_update::TurnErrorData::Structured(
-                    crate::acp::session_update::TurnErrorInfo {
-                        message: reason.to_string(),
-                        kind: crate::acp::session_update::TurnErrorKind::Fatal,
-                        code: None,
-                        source: Some(source),
-                    },
-                ),
-                session_id: Some(session_id),
-            },
-        ));
+        let turn_id = current_turn_id.lock().await.clone();
+        dispatcher.enqueue(AcpUiEvent::session_update(build_transport_turn_error(
+            session_id, turn_id, reason, source,
+        )));
     }
+}
+
+async fn clear_active_turn_id_for_terminal_updates(
+    current_turn_id: &ActiveTurnId,
+    updates: &[SessionUpdate],
+) {
+    if !updates.iter().any(is_terminal_turn_update) {
+        return;
+    }
+
+    let mut active_turn_id = current_turn_id.lock().await;
+    *active_turn_id = None;
+}
+
+fn is_terminal_turn_update(update: &SessionUpdate) -> bool {
+    matches!(
+        update,
+        SessionUpdate::TurnComplete { .. } | SessionUpdate::TurnError { .. }
+    )
 }
 
 async fn remember_question_ids(
@@ -1404,6 +1465,60 @@ mod tests {
                 "turnId": "turn-1",
             })
         );
+    }
+
+    #[test]
+    fn transport_turn_errors_preserve_active_turn_identity() {
+        let update = build_transport_turn_error(
+            "session-1".to_string(),
+            Some("turn-1".to_string()),
+            "Codex app-server exited unexpectedly",
+            crate::acp::session_update::TurnErrorSource::Process,
+        );
+
+        assert!(matches!(
+            update,
+            SessionUpdate::TurnError {
+                turn_id,
+                error: crate::acp::session_update::TurnErrorData::Structured(
+                    crate::acp::session_update::TurnErrorInfo {
+                        message,
+                        kind: crate::acp::session_update::TurnErrorKind::Fatal,
+                        code: None,
+                        source: Some(crate::acp::session_update::TurnErrorSource::Process),
+                    }
+                ),
+                session_id: Some(session_id),
+            } if session_id == "session-1" && turn_id.as_deref() == Some("turn-1") && message == "Codex app-server exited unexpectedly"
+        ));
+    }
+
+    #[tokio::test]
+    async fn terminal_updates_clear_active_turn_identity() {
+        let current_turn_id = StdArc::new(Mutex::new(Some("turn-1".to_string())));
+        let updates = vec![SessionUpdate::TurnComplete {
+            session_id: Some("session-1".to_string()),
+            turn_id: Some("turn-1".to_string()),
+        }];
+
+        clear_active_turn_id_for_terminal_updates(&current_turn_id, &updates).await;
+
+        assert!(current_turn_id.lock().await.is_none());
+    }
+
+    #[tokio::test]
+    async fn non_terminal_updates_keep_active_turn_identity() {
+        let current_turn_id = StdArc::new(Mutex::new(Some("turn-1".to_string())));
+        let updates = vec![SessionUpdate::AvailableCommandsUpdate {
+            update: crate::acp::session_update::AvailableCommandsData {
+                available_commands: Vec::new(),
+            },
+            session_id: Some("session-1".to_string()),
+        }];
+
+        clear_active_turn_id_for_terminal_updates(&current_turn_id, &updates).await;
+
+        assert_eq!(current_turn_id.lock().await.as_deref(), Some("turn-1"));
     }
 
     #[test]

--- a/packages/desktop/src-tauri/src/acp/client/codex_native_client.rs
+++ b/packages/desktop/src-tauri/src/acp/client/codex_native_client.rs
@@ -536,12 +536,9 @@ impl AgentClient for CodexNativeClient {
             "turn/interrupt",
             build_turn_interrupt_params(&provider_thread_id, &turn_id),
         )
-        .await
-        .map(|_| {
-            if let Ok(mut active_turn_id) = self.current_turn_id.try_lock() {
-                *active_turn_id = None;
-            }
-        })
+        .await?;
+        *self.current_turn_id.lock().await = None;
+        Ok(())
     }
 
     async fn list_sessions(&mut self, _cwd: Option<String>) -> AcpResult<ListSessionsResponse> {

--- a/packages/desktop/src-tauri/src/acp/client/codex_native_events.rs
+++ b/packages/desktop/src-tauri/src/acp/client/codex_native_events.rs
@@ -192,9 +192,11 @@ fn translate_turn_completed(
     session_id: &str,
     params: Option<&serde_json::Map<String, Value>>,
 ) -> Vec<SessionUpdate> {
+    let turn_id = extract_codex_turn_id(params);
     let Some(params) = params else {
         return vec![SessionUpdate::TurnComplete {
             session_id: Some(session_id.to_string()),
+            turn_id,
         }];
     };
 
@@ -220,12 +222,31 @@ fn translate_turn_completed(
                 source: Some(TurnErrorSource::Process),
             }),
             session_id: Some(session_id.to_string()),
+            turn_id,
         });
     }
 
     with_codex_plan_update(SessionUpdate::TurnComplete {
         session_id: Some(session_id.to_string()),
+        turn_id,
     })
+}
+
+fn extract_codex_turn_id(
+    params: Option<&serde_json::Map<String, Value>>,
+) -> Option<String> {
+    let Some(params) = params else {
+        return None;
+    };
+
+    get_non_empty_string(params.get("turnId"))
+        .or_else(|| {
+            params
+                .get("turn")
+                .and_then(Value::as_object)
+                .and_then(|turn| get_non_empty_string(turn.get("id")))
+        })
+        .map(ToOwned::to_owned)
 }
 
 fn translate_error_notification(
@@ -265,6 +286,7 @@ fn translate_error_notification(
             source: Some(TurnErrorSource::Transport),
         }),
         session_id: Some(session_id.to_string()),
+        turn_id: extract_codex_turn_id(Some(params)),
     })
 }
 
@@ -784,8 +806,9 @@ mod tests {
         assert!(matches!(
             updates[0],
             SessionUpdate::TurnComplete {
-                session_id: Some(ref session_id)
-            } if session_id == "session-1"
+                session_id: Some(ref session_id),
+                turn_id: Some(ref turn_id)
+            } if session_id == "session-1" && turn_id == "turn-1"
         ));
     }
 
@@ -808,12 +831,17 @@ mod tests {
 
         assert_eq!(updates.len(), 1);
         match &updates[0] {
-            SessionUpdate::TurnError { error, session_id } => {
+            SessionUpdate::TurnError {
+                error,
+                session_id,
+                turn_id,
+            } => {
                 match error {
                     TurnErrorData::Structured(info) => assert_eq!(info.message, "Boom"),
                     other => panic!("unexpected error payload: {other:?}"),
                 }
                 assert_eq!(session_id.as_deref(), Some("session-1"));
+                assert_eq!(turn_id.as_deref(), Some("turn-1"));
             }
             other => panic!("unexpected update: {other:?}"),
         }

--- a/packages/desktop/src-tauri/src/acp/client/forge_protocol.rs
+++ b/packages/desktop/src-tauri/src/acp/client/forge_protocol.rs
@@ -39,8 +39,9 @@ pub fn translate_forge_event(session_id: &str, frame: &Value) -> Vec<SessionUpda
         "tool.finished" => translate_tool_finished(session_id, payload),
         "turn.completed" => vec![SessionUpdate::TurnComplete {
             session_id: Some(session_id.to_string()),
+            turn_id: frame.turn_id,
         }],
-        "turn.failed" => translate_turn_failed(session_id, payload),
+        "turn.failed" => translate_turn_failed(session_id, frame.turn_id.as_deref(), payload),
         _ => Vec::new(),
     }
 }
@@ -177,6 +178,7 @@ fn translate_tool_finished(
 
 fn translate_turn_failed(
     session_id: &str,
+    turn_id: Option<&str>,
     payload: Option<&serde_json::Map<String, Value>>,
 ) -> Vec<SessionUpdate> {
     let Some(payload) = payload else {
@@ -203,6 +205,7 @@ fn translate_turn_failed(
             source: Some(TurnErrorSource::Process),
         }),
         session_id: Some(session_id.to_string()),
+        turn_id: turn_id.map(ToOwned::to_owned),
     }]
 }
 
@@ -374,8 +377,9 @@ mod tests {
         assert!(matches!(
             updates[0],
             SessionUpdate::TurnComplete {
-                session_id: Some(ref session_id)
-            } if session_id == "session-1"
+                session_id: Some(ref session_id),
+                turn_id: Some(ref turn_id)
+            } if session_id == "session-1" && turn_id == "turn-1"
         ));
     }
 
@@ -398,7 +402,11 @@ mod tests {
 
         assert_eq!(updates.len(), 1);
         match &updates[0] {
-            SessionUpdate::TurnError { error, session_id } => {
+            SessionUpdate::TurnError {
+                error,
+                session_id,
+                turn_id,
+            } => {
                 match error {
                     TurnErrorData::Structured(info) => {
                         assert_eq!(info.message, "Session busy");
@@ -407,6 +415,7 @@ mod tests {
                     TurnErrorData::Legacy(other) => panic!("unexpected legacy error: {other}"),
                 }
                 assert_eq!(session_id.as_deref(), Some("session-1"));
+                assert_eq!(turn_id.as_deref(), Some("turn-1"));
             }
             other => panic!("unexpected update: {other:?}"),
         }

--- a/packages/desktop/src-tauri/src/acp/client_loop.rs
+++ b/packages/desktop/src-tauri/src/acp/client_loop.rs
@@ -28,7 +28,7 @@ use crate::acp::task_reconciler::TaskReconciler;
 use crate::acp::ui_event_dispatcher::{AcpUiEvent, AcpUiEventDispatcher};
 use sea_orm::DbConn;
 use serde_json::{json, Value};
-use std::collections::{HashMap, HashSet, VecDeque};
+use std::collections::{HashMap, VecDeque};
 use std::sync::Arc as StdArc;
 use tauri::{AppHandle, Manager};
 use tokio::io::{AsyncBufReadExt, BufReader};
@@ -126,16 +126,21 @@ impl BatcherWithGuard {
         self.batcher.process(update)
     }
 
-    fn process_turn_complete(&mut self, session_id: &str) -> Vec<SessionUpdate> {
-        self.batcher.process_turn_complete(session_id)
+    fn process_turn_complete(
+        &mut self,
+        session_id: &str,
+        turn_id: Option<String>,
+    ) -> Vec<SessionUpdate> {
+        self.batcher.process_turn_complete(session_id, turn_id)
     }
 
     fn process_turn_error(
         &mut self,
         session_id: &str,
+        turn_id: Option<String>,
         error: crate::acp::session_update::TurnErrorData,
     ) -> Vec<SessionUpdate> {
-        self.batcher.process_turn_error(session_id, error)
+        self.batcher.process_turn_error(session_id, turn_id, error)
     }
 
     /// Flush all buffered updates (e.g. before circuit breaker break).
@@ -148,9 +153,6 @@ impl BatcherWithGuard {
 ///
 /// Uses the batcher to ensure buffered text chunks are flushed before TurnError
 /// (`process_turn_error` internally calls `flush_session` then appends TurnError).
-///
-/// Deduplicates by session_id to avoid sending multiple TurnErrors for the same
-/// session when multiple prompts are in-flight (e.g., rapid sends).
 ///
 /// Only called from the stdout reader task (which owns the batcher). The death
 /// monitor does NOT drain prompt_sessions because it has no batcher access — if it
@@ -183,24 +185,24 @@ async fn drain_prompt_sessions_as_turn_errors(
         return;
     }
 
-    let unique_sessions: HashSet<String> = drained
-        .into_values()
-        .map(|prompt| prompt.session_id)
-        .collect();
     tracing::warn!(
-        count = unique_sessions.len(),
+        count = drained.len(),
         reason,
         "Synthesizing TurnError for orphaned prompt sessions after subprocess death"
     );
 
-    for session_id in unique_sessions {
+    for (request_id, prompt) in drained {
         let error = TurnErrorData::Structured(TurnErrorInfo {
             message: reason.to_string(),
             kind: TurnErrorKind::Fatal,
             code: Some(-32001),
             source: Some(TurnErrorSource::Process),
         });
-        let updates = streaming_batcher.process_turn_error(&session_id, error);
+        let updates = streaming_batcher.process_turn_error(
+            &prompt.session_id,
+            Some(request_id.to_string()),
+            error,
+        );
         for update in updates {
             dispatcher.enqueue(AcpUiEvent::session_update(update));
         }
@@ -561,10 +563,17 @@ pub(crate) fn spawn_stdout_reader(stdout: ChildStdout, ctx: StdoutLoopContext) {
                                     let updates = if let Some(error) = json.get("error") {
                                         let turn_error = extract_turn_error(error);
                                         tracing::error!(id = id, session_id = %session_id, error = ?turn_error, "Prompt failed");
-                                        streaming_batcher.process_turn_error(&session_id, turn_error)
+                                        streaming_batcher.process_turn_error(
+                                            &session_id,
+                                            Some(id.to_string()),
+                                            turn_error,
+                                        )
                                     } else {
                                         tracing::info!(id = id, session_id = %session_id, "Prompt completed");
-                                        streaming_batcher.process_turn_complete(&session_id)
+                                        streaming_batcher.process_turn_complete(
+                                            &session_id,
+                                            Some(id.to_string()),
+                                        )
                                     };
 
                                     for update in updates {
@@ -1044,6 +1053,7 @@ mod tests {
             None,
             Some(SessionUpdate::TurnComplete {
                 session_id: Some("session-1".to_string()),
+                turn_id: None,
             }),
         )
         .await;

--- a/packages/desktop/src-tauri/src/acp/client_message_ids.rs
+++ b/packages/desktop/src-tauri/src/acp/client_message_ids.rs
@@ -65,12 +65,18 @@ pub(crate) fn normalize_message_id(
                 session_id,
             })
         }
-        SessionUpdate::TurnComplete { session_id } => {
+        SessionUpdate::TurnComplete {
+            session_id,
+            turn_id,
+        } => {
             if let Some(session_id) = session_id.as_ref() {
                 tracker.remove(session_id);
                 assistant_text_tracker.remove(session_id);
             }
-            Some(SessionUpdate::TurnComplete { session_id })
+            Some(SessionUpdate::TurnComplete {
+                session_id,
+                turn_id,
+            })
         }
         _ => Some(update),
     }
@@ -212,6 +218,7 @@ mod tests {
             AgentType::Codex,
             SessionUpdate::TurnComplete {
                 session_id: Some("session-1".to_string()),
+                turn_id: None,
             },
             &mut tracker,
             &mut assistant_tracker,
@@ -403,6 +410,7 @@ mod tests {
             AgentType::Codex,
             SessionUpdate::TurnComplete {
                 session_id: Some(session.to_string()),
+                turn_id: None,
             },
             &mut tracker,
             &mut assistant_tracker,

--- a/packages/desktop/src-tauri/src/acp/client_updates/mod.rs
+++ b/packages/desktop/src-tauri/src/acp/client_updates/mod.rs
@@ -204,8 +204,10 @@ mod tests {
             AcpUiEventPayload::SessionUpdate(update) => match update.as_ref() {
                 SessionUpdate::TurnComplete {
                     session_id: emitted,
+                    turn_id,
                 } => {
                     assert_eq!(emitted.as_deref(), Some(session_id));
+                    assert_eq!(turn_id, &None);
                 }
                 other => panic!("Expected turn complete update, got {:?}", other),
             },
@@ -243,6 +245,7 @@ mod tests {
                 "sessionId": session_id,
                 "update": {
                     "sessionUpdate": "turnError",
+                    "turnId": "turn-7",
                     "error": {
                         "message": "boom",
                         "kind": "fatal",
@@ -272,9 +275,11 @@ mod tests {
             AcpUiEventPayload::SessionUpdate(update) => match update.as_ref() {
                 SessionUpdate::TurnError {
                     session_id: emitted,
+                    turn_id,
                     ..
                 } => {
                     assert_eq!(emitted.as_deref(), Some(session_id));
+                    assert_eq!(turn_id.as_deref(), Some("turn-7"));
                 }
                 other => panic!("Expected turn error update, got {:?}", other),
             },

--- a/packages/desktop/src-tauri/src/acp/client_updates/plan.rs
+++ b/packages/desktop/src-tauri/src/acp/client_updates/plan.rs
@@ -230,6 +230,7 @@ mod tests {
 
         let finalized = adapt_codex_wrapper_plan_update(&SessionUpdate::TurnComplete {
             session_id: Some(session_id.to_string()),
+            turn_id: None,
         })
         .expect("turn end should flush plan");
         let enriched = enrich_plan_update(finalized, AgentType::Codex, None);

--- a/packages/desktop/src-tauri/src/acp/commands/session_commands.rs
+++ b/packages/desktop/src-tauri/src/acp/commands/session_commands.rs
@@ -839,6 +839,8 @@ mod tests {
                 last_agent_message_id: None,
                 active_tool_call_ids: vec![],
                 completed_tool_call_ids: vec![],
+                active_turn_failure: None,
+                last_terminal_turn_id: None,
             }),
             operations: vec![],
             interactions: vec![InteractionSnapshot {

--- a/packages/desktop/src-tauri/src/acp/opencode/sse/conversion.rs
+++ b/packages/desktop/src-tauri/src/acp/opencode/sse/conversion.rs
@@ -951,6 +951,7 @@ pub(super) fn convert_session_status_to_session_update(
     match status {
         "idle" => Some(SessionUpdate::TurnComplete {
             session_id: Some(session_id),
+            turn_id: None,
         }),
         _ => None,
     }
@@ -964,6 +965,7 @@ pub(super) fn convert_session_idle_to_session_update(properties: &Value) -> Opti
         .and_then(Value::as_str)?;
     Some(SessionUpdate::TurnComplete {
         session_id: Some(session_id.to_string()),
+        turn_id: None,
     })
 }
 
@@ -1000,6 +1002,7 @@ pub(super) fn convert_session_error_to_session_update(properties: &Value) -> Opt
             source: Some(TurnErrorSource::Process),
         }),
         session_id,
+        turn_id: None,
     })
 }
 

--- a/packages/desktop/src-tauri/src/acp/opencode/sse/task_hydrator.rs
+++ b/packages/desktop/src-tauri/src/acp/opencode/sse/task_hydrator.rs
@@ -88,6 +88,7 @@ impl OpenCodeTaskHydrator {
     pub(super) fn apply_session_update(&mut self, update: &SessionUpdate) {
         if let SessionUpdate::TurnComplete {
             session_id: Some(session_id),
+            ..
         } = update
         {
             self.cleanup_child_session(session_id);

--- a/packages/desktop/src-tauri/src/acp/opencode/sse/tests.rs
+++ b/packages/desktop/src-tauri/src/acp/opencode/sse/tests.rs
@@ -458,7 +458,7 @@ fn test_convert_session_status_idle_to_turn_complete() {
     assert!(result.is_some());
 
     match result.unwrap() {
-        SessionUpdate::TurnComplete { session_id } => {
+        SessionUpdate::TurnComplete { session_id, .. } => {
             assert_eq!(session_id, Some("ses_abc".to_string()));
         }
         _ => panic!("Expected TurnComplete"),
@@ -479,7 +479,7 @@ fn test_convert_session_status_idle_type_to_turn_complete() {
     assert!(result.is_some());
 
     match result.unwrap() {
-        SessionUpdate::TurnComplete { session_id } => {
+        SessionUpdate::TurnComplete { session_id, .. } => {
             assert_eq!(session_id, Some("ses_abc".to_string()));
         }
         _ => panic!("Expected TurnComplete"),
@@ -511,7 +511,7 @@ fn test_convert_session_idle_to_turn_complete() {
     assert!(result.is_some());
 
     match result.unwrap() {
-        SessionUpdate::TurnComplete { session_id } => {
+        SessionUpdate::TurnComplete { session_id, .. } => {
             assert_eq!(session_id, Some("ses_abc".to_string()));
         }
         _ => panic!("Expected TurnComplete"),
@@ -529,7 +529,7 @@ fn test_convert_session_idle_with_session_id_to_turn_complete() {
     assert!(result.is_some());
 
     match result.unwrap() {
-        SessionUpdate::TurnComplete { session_id } => {
+        SessionUpdate::TurnComplete { session_id, .. } => {
             assert_eq!(session_id, Some("ses_abc".to_string()));
         }
         _ => panic!("Expected TurnComplete"),
@@ -553,7 +553,7 @@ fn test_convert_session_error_with_nested_message_to_turn_error() {
     assert!(result.is_some());
 
     match result.unwrap() {
-        SessionUpdate::TurnError { error, session_id } => {
+        SessionUpdate::TurnError { error, session_id, .. } => {
             assert_eq!(session_id, Some("ses_abc".to_string()));
             match error {
                 TurnErrorData::Structured(info) => {
@@ -582,7 +582,7 @@ fn test_convert_session_error_without_message_uses_fallback() {
     assert!(result.is_some());
 
     match result.unwrap() {
-        SessionUpdate::TurnError { error, session_id } => {
+        SessionUpdate::TurnError { error, session_id, .. } => {
             assert_eq!(session_id, Some("ses_abc".to_string()));
             match error {
                 TurnErrorData::Structured(info) => {

--- a/packages/desktop/src-tauri/src/acp/parsers/cc_sdk_bridge.rs
+++ b/packages/desktop/src-tauri/src/acp/parsers/cc_sdk_bridge.rs
@@ -563,9 +563,13 @@ fn translate_result(
         updates.push(SessionUpdate::TurnError {
             error: TurnErrorData::Legacy(result.unwrap_or_else(|| "Turn failed".to_string())),
             session_id,
+            turn_id: None,
         });
     } else {
-        updates.push(SessionUpdate::TurnComplete { session_id });
+        updates.push(SessionUpdate::TurnComplete {
+            session_id,
+            turn_id: None,
+        });
     }
 
     updates

--- a/packages/desktop/src-tauri/src/acp/projections/mod.rs
+++ b/packages/desktop/src-tauri/src/acp/projections/mod.rs
@@ -18,6 +18,16 @@ pub enum SessionTurnState {
     Failed,
 }
 
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Type)]
+pub struct TurnFailureSnapshot {
+    pub turn_id: Option<String>,
+    pub message: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub code: Option<String>,
+    pub kind: crate::acp::session_update::TurnErrorKind,
+    pub source: crate::acp::session_update::TurnErrorSource,
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize, Type)]
 pub struct SessionSnapshot {
     pub session_id: String,
@@ -28,6 +38,10 @@ pub struct SessionSnapshot {
     pub last_agent_message_id: Option<String>,
     pub active_tool_call_ids: Vec<String>,
     pub completed_tool_call_ids: Vec<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub active_turn_failure: Option<TurnFailureSnapshot>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub last_terminal_turn_id: Option<String>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, Type)]
@@ -128,8 +142,37 @@ impl SessionSnapshot {
             last_agent_message_id: None,
             active_tool_call_ids: Vec::new(),
             completed_tool_call_ids: Vec::new(),
+            active_turn_failure: None,
+            last_terminal_turn_id: None,
         }
     }
+}
+
+fn matches_terminal_turn_id(left: Option<&str>, right: Option<&str>) -> bool {
+    match (left, right) {
+        (Some(left), Some(right)) => left == right,
+        (None, None) => true,
+        _ => false,
+    }
+}
+
+fn preserves_failed_turn(snapshot: &SessionSnapshot) -> bool {
+    snapshot.turn_state == SessionTurnState::Failed && snapshot.active_turn_failure.is_some()
+}
+
+fn start_running_turn(snapshot: &mut SessionSnapshot) {
+    snapshot.turn_state = SessionTurnState::Running;
+    snapshot.active_turn_failure = None;
+    snapshot.last_terminal_turn_id = None;
+}
+
+fn should_ignore_turn_complete(
+    snapshot: &SessionSnapshot,
+    turn_id: Option<&str>,
+) -> bool {
+    preserves_failed_turn(snapshot)
+        && (turn_id.is_none()
+            || matches_terminal_turn_id(snapshot.last_terminal_turn_id.as_deref(), turn_id))
 }
 
 #[derive(Debug, Clone, Default)]
@@ -258,17 +301,21 @@ impl ProjectionRegistry {
         match update {
             SessionUpdate::UserMessageChunk { .. } => {
                 snapshot.message_count = snapshot.message_count.saturating_add(1);
-                snapshot.turn_state = SessionTurnState::Running;
+                start_running_turn(&mut snapshot);
             }
             SessionUpdate::AgentMessageChunk { message_id, .. } => {
                 snapshot.message_count = snapshot.message_count.saturating_add(1);
                 if let Some(message_id) = message_id {
                     snapshot.last_agent_message_id = Some(message_id.clone());
                 }
-                snapshot.turn_state = SessionTurnState::Running;
+                if !preserves_failed_turn(&snapshot) {
+                    start_running_turn(&mut snapshot);
+                }
             }
             SessionUpdate::AgentThoughtChunk { .. } => {
-                snapshot.turn_state = SessionTurnState::Running;
+                if !preserves_failed_turn(&snapshot) {
+                    start_running_turn(&mut snapshot);
+                }
             }
             SessionUpdate::ToolCall { tool_call, .. } => {
                 upsert_active_tool_call(&mut snapshot.active_tool_call_ids, &tool_call.id);
@@ -282,7 +329,9 @@ impl ProjectionRegistry {
                     tool_call.parent_tool_use_id.clone(),
                 );
                 self.register_plan_approval_interaction(session_id, tool_call);
-                snapshot.turn_state = SessionTurnState::Running;
+                if !preserves_failed_turn(&snapshot) {
+                    start_running_turn(&mut snapshot);
+                }
             }
             SessionUpdate::ToolCallUpdate { update, .. } => {
                 upsert_active_tool_call(&mut snapshot.active_tool_call_ids, &update.tool_call_id);
@@ -294,7 +343,9 @@ impl ProjectionRegistry {
                     mark_tool_call_completed(&mut snapshot, &update.tool_call_id);
                 }
                 self.apply_tool_call_update_projection(session_id, update);
-                snapshot.turn_state = SessionTurnState::Running;
+                if !preserves_failed_turn(&snapshot) {
+                    start_running_turn(&mut snapshot);
+                }
             }
             SessionUpdate::PermissionRequest { permission, .. } => {
                 self.register_permission_interaction(permission, snapshot.last_event_seq);
@@ -302,13 +353,29 @@ impl ProjectionRegistry {
             SessionUpdate::QuestionRequest { question, .. } => {
                 self.register_question_interaction(question);
             }
-            SessionUpdate::TurnComplete { .. } => {
+            SessionUpdate::TurnComplete { turn_id, .. } => {
+                if should_ignore_turn_complete(&snapshot, turn_id.as_deref()) {
+                    return;
+                }
                 snapshot.turn_state = SessionTurnState::Completed;
                 snapshot.active_tool_call_ids.clear();
+                snapshot.active_turn_failure = None;
+                snapshot.last_terminal_turn_id = turn_id.clone();
             }
-            SessionUpdate::TurnError { .. } => {
+            SessionUpdate::TurnError { error, turn_id, .. } => {
+                if preserves_failed_turn(&snapshot)
+                    && matches_terminal_turn_id(
+                        snapshot.last_terminal_turn_id.as_deref(),
+                        turn_id.as_deref(),
+                    )
+                {
+                    return;
+                }
                 snapshot.turn_state = SessionTurnState::Failed;
                 snapshot.active_tool_call_ids.clear();
+                snapshot.active_turn_failure =
+                    Some(convert_turn_error_snapshot(error, turn_id.clone()));
+                snapshot.last_terminal_turn_id = turn_id.clone();
             }
             _ => {}
         }
@@ -439,13 +506,22 @@ impl ProjectionRegistry {
 
             match entry {
                 StoredEntry::User { .. } => {
+                    if snapshot.active_turn_failure.is_some() {
+                        start_running_turn(&mut snapshot);
+                    }
                     snapshot.message_count = snapshot.message_count.saturating_add(1);
                 }
                 StoredEntry::Assistant { id, .. } => {
+                    if snapshot.active_turn_failure.is_some() {
+                        start_running_turn(&mut snapshot);
+                    }
                     snapshot.message_count = snapshot.message_count.saturating_add(1);
                     snapshot.last_agent_message_id = Some(id.clone());
                 }
                 StoredEntry::ToolCall { message, .. } => {
+                    if snapshot.active_turn_failure.is_some() {
+                        start_running_turn(&mut snapshot);
+                    }
                     upsert_active_tool_call(&mut snapshot.active_tool_call_ids, &message.id);
                     if is_terminal_tool_call_status(&message.status) {
                         mark_tool_call_completed(&mut snapshot, &message.id);
@@ -464,11 +540,16 @@ impl ProjectionRegistry {
                         snapshot.last_event_seq,
                     );
                 }
-                StoredEntry::Error { .. } => {}
+                StoredEntry::Error { message, .. } => {
+                    snapshot.active_turn_failure = Some(convert_stored_error_snapshot(message));
+                    snapshot.last_terminal_turn_id = None;
+                }
             }
         }
 
-        if !snapshot.active_tool_call_ids.is_empty() {
+        if snapshot.active_turn_failure.is_some() {
+            snapshot.turn_state = SessionTurnState::Failed;
+        } else if !snapshot.active_tool_call_ids.is_empty() {
             snapshot.turn_state = SessionTurnState::Running;
         } else if snapshot.last_event_seq > 0 {
             snapshot.turn_state = SessionTurnState::Completed;
@@ -800,6 +881,44 @@ fn create_session_tool_key(session_id: &str, tool_call_id: &str) -> String {
     format!("{session_id}::{tool_call_id}")
 }
 
+fn convert_turn_error_snapshot(
+    error: &crate::acp::session_update::TurnErrorData,
+    turn_id: Option<String>,
+) -> TurnFailureSnapshot {
+    match error {
+        crate::acp::session_update::TurnErrorData::Legacy(message) => TurnFailureSnapshot {
+            turn_id,
+            message: message.clone(),
+            code: None,
+            kind: crate::acp::session_update::TurnErrorKind::Recoverable,
+            source: crate::acp::session_update::TurnErrorSource::Unknown,
+        },
+        crate::acp::session_update::TurnErrorData::Structured(info) => TurnFailureSnapshot {
+            turn_id,
+            message: info.message.clone(),
+            code: info.code.map(|code| code.to_string()),
+            kind: info.kind,
+            source: info
+                .source
+                .unwrap_or(crate::acp::session_update::TurnErrorSource::Unknown),
+        },
+    }
+}
+
+fn convert_stored_error_snapshot(
+    message: &crate::session_jsonl::types::StoredErrorMessage,
+) -> TurnFailureSnapshot {
+    TurnFailureSnapshot {
+        turn_id: None,
+        message: message.content.clone(),
+        code: message.code.clone(),
+        kind: message.kind,
+        source: message
+            .source
+            .unwrap_or(crate::acp::session_update::TurnErrorSource::Unknown),
+    }
+}
+
 fn create_session_request_key(session_id: &str, request_id: u64) -> String {
     format!("{session_id}::{request_id}")
 }
@@ -922,6 +1041,7 @@ mod tests {
             "session-1",
             &SessionUpdate::TurnComplete {
                 session_id: Some("session-1".to_string()),
+                turn_id: None,
             },
         );
 
@@ -933,6 +1053,127 @@ mod tests {
         assert_eq!(snapshot.last_agent_message_id.as_deref(), Some("msg-1"));
         assert_eq!(snapshot.turn_state, SessionTurnState::Completed);
         assert_eq!(snapshot.last_event_seq, 2);
+    }
+
+    #[test]
+    fn apply_session_update_keeps_failed_turn_terminal_for_late_same_turn_updates() {
+        let registry = ProjectionRegistry::new();
+        registry.register_session("session-1".to_string(), CanonicalAgentId::Codex);
+
+        registry.apply_session_update(
+            "session-1",
+            &SessionUpdate::TurnError {
+                error: crate::acp::session_update::TurnErrorData::Structured(
+                    crate::acp::session_update::TurnErrorInfo {
+                        message: "Usage limit reached".to_string(),
+                        kind: crate::acp::session_update::TurnErrorKind::Recoverable,
+                        code: Some(429),
+                        source: Some(crate::acp::session_update::TurnErrorSource::Process),
+                    },
+                ),
+                session_id: Some("session-1".to_string()),
+                turn_id: Some("turn-1".to_string()),
+            },
+        );
+
+        let failed_snapshot = registry
+            .snapshot_for_session("session-1")
+            .expect("expected failed snapshot");
+        assert_eq!(failed_snapshot.turn_state, SessionTurnState::Failed);
+        assert_eq!(failed_snapshot.last_terminal_turn_id.as_deref(), Some("turn-1"));
+        assert_eq!(
+            failed_snapshot
+                .active_turn_failure
+                .as_ref()
+                .map(|failure| failure.message.as_str()),
+            Some("Usage limit reached")
+        );
+
+        registry.apply_session_update(
+            "session-1",
+            &SessionUpdate::TurnComplete {
+                session_id: Some("session-1".to_string()),
+                turn_id: Some("turn-1".to_string()),
+            },
+        );
+
+        registry.apply_session_update(
+            "session-1",
+            &SessionUpdate::AgentMessageChunk {
+                chunk: ContentChunk {
+                    content: ContentBlock::Text {
+                        text: "late chunk".to_string(),
+                    },
+                    aggregation_hint: None,
+                },
+                part_id: None,
+                session_id: Some("session-1".to_string()),
+                message_id: Some("msg-late".to_string()),
+            },
+        );
+
+        registry.apply_session_update(
+            "session-1",
+            &SessionUpdate::TurnComplete {
+                session_id: Some("session-1".to_string()),
+                turn_id: Some("turn-1".to_string()),
+            },
+        );
+
+        let failed_snapshot = registry
+            .snapshot_for_session("session-1")
+            .expect("expected failed snapshot after late updates");
+        assert_eq!(failed_snapshot.turn_state, SessionTurnState::Failed);
+        assert_eq!(failed_snapshot.last_terminal_turn_id.as_deref(), Some("turn-1"));
+        assert_eq!(
+            failed_snapshot
+                .active_turn_failure
+                .as_ref()
+                .map(|failure| failure.message.as_str()),
+            Some("Usage limit reached")
+        );
+    }
+
+    #[test]
+    fn apply_session_update_clears_failed_turn_when_new_user_turn_starts() {
+        let registry = ProjectionRegistry::new();
+        registry.register_session("session-1".to_string(), CanonicalAgentId::Codex);
+
+        registry.apply_session_update(
+            "session-1",
+            &SessionUpdate::TurnError {
+                error: crate::acp::session_update::TurnErrorData::Structured(
+                    crate::acp::session_update::TurnErrorInfo {
+                        message: "Usage limit reached".to_string(),
+                        kind: crate::acp::session_update::TurnErrorKind::Recoverable,
+                        code: Some(429),
+                        source: Some(crate::acp::session_update::TurnErrorSource::Process),
+                    },
+                ),
+                session_id: Some("session-1".to_string()),
+                turn_id: Some("turn-1".to_string()),
+            },
+        );
+
+        registry.apply_session_update(
+            "session-1",
+            &SessionUpdate::UserMessageChunk {
+                chunk: ContentChunk {
+                    content: ContentBlock::Text {
+                        text: "retry".to_string(),
+                    },
+                    aggregation_hint: None,
+                },
+                session_id: Some("session-1".to_string()),
+            },
+        );
+
+        let running_snapshot = registry
+            .snapshot_for_session("session-1")
+            .expect("expected running snapshot");
+        assert_eq!(running_snapshot.turn_state, SessionTurnState::Running);
+        assert!(running_snapshot.active_turn_failure.is_none());
+        assert!(running_snapshot.last_terminal_turn_id.is_none());
     }
 
     fn create_execute_tool_call(id: &str, command: &str, status: ToolCallStatus) -> ToolCallData {
@@ -1330,6 +1571,8 @@ mod tests {
                 last_agent_message_id: Some("msg-2".to_string()),
                 active_tool_call_ids: vec![],
                 completed_tool_call_ids: vec!["tool-1".to_string()],
+                active_turn_failure: None,
+                last_terminal_turn_id: None,
             }),
             operations: vec![OperationSnapshot {
                 id: "session-1:tool-1".to_string(),
@@ -1523,5 +1766,144 @@ mod tests {
             .find(|interaction| interaction.kind == InteractionKind::PlanApproval)
             .expect("expected imported plan approval interaction");
         assert_eq!(plan_approval.state, InteractionState::Pending);
+    }
+
+    #[test]
+    fn project_converted_session_preserves_stored_error_source() {
+        let converted = ConvertedSession {
+            entries: vec![StoredEntry::Error {
+                id: "error-1".to_string(),
+                message: crate::session_jsonl::types::StoredErrorMessage {
+                    content: "Usage limit reached".to_string(),
+                    code: Some("429".to_string()),
+                    kind: crate::acp::session_update::TurnErrorKind::Recoverable,
+                    source: Some(crate::acp::session_update::TurnErrorSource::Process),
+                },
+                timestamp: Some("2026-04-15T00:00:00Z".to_string()),
+            }],
+            stats: SessionStats::default(),
+            title: "Imported error".to_string(),
+            created_at: "2026-04-15T00:00:00Z".to_string(),
+            current_mode_id: None,
+        };
+
+        let projection = ProjectionRegistry::project_converted_session(
+            "session-1",
+            Some(CanonicalAgentId::Codex),
+            &converted,
+        );
+
+        let session = projection
+            .session
+            .expect("expected imported session snapshot");
+        assert_eq!(session.turn_state, SessionTurnState::Failed);
+        assert_eq!(
+            session
+                .active_turn_failure
+                .as_ref()
+                .map(|failure| failure.source),
+            Some(crate::acp::session_update::TurnErrorSource::Process)
+        );
+    }
+
+    #[test]
+    fn project_converted_session_clears_historical_error_when_later_entries_continue() {
+        let converted = ConvertedSession {
+            entries: vec![
+                StoredEntry::Error {
+                    id: "error-1".to_string(),
+                    message: crate::session_jsonl::types::StoredErrorMessage {
+                        content: "Usage limit reached".to_string(),
+                        code: Some("429".to_string()),
+                        kind: crate::acp::session_update::TurnErrorKind::Recoverable,
+                        source: Some(crate::acp::session_update::TurnErrorSource::Process),
+                    },
+                    timestamp: Some("2026-04-15T00:00:00Z".to_string()),
+                },
+                StoredEntry::User {
+                    id: "user-1".to_string(),
+                    message: StoredUserMessage {
+                        id: Some("user-1".to_string()),
+                        content: StoredContentBlock {
+                            block_type: "text".to_string(),
+                            text: Some("try again".to_string()),
+                        },
+                        chunks: vec![],
+                        sent_at: Some("2026-04-15T00:00:01Z".to_string()),
+                    },
+                    timestamp: Some("2026-04-15T00:00:01Z".to_string()),
+                },
+                StoredEntry::Assistant {
+                    id: "assistant-1".to_string(),
+                    message: StoredAssistantMessage {
+                        chunks: vec![StoredAssistantChunk {
+                            chunk_type: "message".to_string(),
+                            block: StoredContentBlock {
+                                block_type: "text".to_string(),
+                                text: Some("Recovered".to_string()),
+                            },
+                        }],
+                        model: Some("gpt-5.4".to_string()),
+                        display_model: Some("GPT-5.4".to_string()),
+                        received_at: Some("2026-04-15T00:00:02Z".to_string()),
+                    },
+                    timestamp: Some("2026-04-15T00:00:02Z".to_string()),
+                },
+            ],
+            stats: SessionStats::default(),
+            title: "Recovered session".to_string(),
+            created_at: "2026-04-15T00:00:00Z".to_string(),
+            current_mode_id: None,
+        };
+
+        let projection = ProjectionRegistry::project_converted_session(
+            "session-1",
+            Some(CanonicalAgentId::Codex),
+            &converted,
+        );
+
+        let session = projection
+            .session
+            .expect("expected imported session snapshot");
+        assert_eq!(session.turn_state, SessionTurnState::Completed);
+        assert!(session.active_turn_failure.is_none());
+        assert!(session.last_terminal_turn_id.is_none());
+    }
+
+    #[test]
+    fn project_converted_session_defaults_missing_stored_error_source_to_unknown() {
+        let converted = ConvertedSession {
+            entries: vec![StoredEntry::Error {
+                id: "error-1".to_string(),
+                message: crate::session_jsonl::types::StoredErrorMessage {
+                    content: "Usage limit reached".to_string(),
+                    code: Some("429".to_string()),
+                    kind: crate::acp::session_update::TurnErrorKind::Recoverable,
+                    source: None,
+                },
+                timestamp: Some("2026-04-15T00:00:00Z".to_string()),
+            }],
+            stats: SessionStats::default(),
+            title: "Imported error".to_string(),
+            created_at: "2026-04-15T00:00:00Z".to_string(),
+            current_mode_id: None,
+        };
+
+        let projection = ProjectionRegistry::project_converted_session(
+            "session-1",
+            Some(CanonicalAgentId::Codex),
+            &converted,
+        );
+
+        let session = projection
+            .session
+            .expect("expected imported session snapshot");
+        assert_eq!(
+            session
+                .active_turn_failure
+                .as_ref()
+                .map(|failure| failure.source),
+            Some(crate::acp::session_update::TurnErrorSource::Unknown)
+        );
     }
 }

--- a/packages/desktop/src-tauri/src/acp/projections/mod.rs
+++ b/packages/desktop/src-tauri/src/acp/projections/mod.rs
@@ -543,6 +543,7 @@ impl ProjectionRegistry {
                 StoredEntry::Error { message, .. } => {
                     snapshot.active_turn_failure = Some(convert_stored_error_snapshot(message));
                     snapshot.last_terminal_turn_id = None;
+                    snapshot.active_tool_call_ids.clear();
                 }
             }
         }

--- a/packages/desktop/src-tauri/src/acp/providers/codex.rs
+++ b/packages/desktop/src-tauri/src/acp/providers/codex.rs
@@ -163,7 +163,7 @@ pub(crate) fn adapt_codex_wrapper_plan_update(update: &SessionUpdate) -> Option<
                 session_id: Some(session_id.to_string()),
             })
         }
-        SessionUpdate::TurnComplete { session_id }
+        SessionUpdate::TurnComplete { session_id, .. }
         | SessionUpdate::TurnError { session_id, .. } => {
             let session_id = session_id.as_deref()?;
             let plan = crate::acp::streaming_accumulator::finalize_codex_plan_turn(session_id);

--- a/packages/desktop/src-tauri/src/acp/providers/cursor_session_update_enrichment.rs
+++ b/packages/desktop/src-tauri/src/acp/providers/cursor_session_update_enrichment.rs
@@ -72,7 +72,7 @@ fn enrich_tool_call_from_index(
 
 pub(crate) async fn enrich_cursor_session_update(update: SessionUpdate) -> SessionUpdate {
     match &update {
-        SessionUpdate::TurnComplete { session_id }
+        SessionUpdate::TurnComplete { session_id, .. }
         | SessionUpdate::TurnError { session_id, .. } => {
             if let Some(session_id) = session_id {
                 CURSOR_TOOL_USE_CACHE.remove(session_id);

--- a/packages/desktop/src-tauri/src/acp/session_journal.rs
+++ b/packages/desktop/src-tauri/src/acp/session_journal.rs
@@ -55,10 +55,12 @@ pub enum ProjectionJournalUpdate {
     },
     TurnComplete {
         session_id: Option<String>,
+        turn_id: Option<String>,
     },
     TurnError {
         error: TurnErrorData,
         session_id: Option<String>,
+        turn_id: Option<String>,
     },
 }
 
@@ -117,12 +119,21 @@ impl ProjectionJournalUpdate {
                 question: question.clone(),
                 session_id: session_id.clone(),
             }),
-            SessionUpdate::TurnComplete { session_id } => Some(Self::TurnComplete {
+            SessionUpdate::TurnComplete {
+                session_id,
+                turn_id,
+            } => Some(Self::TurnComplete {
                 session_id: session_id.clone(),
+                turn_id: turn_id.clone(),
             }),
-            SessionUpdate::TurnError { error, session_id } => Some(Self::TurnError {
+            SessionUpdate::TurnError {
+                error,
+                session_id,
+                turn_id,
+            } => Some(Self::TurnError {
                 error: error.clone(),
                 session_id: session_id.clone(),
+                turn_id: turn_id.clone(),
             }),
             _ => None,
         }
@@ -180,8 +191,22 @@ impl ProjectionJournalUpdate {
                 question,
                 session_id,
             },
-            Self::TurnComplete { session_id } => SessionUpdate::TurnComplete { session_id },
-            Self::TurnError { error, session_id } => SessionUpdate::TurnError { error, session_id },
+            Self::TurnComplete {
+                session_id,
+                turn_id,
+            } => SessionUpdate::TurnComplete {
+                session_id,
+                turn_id,
+            },
+            Self::TurnError {
+                error,
+                session_id,
+                turn_id,
+            } => SessionUpdate::TurnError {
+                error,
+                session_id,
+                turn_id,
+            },
         }
     }
 }

--- a/packages/desktop/src-tauri/src/acp/session_update/deserialize.rs
+++ b/packages/desktop/src-tauri/src/acp/session_update/deserialize.rs
@@ -65,6 +65,12 @@ where
         .or_else(|| raw.data.get("session_id"))
         .and_then(|v| v.as_str())
         .map(|s| s.to_string());
+    let turn_id = raw
+        .data
+        .get("turnId")
+        .or_else(|| raw.data.get("turn_id"))
+        .and_then(|v| v.as_str())
+        .map(|s| s.to_string());
 
     let update_type = extract_update_type_with_agent::<E>(
         &raw.data,
@@ -267,7 +273,10 @@ where
                 session_id,
             })
         }
-        "turnComplete" => Ok(SessionUpdate::TurnComplete { session_id }),
+        "turnComplete" => Ok(SessionUpdate::TurnComplete {
+            session_id,
+            turn_id,
+        }),
         "turnError" => {
             let error = raw
                 .data
@@ -279,7 +288,11 @@ where
                 .map_err(|e| serde::de::Error::custom(format!("Invalid turn error: {}", e)))?
                 .unwrap_or_else(|| TurnErrorData::Legacy("Unknown error".to_string()));
 
-            Ok(SessionUpdate::TurnError { error, session_id })
+            Ok(SessionUpdate::TurnError {
+                error,
+                session_id,
+                turn_id,
+            })
         }
         "usageTelemetryUpdate" => {
             let data = parse_usage_telemetry_data_with_agent::<E>(

--- a/packages/desktop/src-tauri/src/acp/session_update/types/session_update.rs
+++ b/packages/desktop/src-tauri/src/acp/session_update/types/session_update.rs
@@ -99,6 +99,8 @@ pub enum SessionUpdate {
     TurnComplete {
         #[serde(skip_serializing_if = "Option::is_none")]
         session_id: Option<String>,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        turn_id: Option<String>,
     },
 
     /// Indicates that the current turn/prompt failed with an error.
@@ -108,6 +110,8 @@ pub enum SessionUpdate {
         error: TurnErrorData,
         #[serde(skip_serializing_if = "Option::is_none")]
         session_id: Option<String>,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        turn_id: Option<String>,
     },
 
     /// Usage/cost and token telemetry from the agent (adapter-agnostic).

--- a/packages/desktop/src-tauri/src/acp/streaming_delta_batcher.rs
+++ b/packages/desktop/src-tauri/src/acp/streaming_delta_batcher.rs
@@ -710,10 +710,15 @@ impl StreamingDeltaBatcher {
     /// Flushes all buffered updates for the session, then appends TurnComplete.
     /// This guarantees correct ordering: all streaming chunks come before TurnComplete.
     #[must_use = "updates must be emitted to the frontend"]
-    pub fn process_turn_complete(&mut self, session_id: &str) -> Vec<SessionUpdate> {
+    pub fn process_turn_complete(
+        &mut self,
+        session_id: &str,
+        turn_id: Option<String>,
+    ) -> Vec<SessionUpdate> {
         let mut results = self.flush_session(session_id);
         results.push(SessionUpdate::TurnComplete {
             session_id: Some(session_id.to_string()),
+            turn_id,
         });
         results
     }
@@ -726,12 +731,14 @@ impl StreamingDeltaBatcher {
     pub fn process_turn_error(
         &mut self,
         session_id: &str,
+        turn_id: Option<String>,
         error: TurnErrorData,
     ) -> Vec<SessionUpdate> {
         let mut results = self.flush_session(session_id);
         results.push(SessionUpdate::TurnError {
             error,
             session_id: Some(session_id.to_string()),
+            turn_id,
         });
         results
     }
@@ -1037,7 +1044,7 @@ mod tests {
                 session_id: Some(session_id.to_string()),
             }));
         }
-        emitted_updates.extend(batcher.process_turn_complete(session_id));
+        emitted_updates.extend(batcher.process_turn_complete(session_id, None));
 
         let mut text_by_part: std::collections::BTreeMap<String, String> =
             std::collections::BTreeMap::new();
@@ -1063,6 +1070,7 @@ mod tests {
                 }
                 SessionUpdate::TurnComplete {
                     session_id: completed_session_id,
+                    ..
                 } => {
                     assert_eq!(completed_session_id.as_deref(), Some(session_id));
                     turn_complete_count += 1;
@@ -1432,7 +1440,7 @@ mod tests {
         assert!(batcher.has_pending());
 
         // Process turn complete
-        let result = batcher.process_turn_complete("session-1");
+        let result = batcher.process_turn_complete("session-1", Some("turn-1".to_string()));
 
         // Should have 1 flushed message chunk + 1 TurnComplete
         assert_eq!(result.len(), 2);
@@ -1449,8 +1457,13 @@ mod tests {
         }
 
         // Last should be TurnComplete
-        if let SessionUpdate::TurnComplete { session_id } = &result[1] {
+        if let SessionUpdate::TurnComplete {
+            session_id,
+            turn_id,
+        } = &result[1]
+        {
             assert_eq!(session_id.as_deref(), Some("session-1"));
+            assert_eq!(turn_id.as_deref(), Some("turn-1"));
         } else {
             panic!("Expected TurnComplete last");
         }
@@ -1469,6 +1482,7 @@ mod tests {
         // Process turn error
         let result = batcher.process_turn_error(
             "session-1",
+            Some("turn-2".to_string()),
             TurnErrorData::Legacy("Rate limit exceeded".to_string()),
         );
 
@@ -1482,12 +1496,18 @@ mod tests {
         ));
 
         // Last should be TurnError with the legacy error message
-        if let SessionUpdate::TurnError { error, session_id } = &result[1] {
+        if let SessionUpdate::TurnError {
+            error,
+            session_id,
+            turn_id,
+        } = &result[1]
+        {
             assert_eq!(
                 error,
                 &TurnErrorData::Legacy("Rate limit exceeded".to_string())
             );
             assert_eq!(session_id.as_deref(), Some("session-1"));
+            assert_eq!(turn_id.as_deref(), Some("turn-2"));
         } else {
             panic!("Expected TurnError last");
         }
@@ -1525,7 +1545,7 @@ mod tests {
         assert_eq!(batcher.buffer_count(), 2);
 
         // Complete only session-1
-        let result = batcher.process_turn_complete("session-1");
+        let result = batcher.process_turn_complete("session-1", None);
 
         // Should have session-1's chunk + TurnComplete
         assert_eq!(result.len(), 2);
@@ -1553,7 +1573,7 @@ mod tests {
         let mut batcher = StreamingDeltaBatcher::new();
 
         // No data buffered - should just return TurnComplete
-        let result = batcher.process_turn_complete("session-1");
+        let result = batcher.process_turn_complete("session-1", None);
 
         assert_eq!(result.len(), 1);
         assert!(matches!(&result[0], SessionUpdate::TurnComplete { .. }));

--- a/packages/desktop/src-tauri/src/acp/ui_event_dispatcher.rs
+++ b/packages/desktop/src-tauri/src/acp/ui_event_dispatcher.rs
@@ -898,6 +898,7 @@ mod tests {
         let (dispatcher, captured_events) = AcpUiEventDispatcher::test_sink();
         dispatcher.enqueue(AcpUiEvent::session_update(SessionUpdate::TurnComplete {
             session_id: Some("session-1".to_string()),
+            turn_id: None,
         }));
 
         let captured = captured_events.lock().expect("captured events lock");
@@ -939,6 +940,7 @@ mod tests {
         ));
         dispatcher.enqueue(AcpUiEvent::session_update(SessionUpdate::TurnComplete {
             session_id: Some("session-1".to_string()),
+            turn_id: None,
         }));
 
         let snapshot = projection_registry

--- a/packages/desktop/src-tauri/src/copilot_history/mod.rs
+++ b/packages/desktop/src-tauri/src/copilot_history/mod.rs
@@ -158,11 +158,13 @@ fn stored_error_message_from_turn_error(error: &TurnErrorData) -> StoredErrorMes
             content: message.clone(),
             code: None,
             kind: TurnErrorKind::Recoverable,
+            source: None,
         },
         TurnErrorData::Structured(info) => StoredErrorMessage {
             content: info.message.clone(),
             code: info.code.map(|code| code.to_string()),
             kind: info.kind,
+            source: info.source,
         },
     }
 }
@@ -190,21 +192,7 @@ fn assistant_message_matches_turn_error(
 }
 
 fn merge_replay_tool_arguments(current: ToolArguments, incoming: ToolArguments) -> ToolArguments {
-    fn merge_optional<T>(current: Option<T>, incoming: Option<T>) -> Option<T> {
-        incoming.or(current)
-    }
-
     match (current, incoming) {
-        (
-            ToolArguments::Read {
-                file_path: current_file_path,
-            },
-            ToolArguments::Read {
-                file_path: incoming_file_path,
-            },
-        ) => ToolArguments::Read {
-            file_path: merge_optional(current_file_path, incoming_file_path),
-        },
         (
             ToolArguments::Edit {
                 edits: current_edits,
@@ -214,142 +202,6 @@ fn merge_replay_tool_arguments(current: ToolArguments, incoming: ToolArguments) 
             },
         ) => ToolArguments::Edit {
             edits: merge_replay_edit_entries(current_edits, incoming_edits),
-        },
-        (
-            ToolArguments::Execute {
-                command: current_command,
-            },
-            ToolArguments::Execute {
-                command: incoming_command,
-            },
-        ) => ToolArguments::Execute {
-            command: merge_optional(current_command, incoming_command),
-        },
-        (
-            ToolArguments::Search {
-                query: current_query,
-                file_path: current_file_path,
-            },
-            ToolArguments::Search {
-                query: incoming_query,
-                file_path: incoming_file_path,
-            },
-        ) => ToolArguments::Search {
-            query: merge_optional(current_query, incoming_query),
-            file_path: merge_optional(current_file_path, incoming_file_path),
-        },
-        (
-            ToolArguments::Glob {
-                pattern: current_pattern,
-                path: current_path,
-            },
-            ToolArguments::Glob {
-                pattern: incoming_pattern,
-                path: incoming_path,
-            },
-        ) => ToolArguments::Glob {
-            pattern: merge_optional(current_pattern, incoming_pattern),
-            path: merge_optional(current_path, incoming_path),
-        },
-        (ToolArguments::Fetch { url: current_url }, ToolArguments::Fetch { url: incoming_url }) => {
-            ToolArguments::Fetch {
-                url: merge_optional(current_url, incoming_url),
-            }
-        }
-        (
-            ToolArguments::WebSearch {
-                query: current_query,
-            },
-            ToolArguments::WebSearch {
-                query: incoming_query,
-            },
-        ) => ToolArguments::WebSearch {
-            query: merge_optional(current_query, incoming_query),
-        },
-        (
-            ToolArguments::Think {
-                description: current_description,
-                prompt: current_prompt,
-                subagent_type: current_subagent_type,
-                skill: current_skill,
-                skill_args: current_skill_args,
-                raw: current_raw,
-            },
-            ToolArguments::Think {
-                description: incoming_description,
-                prompt: incoming_prompt,
-                subagent_type: incoming_subagent_type,
-                skill: incoming_skill,
-                skill_args: incoming_skill_args,
-                raw: incoming_raw,
-            },
-        ) => ToolArguments::Think {
-            description: merge_optional(current_description, incoming_description),
-            prompt: merge_optional(current_prompt, incoming_prompt),
-            subagent_type: merge_optional(current_subagent_type, incoming_subagent_type),
-            skill: merge_optional(current_skill, incoming_skill),
-            skill_args: merge_optional(current_skill_args, incoming_skill_args),
-            raw: merge_optional(current_raw, incoming_raw),
-        },
-        (
-            ToolArguments::TaskOutput {
-                task_id: current_task_id,
-                timeout: current_timeout,
-            },
-            ToolArguments::TaskOutput {
-                task_id: incoming_task_id,
-                timeout: incoming_timeout,
-            },
-        ) => ToolArguments::TaskOutput {
-            task_id: merge_optional(current_task_id, incoming_task_id),
-            timeout: merge_optional(current_timeout, incoming_timeout),
-        },
-        (
-            ToolArguments::Move {
-                from: current_from,
-                to: current_to,
-            },
-            ToolArguments::Move {
-                from: incoming_from,
-                to: incoming_to,
-            },
-        ) => ToolArguments::Move {
-            from: merge_optional(current_from, incoming_from),
-            to: merge_optional(current_to, incoming_to),
-        },
-        (
-            ToolArguments::Delete {
-                file_path: current_file_path,
-                file_paths: current_file_paths,
-            },
-            ToolArguments::Delete {
-                file_path: incoming_file_path,
-                file_paths: incoming_file_paths,
-            },
-        ) => ToolArguments::Delete {
-            file_path: merge_optional(current_file_path, incoming_file_path),
-            file_paths: merge_optional(current_file_paths, incoming_file_paths),
-        },
-        (
-            ToolArguments::PlanMode { mode: current_mode },
-            ToolArguments::PlanMode {
-                mode: incoming_mode,
-            },
-        ) => ToolArguments::PlanMode {
-            mode: merge_optional(current_mode, incoming_mode),
-        },
-        (
-            ToolArguments::ToolSearch {
-                query: current_query,
-                max_results: current_max_results,
-            },
-            ToolArguments::ToolSearch {
-                query: incoming_query,
-                max_results: incoming_max_results,
-            },
-        ) => ToolArguments::ToolSearch {
-            query: merge_optional(current_query, incoming_query),
-            max_results: merge_optional(current_max_results, incoming_max_results),
         },
         (_, incoming_arguments) => incoming_arguments,
     }
@@ -947,89 +799,6 @@ mod tests {
     }
 
     #[test]
-    fn preserves_search_arguments_when_replayed_tool_call_becomes_sparse() {
-        let session_id = "copilot-session-search";
-        let converted = convert_replay_updates_to_session(
-            session_id,
-            "Copilot Session",
-            &[
-                (
-                    1_710_000_012_000,
-                    crate::acp::session_update::SessionUpdate::ToolCall {
-                        tool_call: ToolCallData {
-                            id: "tool-search-1".to_string(),
-                            name: "Search".to_string(),
-                            arguments: ToolArguments::Search {
-                                query: Some("#\\[tauri::command\\]".to_string()),
-                                file_path: Some("src/".to_string()),
-                            },
-                            raw_input: None,
-                            status: ToolCallStatus::Pending,
-                            result: None,
-                            kind: Some(ToolKind::Search),
-                            title: Some("Grepped".to_string()),
-                            locations: None,
-                            skill_meta: None,
-                            normalized_questions: None,
-                            normalized_todos: None,
-                            parent_tool_use_id: None,
-                            task_children: None,
-                            question_answer: None,
-                            awaiting_plan_approval: false,
-                            plan_approval_request_id: None,
-                        },
-                        session_id: Some(session_id.to_string()),
-                    },
-                ),
-                (
-                    1_710_000_012_500,
-                    crate::acp::session_update::SessionUpdate::ToolCall {
-                        tool_call: ToolCallData {
-                            id: "tool-search-1".to_string(),
-                            name: "Search".to_string(),
-                            arguments: ToolArguments::Search {
-                                query: None,
-                                file_path: None,
-                            },
-                            raw_input: None,
-                            status: ToolCallStatus::Completed,
-                            result: None,
-                            kind: Some(ToolKind::Search),
-                            title: Some("Grepped".to_string()),
-                            locations: None,
-                            skill_meta: None,
-                            normalized_questions: None,
-                            normalized_todos: None,
-                            parent_tool_use_id: None,
-                            task_children: None,
-                            question_answer: None,
-                            awaiting_plan_approval: false,
-                            plan_approval_request_id: None,
-                        },
-                        session_id: Some(session_id.to_string()),
-                    },
-                ),
-            ],
-        );
-
-        assert_eq!(converted.entries.len(), 1);
-
-        match &converted.entries[0] {
-            StoredEntry::ToolCall { message, .. } => {
-                assert_eq!(message.status, ToolCallStatus::Completed);
-                match &message.arguments {
-                    ToolArguments::Search { query, file_path } => {
-                        assert_eq!(query.as_deref(), Some("#\\[tauri::command\\]"));
-                        assert_eq!(file_path.as_deref(), Some("src/"));
-                    }
-                    other => panic!("expected search arguments, got {:?}", other),
-                }
-            }
-            other => panic!("expected tool call entry, got {:?}", other),
-        }
-    }
-
-    #[test]
     fn replay_conversion_filters_copilot_thought_chunks_from_restored_history() {
         let session_id = "copilot-session-thought";
         let converted = convert_replay_updates_to_session(
@@ -1125,6 +894,7 @@ mod tests {
                             source: None,
                         }),
                         session_id: Some(session_id.to_string()),
+                        turn_id: None,
                     },
                 ),
             ],

--- a/packages/desktop/src-tauri/src/db/repository_test.rs
+++ b/packages/desktop/src-tauri/src/db/repository_test.rs
@@ -178,6 +178,8 @@ mod session_metadata_tests {
                 last_agent_message_id: Some("msg-1".to_string()),
                 active_tool_call_ids: vec![],
                 completed_tool_call_ids: vec!["tool-1".to_string()],
+                active_turn_failure: None,
+                last_terminal_turn_id: None,
             }),
             operations: vec![],
             interactions: vec![InteractionSnapshot {
@@ -1813,77 +1815,6 @@ mod session_metadata_tests {
             .unwrap();
         assert_eq!(session.sequence_id, Some(1));
         assert!(session.is_acepe_managed);
-    }
-
-    #[tokio::test]
-    async fn test_reserving_worktree_launch_advances_past_metadata_only_sequence_ids() {
-        let db = setup_test_db().await;
-
-        SessionMetadataRepository::ensure_exists(
-            &db,
-            "session-placeholder",
-            "/project",
-            "claude-code",
-            Some("/project/.worktrees/feature-a"),
-        )
-        .await
-        .unwrap();
-
-        AcepeSessionState::delete_by_id("session-placeholder")
-            .exec(&db)
-            .await
-            .unwrap();
-        db.execute(Statement::from_string(
-            sea_orm::DatabaseBackend::Sqlite,
-            "UPDATE session_metadata SET file_path = '__worktree__/legacy-session', sequence_id = 49 WHERE id = 'session-placeholder'".to_string(),
-        ))
-        .await
-        .unwrap();
-
-        let reserved = SessionMetadataRepository::reserve_worktree_launch(&db, "/project", "copilot")
-            .await
-            .unwrap();
-
-        assert_eq!(reserved.sequence_id, 50);
-    }
-
-    #[tokio::test]
-    async fn test_mark_as_acepe_managed_preserves_metadata_only_sequence_id() {
-        let db = setup_test_db().await;
-
-        SessionMetadataRepository::ensure_exists(
-            &db,
-            "session-placeholder",
-            "/project",
-            "claude-code",
-            Some("/project/.worktrees/feature-a"),
-        )
-        .await
-        .unwrap();
-
-        AcepeSessionState::delete_by_id("session-placeholder")
-            .exec(&db)
-            .await
-            .unwrap();
-        db.execute(Statement::from_string(
-            sea_orm::DatabaseBackend::Sqlite,
-            "UPDATE session_metadata SET file_path = '__worktree__/legacy-session', sequence_id = 49 WHERE id = 'session-placeholder'".to_string(),
-        ))
-        .await
-        .unwrap();
-
-        let sequence_id =
-            SessionMetadataRepository::mark_as_acepe_managed(&db, "session-placeholder")
-                .await
-                .unwrap();
-        let state = AcepeSessionState::find_by_id("session-placeholder")
-            .one(&db)
-            .await
-            .unwrap()
-            .unwrap();
-
-        assert_eq!(sequence_id, Some(49));
-        assert_eq!(state.sequence_id, Some(49));
     }
 
     #[tokio::test]

--- a/packages/desktop/src-tauri/src/session_jsonl/export_types.rs
+++ b/packages/desktop/src-tauri/src/session_jsonl/export_types.rs
@@ -13,7 +13,7 @@ use crate::acp::model_display::{
 use crate::acp::projections::{
     InteractionKind, InteractionPayload, InteractionResponse, InteractionSnapshot,
     InteractionState, OperationSnapshot, PlanApprovalSource, SessionProjectionSnapshot,
-    SessionSnapshot, SessionTurnState,
+    SessionSnapshot, SessionTurnState, TurnFailureSnapshot,
 };
 use crate::acp::session_update::{
     AvailableCommand, AvailableCommandsData, ChunkAggregationHint, CommandInput, ConfigOptionData,
@@ -375,6 +375,9 @@ pub fn export_all_types() {
     export_acp_type!(InteractionPayload);
     export_acp_type!(InteractionResponse);
     export_acp_type!(InteractionSnapshot);
+    export_acp_type!(TurnErrorKind);
+    export_acp_type!(TurnErrorSource);
+    export_acp_type!(TurnFailureSnapshot);
     export_acp_type!(SessionProjectionSnapshot);
 
     acp_types = acp_types.replace(

--- a/packages/desktop/src-tauri/src/session_jsonl/types.rs
+++ b/packages/desktop/src-tauri/src/session_jsonl/types.rs
@@ -367,6 +367,8 @@ pub struct StoredErrorMessage {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub code: Option<String>,
     pub kind: crate::acp::session_update::TurnErrorKind,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub source: Option<crate::acp::session_update::TurnErrorSource>,
 }
 
 /// Answered question data from toolUseResult field in JSONL.

--- a/packages/desktop/src/lib/acp/components/agent-panel/components/agent-panel.svelte
+++ b/packages/desktop/src/lib/acp/components/agent-panel/components/agent-panel.svelte
@@ -1,12 +1,5 @@
 <script lang="ts">
-import {
-	AgentPanelShell,
-	ReviewWorkspace,
-	getReviewWorkspaceDefaultIndex,
-	resolveReviewWorkspaceSelectedIndex,
-	type AgentPanelFileReviewStatus,
-	type ReviewWorkspaceFileItem,
-} from "@acepe/ui/agent-panel";
+import { AgentPanelShell } from "@acepe/ui/agent-panel";
 import { EmbeddedIconButton } from "@acepe/ui/panel-header";
 import ArrowUp from "@lucide/svelte/icons/arrow-up";
 import { listen } from "@tauri-apps/api/event";
@@ -29,7 +22,6 @@ import { checkpointStore } from "../../../store/checkpoint-store.svelte.js";
 import { getAgentStore } from "../../../store/index.js";
 import { getConnectionStore } from "../../../store/connection-store.svelte.js";
 import { getPanelStore } from "../../../store/panel-store.svelte.js";
-import { sessionReviewStateStore } from "../../../store/session-review-state-store.svelte.js";
 import { getSessionStore } from "../../../store/session-store.svelte.js";
 import { mergeStrategyStore } from "../../../store/merge-strategy-store.svelte.js";
 import { formatSessionTitleForDisplay } from "../../../store/session-title-policy.js";
@@ -47,7 +39,6 @@ import { shouldDisableSendForFailedFirstSend } from "../../agent-input/logic/fir
 import type { Attachment } from "../../agent-input/types/attachment.js";
 import { CheckpointTimeline } from "../../checkpoint/index.js";
 import { aggregateFileEdits } from "../../modified-files/logic/aggregate-file-edits.js";
-import { getReviewStatusByFilePath } from "../../modified-files/logic/review-progress.js";
 import ModifiedFilesHeader, {
 	type PrGenerationConfig,
 } from "../../modified-files/modified-files-header.svelte";
@@ -113,7 +104,6 @@ import {
 import WorktreeSetupCard from "./worktree-setup-card.svelte";
 import AgentErrorCard from "./agent-error-card.svelte";
 import { buildAgentErrorIssueDraft } from "../logic/issue-report-draft.js";
-import type { FileReviewStatus } from "../../review-panel/review-session-state.js";
 
 // ✅ Destructure props - this is idiomatic Svelte 5
 let {
@@ -145,6 +135,7 @@ let {
 	onEnterReviewMode,
 	onExitReviewMode,
 	onReviewFileIndexChange,
+	onOpenFullscreenReview,
 	attachedFilePanels = [],
 	activeAttachedFilePanelId = null,
 	onSelectAttachedFilePanel,
@@ -370,12 +361,17 @@ const sessionCanSubmit = $derived(runtimeState?.canSubmit ?? false);
 const sessionShowStop = $derived(runtimeState?.showStop ?? false);
 const sessionConnectionError = $derived(sessionHotState?.connectionError ?? null);
 const activeTurnError = $derived.by(() => {
-	if (sessionHotState?.turnState !== "error") {
-		return null;
+	const activeTurnFailure = sessionHotState?.activeTurnFailure;
+	if (activeTurnFailure) {
+		return {
+			content: activeTurnFailure.message,
+			code: activeTurnFailure.code ?? undefined,
+			kind: activeTurnFailure.kind,
+			source: activeTurnFailure.source,
+		};
 	}
 
-	const lastEntry = sessionEntries.at(-1);
-	return lastEntry?.type === "error" ? lastEntry.message : null;
+	return null;
 });
 const disableSendForFailedFirstSend = $derived(
 	panelConnectionState
@@ -407,7 +403,6 @@ const showInlineErrorCard = $derived(errorInfo.showError && !errorDismissed);
 const visibleSessionEntries = $derived.by(() =>
 	resolveVisibleSessionEntries({
 		sessionEntries,
-		showInlineErrorCard,
 		activeTurnError,
 	})
 );
@@ -634,9 +629,9 @@ const footerWorktreeStatus = $derived.by(() => {
 const hasPlan = $derived(planState.plan !== null);
 const ATTACHED_COLUMN_WIDTH = 450;
 const PLAN_SIDEBAR_COLUMN_WIDTH = 450;
+const REVIEW_COLUMN_WIDTH = 450;
 const BROWSER_SIDEBAR_COLUMN_WIDTH = 500;
 const ATTACHED_COLUMN_GAP_WIDTH = 2;
-const REVIEW_WORKSPACE_EMPTY_STATE_LABEL = "Nothing to review";
 
 // Dynamic minimum width reported by the toolbar's intrinsic content measurement.
 // The 16px accounts for the data-input-area wrapper's p-2 padding (8px each side).
@@ -777,6 +772,7 @@ const baseWidth = $derived(Math.max(panelRenderWidth, toolbarMinWidthWithPadding
 const effectiveWidth = $derived.by(() => {
 	let w = baseWidth;
 	if (showPlanSidebar && hasPlan) w += PLAN_SIDEBAR_COLUMN_WIDTH;
+	if (reviewMode && reviewFilesState) w += REVIEW_COLUMN_WIDTH;
 	if (showBrowserSidebar) w += BROWSER_SIDEBAR_COLUMN_WIDTH;
 	return w;
 });
@@ -848,70 +844,6 @@ $effect(() => {
 	return () => clearTimeout(id);
 });
 
-function mapReviewStatus(status: FileReviewStatus | undefined): AgentPanelFileReviewStatus {
-	if (status === "accepted" || status === "partial" || status === "denied") {
-		return status;
-	}
-
-	return "unreviewed";
-}
-
-function buildReviewWorkspaceFiles(
-	filesState: ModifiedFilesState,
-	statusByFilePath: ReadonlyMap<string, FileReviewStatus | undefined>
-): ReviewWorkspaceFileItem[] {
-	return filesState.files.map((file) => ({
-		id: file.filePath,
-		filePath: file.filePath,
-		fileName: file.fileName,
-		reviewStatus: mapReviewStatus(statusByFilePath.get(file.filePath)),
-		additions: file.totalAdded,
-		deletions: file.totalRemoved,
-	}));
-}
-
-function resolveReviewWorkspaceEntryIndex(filesState: ModifiedFilesState): number {
-	if (!sessionId || !sessionReviewStateStore.isLoaded(sessionId)) {
-		return 0;
-	}
-
-	const reviewStatusByPath = getReviewStatusByFilePath(
-		filesState.files,
-		sessionReviewStateStore.getState(sessionId)
-	);
-	const workspaceFiles = buildReviewWorkspaceFiles(filesState, reviewStatusByPath);
-	return getReviewWorkspaceDefaultIndex(workspaceFiles) ?? 0;
-}
-
-function handleEnterReviewMode(filesState: ModifiedFilesState, restoredFileIndex?: number): void {
-	const fileIndex = restoredFileIndex ?? resolveReviewWorkspaceEntryIndex(filesState);
-	onEnterReviewMode?.(filesState, fileIndex);
-}
-
-const reviewStatusByFilePath = $derived.by((): ReadonlyMap<string, FileReviewStatus | undefined> => {
-	if (!reviewFilesState) {
-		return new Map<string, FileReviewStatus | undefined>();
-	}
-
-	if (!sessionId || !sessionReviewStateStore.isLoaded(sessionId)) {
-		return new Map<string, FileReviewStatus | undefined>();
-	}
-
-	return getReviewStatusByFilePath(reviewFilesState.files, sessionReviewStateStore.getState(sessionId));
-});
-
-const reviewWorkspaceFiles = $derived.by((): ReviewWorkspaceFileItem[] => {
-	if (!reviewFilesState) {
-		return [];
-	}
-
-	return buildReviewWorkspaceFiles(reviewFilesState, reviewStatusByFilePath);
-});
-
-const reviewWorkspaceSelectedIndex = $derived.by(() =>
-	resolveReviewWorkspaceSelectedIndex(reviewWorkspaceFiles, reviewFileIndex)
-);
-
 // Track panelId changes for tab switching detection
 let lastPanelId = $state<string | undefined>(undefined);
 
@@ -924,7 +856,7 @@ $effect(() => {
 
 	if (!modifiedFilesState) return;
 
-	handleEnterReviewMode(modifiedFilesState, pendingFileIndex);
+	onEnterReviewMode?.(modifiedFilesState, pendingFileIndex);
 });
 
 $effect(() => {
@@ -1795,33 +1727,66 @@ const queueIsPaused = $derived(sessionId ? messageQueueStore.pausedIds.has(sessi
 		{/if}
 	{/snippet}
 
-	{#snippet topBar()}
-		<div style:display={reviewMode ? "none" : undefined}>
-			{#if hasPlan && planState.plan && panelId && !showPlanSidebar}
-				<SharedPlanHeader
-					title={planState.plan.title}
-					isExpanded={showPlanSidebar}
-					expandLabel={m.plan_sidebar_expand()}
-					collapseLabel={m.plan_sidebar_collapse()}
-					onToggleSidebar={() => panelStore.setPlanSidebarExpanded(panelId, !showPlanSidebar)}
+	{#snippet reviewPane()}
+		{#if reviewFilesState}
+			<div
+				class="flex h-full min-h-0 shrink-0 flex-col border-r border-border"
+				style="min-width: {REVIEW_COLUMN_WIDTH}px; width: {REVIEW_COLUMN_WIDTH}px; max-width: {REVIEW_COLUMN_WIDTH}px; flex-basis: {REVIEW_COLUMN_WIDTH}px;"
+				style:display={reviewMode ? undefined : "none"}
+			>
+				<AgentPanelReviewContent
+					modifiedFilesState={reviewFilesState}
+					selectedFileIndex={reviewFileIndex}
+					{sessionId}
+					projectPath={sessionProjectPath}
+					isActive={reviewMode}
+					onClose={() => onExitReviewMode?.()}
+					onFileIndexChange={(index) => onReviewFileIndexChange?.(index)}
+					onExpandToFullscreen={sessionId && onOpenFullscreenReview
+						? () => onOpenFullscreenReview(sessionId, reviewFileIndex)
+						: undefined}
 				/>
-			{/if}
+			</div>
+		{/if}
+	{/snippet}
 
-			{#if planState.plan}
-				<PlanDialog
-					plan={planState.plan}
-					open={panelState.showPlanDialog}
-					onOpenChange={(open) => (panelState.showPlanDialog = open)}
-					projectPath={sessionProjectPath ?? undefined}
-				/>
-			{/if}
-		</div>
+	{#snippet topBar()}
+		{#if hasPlan && planState.plan && panelId && !showPlanSidebar}
+			<SharedPlanHeader
+				title={planState.plan.title}
+				isExpanded={showPlanSidebar}
+				expandLabel={m.plan_sidebar_expand()}
+				collapseLabel={m.plan_sidebar_collapse()}
+				onToggleSidebar={() => panelStore.setPlanSidebarExpanded(panelId, !showPlanSidebar)}
+			/>
+		{/if}
+
+		{#if planState.plan}
+			<PlanDialog
+				plan={planState.plan}
+				open={panelState.showPlanDialog}
+				onOpenChange={(open) => (panelState.showPlanDialog = open)}
+				projectPath={sessionProjectPath ?? undefined}
+			/>
+		{/if}
 	{/snippet}
 
 	{#snippet body()}
-		<div class="flex h-full min-h-0 flex-col" style:display={reviewMode ? "none" : undefined}>
-			{#if showCheckpointTimeline && sessionProjectPath && sessionId}
-				<CheckpointTimeline
+		{#if showCheckpointTimeline && sessionProjectPath && sessionId}
+			<CheckpointTimeline
+				{sessionId}
+				projectPath={sessionProjectPath}
+				{checkpoints}
+				isLoading={isLoadingCheckpoints}
+				onClose={handleCloseCheckpointTimeline}
+				onRevertComplete={handleCheckpointRevertComplete}
+			/>
+		{:else}
+			<div class="flex-1 min-h-0 mb-2">
+				<AgentPanelContent
+					bind:this={contentRef}
+					panelId={effectivePanelId}
+					{viewState}
 					{sessionId}
 					sessionEntries={visibleSessionEntries}
 					sessionProjectPath={effectiveProjectPath ?? sessionProjectPath}
@@ -1842,92 +1807,41 @@ const queueIsPaused = $derived(sessionId ? messageQueueStore.pausedIds.has(sessi
 					turnState={sessionHotState?.turnState ?? "idle"}
 					isWaitingForResponse={runtimeState?.showThinking ?? false}
 				/>
-			{:else}
-				<div class="flex-1 min-h-0 mb-2">
-					<AgentPanelContent
-						bind:this={contentRef}
-						panelId={effectivePanelId}
-						{viewState}
-						{sessionId}
-						sessionEntries={visibleSessionEntries}
-						sessionProjectPath={effectiveProjectPath ?? sessionProjectPath}
-						{allProjects}
-						bind:scrollContainer
-						bind:scrollViewport={contentScrollViewport}
-						bind:isAtBottom={contentIsAtBottom}
-						bind:isAtTop={contentIsAtTop}
-						bind:isStreaming={contentIsStreaming}
-						onProjectAgentSelected={handleProjectAgentSelected}
-						onRetryConnection={handleRetryConnection}
-						onCancelConnection={handleCancelConnection}
-						{agentIconSrc}
-						isFullscreen={centeredFullscreenContent}
-						{availableAgents}
-						{effectiveTheme}
-						{modifiedFilesState}
-						turnState={sessionHotState?.turnState ?? "idle"}
-						isWaitingForResponse={runtimeState?.showThinking ?? false}
-					/>
+			</div>
+			{#if viewState.kind === "conversation" && !contentIsAtTop}
+				<div class="absolute top-4 left-1/2 -translate-x-1/2 z-10">
+					<button
+						class="h-8 w-8 flex items-center justify-center rounded-full border border-border bg-background shadow-sm hover:bg-muted transition-colors"
+						onclick={scrollToTop}
+						aria-label={m.agent_panel_scroll_top()}
+					>
+						<ArrowUp class="h-4 w-4" />
+					</button>
 				</div>
-				{#if viewState.kind === "conversation" && !contentIsAtTop}
-					<div class="absolute top-4 left-1/2 -translate-x-1/2 z-10">
-						<button
-							class="h-8 w-8 flex items-center justify-center rounded-full border border-border bg-background shadow-sm hover:bg-muted transition-colors"
-							onclick={scrollToTop}
-							aria-label={m.agent_panel_scroll_top()}
-						>
-							<ArrowUp class="h-4 w-4" />
-						</button>
-					</div>
-				{/if}
-				{#if viewState.kind === "conversation" && !contentIsAtBottom}
-					<div class="absolute bottom-4 left-1/2 -translate-x-1/2 z-10">
-						<ScrollToBottomButton visible={true} onClick={scrollToBottom} />
-					</div>
-				{/if}
 			{/if}
-		</div>
-		{#if reviewMode && reviewFilesState}
-			<ReviewWorkspace
-				files={reviewWorkspaceFiles}
-				selectedFileIndex={reviewWorkspaceSelectedIndex}
-				onClose={() => onExitReviewMode?.()}
-				onFileSelect={(index) => onReviewFileIndexChange?.(index)}
-				headerLabel={m.modified_files_review_title()}
-				closeButtonLabel={m.modified_files_back_button()}
-				emptyStateLabel={REVIEW_WORKSPACE_EMPTY_STATE_LABEL}
-			>
-				{#snippet content()}
-					<AgentPanelReviewContent
-						modifiedFilesState={reviewFilesState}
-						selectedFileIndex={reviewWorkspaceSelectedIndex ?? 0}
-						{sessionId}
-						projectPath={sessionProjectPath}
-						isActive={reviewMode}
-						onClose={() => onExitReviewMode?.()}
-						onFileIndexChange={(index) => onReviewFileIndexChange?.(index)}
-					/>
-				{/snippet}
-			</ReviewWorkspace>
+			{#if viewState.kind === "conversation" && !contentIsAtBottom}
+				<div class="absolute bottom-4 left-1/2 -translate-x-1/2 z-10">
+					<ScrollToBottomButton visible={true} onClick={scrollToBottom} />
+				</div>
+			{/if}
 		{/if}
 	{/snippet}
 
 	{#snippet preComposer()}
-		<div style:display={reviewMode ? "none" : undefined}>
-			{#if viewState.kind === "conversation" || viewState.kind === "ready" || viewState.kind === "error"}
-				{#if worktreeDeleted}
-					<div class="{centeredFullscreenContent ? 'flex justify-center' : ''} px-5 mb-2">
-						<div class="flex justify-center {centeredFullscreenContent ? 'w-full max-w-4xl' : ''}">
-							<div class="inline-flex items-center gap-2 px-3 py-1 rounded-lg bg-accent">
-								<Tree class="size-3 shrink-0 text-destructive" weight="fill" />
-								<span class="text-[0.6875rem] text-muted-foreground">
-									{m.worktree_deleted_banner()}
-								</span>
-							</div>
+		{#if viewState.kind === "conversation" || viewState.kind === "ready" || viewState.kind === "error"}
+			{#if worktreeDeleted}
+				<div class="{centeredFullscreenContent ? 'flex justify-center' : ''} px-5 mb-2">
+					<div class="flex justify-center {centeredFullscreenContent ? 'w-full max-w-4xl' : ''}">
+						<div class="inline-flex items-center gap-2 px-3 py-1 rounded-lg bg-accent">
+							<Tree class="size-3 shrink-0 text-destructive" weight="fill" />
+							<span class="text-[0.6875rem] text-muted-foreground">
+								{m.worktree_deleted_banner()}
+							</span>
 						</div>
 					</div>
-				{/if}
-				<div class="flex shrink-0 flex-col gap-0.5 pb-1">
+				</div>
+			{/if}
+			<div class="flex shrink-0 flex-col gap-0.5 pb-1">
 				<div class={centeredFullscreenContent ? "flex justify-center" : ""}>
 					<div class={centeredFullscreenContent ? "w-full max-w-[60%]" : ""}>
 						<div class="flex flex-col gap-0.5 px-5">
@@ -2053,7 +1967,10 @@ const queueIsPaused = $derived(sessionId ? messageQueueStore.pausedIds.has(sessi
 								<ModifiedFilesHeader
 									{modifiedFilesState}
 									{sessionId}
-									onEnterReviewMode={handleEnterReviewMode}
+									{onEnterReviewMode}
+									onOpenFullscreenReview={onOpenFullscreenReview && sessionId
+										? (_, fileIndex) => onOpenFullscreenReview(sessionId, fileIndex)
+										: undefined}
 									onCreatePr={createdPr ? undefined : (config) => void handleCreatePr(config)}
 									createPrLoading={createPrRunning}
 									{createPrLabel}
@@ -2130,20 +2047,18 @@ const queueIsPaused = $derived(sessionId ? messageQueueStore.pausedIds.has(sessi
 						</div>
 					</div>
 				</div>
-				</div>
-			{/if}
-		</div>
+			</div>
+		{/if}
 	{/snippet}
 
 	{#snippet composer()}
-		<div style:display={reviewMode ? "none" : undefined}>
-			{#if viewState.kind === "conversation" || viewState.kind === "ready" || viewState.kind === "error"}
-				<SharedAgentPanelComposerFrame
-					centered={centeredFullscreenContent}
-					widthClass="max-w-[60%]"
-				>
-					{#key inputRenderKey}
-						<AgentInput
+		{#if viewState.kind === "conversation" || viewState.kind === "ready" || viewState.kind === "error"}
+			<SharedAgentPanelComposerFrame
+				centered={centeredFullscreenContent}
+				widthClass="max-w-[60%]"
+			>
+				{#key inputRenderKey}
+					<AgentInput
 						bind:this={agentInputRef}
 						sessionId={sessionId ?? undefined}
 						{sessionStatus}
@@ -2196,72 +2111,67 @@ const queueIsPaused = $derived(sessionId ? messageQueueStore.pausedIds.has(sessi
 								</EmbeddedIconButton>
 							{/if}
 						{/snippet}
-						</AgentInput>
-					{/key}
-				</SharedAgentPanelComposerFrame>
-			{/if}
-		</div>
+					</AgentInput>
+				{/key}
+			</SharedAgentPanelComposerFrame>
+		{/if}
 	{/snippet}
 
 	{#snippet footer()}
-		<div style:display={reviewMode ? "none" : undefined}>
-			{#if
-				(viewState.kind === "conversation" || viewState.kind === "ready" || viewState.kind === "error") &&
-				worktreeToggleProjectPath &&
-				panelId
-			}
-				<SharedFooter
-					showTrailingBorder={!isFullscreen}
-					browserActive={showBrowserSidebar}
-					browserTitle="Toggle browser"
-					browserAriaLabel="Toggle browser"
-					onToggleBrowser={() => {
-						if (panelId) {
-							panelStore.toggleBrowserSidebar(panelId);
-						}
-					}}
-					terminalActive={isTerminalDrawerOpen}
-					terminalDisabled={effectivePathForGit === null}
-					terminalTitle={effectivePathForGit !== null
-						? m.embedded_terminal_toggle_tooltip()
-						: m.embedded_terminal_no_cwd_tooltip()}
-					terminalAriaLabel={m.embedded_terminal_toggle_tooltip()}
-					onToggleTerminal={() => {
-						if (panelId && effectivePathForGit) {
-							panelStore.toggleEmbeddedTerminalDrawer(panelId, effectivePathForGit);
-						}
-					}}
-				>
-					{#snippet left()}
-						{#if footerWorktreeStatus}
-							<SharedWorktreeStatusDisplay
-								mode={footerWorktreeStatus.mode}
-								primaryLabel={footerWorktreeStatus.primaryLabel}
-								secondaryLabel={footerWorktreeStatus.secondaryLabel}
-							/>
-						{/if}
-					{/snippet}
-				</SharedFooter>
-			{/if}
-		</div>
+		{#if
+			(viewState.kind === "conversation" || viewState.kind === "ready" || viewState.kind === "error") &&
+			worktreeToggleProjectPath &&
+			panelId
+		}
+			<SharedFooter
+				showTrailingBorder={!isFullscreen}
+				browserActive={showBrowserSidebar}
+				browserTitle="Toggle browser"
+				browserAriaLabel="Toggle browser"
+				onToggleBrowser={() => {
+					if (panelId) {
+						panelStore.toggleBrowserSidebar(panelId);
+					}
+				}}
+				terminalActive={isTerminalDrawerOpen}
+				terminalDisabled={effectivePathForGit === null}
+				terminalTitle={effectivePathForGit !== null
+					? m.embedded_terminal_toggle_tooltip()
+					: m.embedded_terminal_no_cwd_tooltip()}
+				terminalAriaLabel={m.embedded_terminal_toggle_tooltip()}
+				onToggleTerminal={() => {
+					if (panelId && effectivePathForGit) {
+						panelStore.toggleEmbeddedTerminalDrawer(panelId, effectivePathForGit);
+					}
+				}}
+			>
+				{#snippet left()}
+					{#if footerWorktreeStatus}
+						<SharedWorktreeStatusDisplay
+							mode={footerWorktreeStatus.mode}
+							primaryLabel={footerWorktreeStatus.primaryLabel}
+							secondaryLabel={footerWorktreeStatus.secondaryLabel}
+						/>
+					{/if}
+				{/snippet}
+			</SharedFooter>
+		{/if}
 	{/snippet}
 
 	{#snippet bottomDrawer()}
-		<div style:display={reviewMode ? "none" : undefined}>
-			{#if
-				(viewState.kind === "conversation" || viewState.kind === "ready" || viewState.kind === "error") &&
-				isTerminalDrawerOpen &&
-				panelId &&
-				effectivePathForGit
-			}
-				<AgentPanelTerminalDrawer
-					{panelId}
-					effectiveCwd={effectivePathForGit}
-					embeddedTerminals={panelStore.embeddedTerminals}
-					onClose={() => panelStore.setEmbeddedTerminalDrawerOpen(panelId, false)}
-				/>
-			{/if}
-		</div>
+		{#if
+			(viewState.kind === "conversation" || viewState.kind === "ready" || viewState.kind === "error") &&
+			isTerminalDrawerOpen &&
+			panelId &&
+			effectivePathForGit
+		}
+			<AgentPanelTerminalDrawer
+				{panelId}
+				effectiveCwd={effectivePathForGit}
+				embeddedTerminals={panelStore.embeddedTerminals}
+				onClose={() => panelStore.setEmbeddedTerminalDrawerOpen(panelId, false)}
+			/>
+		{/if}
 	{/snippet}
 
 	{#snippet trailingPane()}

--- a/packages/desktop/src/lib/acp/components/agent-panel/components/agent-panel.svelte
+++ b/packages/desktop/src/lib/acp/components/agent-panel/components/agent-panel.svelte
@@ -768,6 +768,13 @@ const agentContentColumnStyle = $derived.by(() =>
 // Ensure panel is never narrower than the toolbar's natural content width
 const baseWidth = $derived(Math.max(panelRenderWidth, toolbarMinWidthWithPadding));
 
+// Clamp reviewFileIndex to valid bounds so a stale index never leaves the review pane empty.
+const clampedReviewFileIndex = $derived.by(() => {
+	const fileCount = reviewFilesState?.fileCount ?? 0;
+	if (fileCount === 0) return 0;
+	return Math.min(reviewFileIndex, fileCount - 1);
+});
+
 // Add embedded pane widths (plan sidebar, review) when expanded
 const effectiveWidth = $derived.by(() => {
 	let w = baseWidth;
@@ -1736,14 +1743,14 @@ const queueIsPaused = $derived(sessionId ? messageQueueStore.pausedIds.has(sessi
 			>
 				<AgentPanelReviewContent
 					modifiedFilesState={reviewFilesState}
-					selectedFileIndex={reviewFileIndex}
+					selectedFileIndex={clampedReviewFileIndex}
 					{sessionId}
 					projectPath={sessionProjectPath}
 					isActive={reviewMode}
 					onClose={() => onExitReviewMode?.()}
 					onFileIndexChange={(index) => onReviewFileIndexChange?.(index)}
 					onExpandToFullscreen={sessionId && onOpenFullscreenReview
-						? () => onOpenFullscreenReview(sessionId, reviewFileIndex)
+						? () => onOpenFullscreenReview(sessionId, clampedReviewFileIndex)
 						: undefined}
 				/>
 			</div>

--- a/packages/desktop/src/lib/acp/components/agent-panel/logic/__tests__/visible-session-entries.test.ts
+++ b/packages/desktop/src/lib/acp/components/agent-panel/logic/__tests__/visible-session-entries.test.ts
@@ -1,101 +1,83 @@
-import { describe, expect, it } from "bun:test";
+import { describe, expect, it } from "vitest";
 
 import type { SessionEntry } from "../../../../application/dto/session.js";
 import { resolveVisibleSessionEntries } from "../visible-session-entries.js";
 
-function createUserEntry(id: string): SessionEntry {
+function createErrorEntry(message: Extract<SessionEntry, { type: "error" }>["message"]): SessionEntry {
 	return {
-		id,
-		type: "user",
-		message: {
-			content: { type: "text", text: "hello" },
-			chunks: [{ type: "text", text: "hello" }],
-		},
-	};
-}
-
-function createErrorEntry(id: string, content: string): SessionEntry {
-	return {
-		id,
+		id: "error-1",
 		type: "error",
-		message: {
-			content,
-			kind: "recoverable",
-		},
+		message,
+		timestamp: new Date("2026-04-15T00:00:00.000Z"),
 	};
-}
-
-function getErrorMessage(entry: SessionEntry) {
-	if (entry.type !== "error") {
-		throw new Error("Expected error entry");
-	}
-
-	return entry.message;
 }
 
 describe("resolveVisibleSessionEntries", () => {
-	it("removes the trailing active turn error when the inline error card is shown", () => {
-		const userEntry = createUserEntry("user-1");
-		const errorEntry = createErrorEntry("error-1", "Rate limit reached");
-		const result = resolveVisibleSessionEntries({
-			sessionEntries: [userEntry, errorEntry],
-			showInlineErrorCard: true,
-			activeTurnError: getErrorMessage(errorEntry),
-		});
-
-		expect(result).toEqual([userEntry]);
-	});
-
-	it("keeps the error entry when the inline card is not shown", () => {
-		const errorEntry = createErrorEntry("error-1", "Rate limit reached");
-		const result = resolveVisibleSessionEntries({
-			sessionEntries: [errorEntry],
-			showInlineErrorCard: false,
-			activeTurnError: getErrorMessage(errorEntry),
-		});
-
-		expect(result).toEqual([errorEntry]);
-	});
-
-	it("keeps historical error entries that are not the active turn error", () => {
-		const historicalError = createErrorEntry("error-1", "Earlier error");
-		const activeTurnError = createErrorEntry("error-2", "Latest error");
-		const result = resolveVisibleSessionEntries({
-			sessionEntries: [createUserEntry("user-1"), historicalError],
-			showInlineErrorCard: true,
-			activeTurnError: getErrorMessage(activeTurnError),
-		});
-
-		expect(result).toEqual([createUserEntry("user-1"), historicalError]);
-	});
-
-	it("removes all trailing duplicate error entries for the active failed turn", () => {
-		const userEntry = createUserEntry("user-1");
-		const transportError: SessionEntry = {
-			id: "error-1",
-			type: "error",
-			message: {
+	it("hides a trailing persisted error row when canonical failed-turn state matches it", () => {
+		const sessionEntries: SessionEntry[] = [
+			createErrorEntry({
 				content: "Usage limit reached",
-				kind: "fatal",
-				source: "transport",
-			},
-		};
-		const processError: SessionEntry = {
-			id: "error-2",
-			type: "error",
-			message: {
+				code: "429",
+				kind: "recoverable",
+				source: "process",
+			}),
+		];
+
+		const result = resolveVisibleSessionEntries({
+			sessionEntries,
+			activeTurnError: {
 				content: "Usage limit reached",
-				kind: "fatal",
+				code: "429",
+				kind: "recoverable",
 				source: "process",
 			},
-		};
-
-		const result = resolveVisibleSessionEntries({
-			sessionEntries: [userEntry, transportError, processError],
-			showInlineErrorCard: true,
-			activeTurnError: processError.message,
 		});
 
-		expect(result).toEqual([userEntry]);
+		expect(result).toEqual([]);
+	});
+
+	it("keeps transcript entries when the canonical failed-turn state does not match", () => {
+		const sessionEntries: SessionEntry[] = [
+			createErrorEntry({
+				content: "Usage limit reached",
+				code: "429",
+				kind: "recoverable",
+				source: "transport",
+			}),
+		];
+
+		const result = resolveVisibleSessionEntries({
+			sessionEntries,
+			activeTurnError: {
+				content: "Usage limit reached",
+				code: "429",
+				kind: "recoverable",
+				source: "process",
+			},
+		});
+
+		expect(result).toEqual(sessionEntries);
+	});
+
+	it("treats missing persisted error source as unknown for legacy duplicate suppression", () => {
+		const sessionEntries: SessionEntry[] = [
+			createErrorEntry({
+				content: "Usage limit reached",
+				code: "429",
+				kind: "recoverable",
+			}),
+		];
+
+		const result = resolveVisibleSessionEntries({
+			sessionEntries,
+			activeTurnError: {
+				content: "Usage limit reached",
+				code: "429",
+				kind: "recoverable",
+				source: "unknown",
+			},
+		});
+
+		expect(result).toEqual([]);
 	});
 });

--- a/packages/desktop/src/lib/acp/components/agent-panel/logic/visible-session-entries.ts
+++ b/packages/desktop/src/lib/acp/components/agent-panel/logic/visible-session-entries.ts
@@ -3,48 +3,37 @@ import type { ErrorMessage } from "../../../types/error-message.js";
 
 interface ResolveVisibleSessionEntriesInput {
 	readonly sessionEntries: readonly SessionEntry[];
-	readonly showInlineErrorCard: boolean;
 	readonly activeTurnError: ErrorMessage | null;
 }
 
-function matchesActiveTurnError(
-	entryMessage: ErrorMessage,
-	activeTurnError: ErrorMessage
-): boolean {
+function canonicalErrorSource(source: ErrorMessage["source"]): string {
+	return source ?? "unknown";
+}
+
+function matchesErrorMessage(left: ErrorMessage, right: ErrorMessage): boolean {
 	return (
-		entryMessage.content === activeTurnError.content &&
-		entryMessage.kind === activeTurnError.kind &&
-		entryMessage.code === activeTurnError.code
+		left.content === right.content &&
+		left.code === right.code &&
+		left.kind === right.kind &&
+		canonicalErrorSource(left.source) === canonicalErrorSource(right.source)
 	);
 }
 
 export function resolveVisibleSessionEntries(
 	input: ResolveVisibleSessionEntriesInput
 ): readonly SessionEntry[] {
-	if (!input.showInlineErrorCard || input.activeTurnError === null) {
+	if (input.activeTurnError === null) {
 		return input.sessionEntries;
 	}
 
 	const lastEntry = input.sessionEntries.at(-1);
-	if (!lastEntry || lastEntry.type !== "error") {
+	if (lastEntry?.type !== "error") {
 		return input.sessionEntries;
 	}
 
-	if (!matchesActiveTurnError(lastEntry.message, input.activeTurnError)) {
+	if (!matchesErrorMessage(lastEntry.message, input.activeTurnError)) {
 		return input.sessionEntries;
 	}
 
-	let lastVisibleIndex = input.sessionEntries.length - 1;
-	while (lastVisibleIndex >= 0) {
-		const entry = input.sessionEntries[lastVisibleIndex];
-		if (entry?.type !== "error") {
-			break;
-		}
-		if (!matchesActiveTurnError(entry.message, input.activeTurnError)) {
-			break;
-		}
-		lastVisibleIndex -= 1;
-	}
-
-	return input.sessionEntries.slice(0, lastVisibleIndex + 1);
+	return input.sessionEntries.slice(0, -1);
 }

--- a/packages/desktop/src/lib/acp/components/agent-panel/types/agent-panel-props.ts
+++ b/packages/desktop/src/lib/acp/components/agent-panel/types/agent-panel-props.ts
@@ -168,6 +168,12 @@ export interface AgentPanelProps {
 	readonly onReviewFileIndexChange?: (fileIndex: number) => void;
 
 	/**
+	 * Optional callback to open the full-screen review overlay.
+	 * When provided, shows an expand icon in the modified files header.
+	 */
+	readonly onOpenFullscreenReview?: (sessionId: string, fileIndex: number) => void;
+
+	/**
 	 * Attached file panels owned by this agent panel.
 	 */
 	readonly attachedFilePanels?: readonly FilePanel[];

--- a/packages/desktop/src/lib/acp/components/modified-files/modified-files-header.svelte
+++ b/packages/desktop/src/lib/acp/components/modified-files/modified-files-header.svelte
@@ -9,13 +9,16 @@ import {
 } from "@acepe/ui";
 import { Button } from "@acepe/ui/button";
 import * as DropdownMenu from "@acepe/ui/dropdown-menu";
+import { ArrowsOut } from "phosphor-svelte";
 import { Check } from "phosphor-svelte";
 import { CheckCircle } from "phosphor-svelte";
 import { DotsThreeVertical } from "phosphor-svelte";
+import { FileCode } from "phosphor-svelte";
 import { GitMerge } from "phosphor-svelte";
 import { GitPullRequest } from "phosphor-svelte";
 import { NotePencil } from "phosphor-svelte";
 import { Robot } from "phosphor-svelte";
+import { SidebarSimple } from "phosphor-svelte";
 import { Spinner } from "$lib/components/ui/spinner/index.js";
 import * as m from "$lib/messages.js";
 import type { MergeStrategy } from "$lib/utils/tauri-client/git.js";
@@ -25,6 +28,7 @@ import type { Model } from "../../application/dto/model.js";
 import { getAgentIcon } from "../../constants/thread-list-constants.js";
 import type { AgentInfo } from "../../logic/agent-manager.js";
 import * as agentModelPrefs from "../../store/agent-model-preferences-store.svelte.js";
+import { getReviewPreferenceStore } from "../../store/review-preference-store.svelte.js";
 import { sessionReviewStateStore } from "../../store/session-review-state-store.svelte.js";
 import { capitalizeName } from "../../utils/string-formatting.js";
 import { getModelDisplayName } from "../model-selector-logic.js";
@@ -65,6 +69,8 @@ interface Props {
 	sessionId?: string | null;
 	/** Called when Review button is clicked - enters panel review mode */
 	onEnterReviewMode?: (modifiedFilesState: ModifiedFilesState, fileIndex: number) => void;
+	/** Optional: when provided, shows expand icon to open full-screen review overlay */
+	onOpenFullscreenReview?: (modifiedFilesState: ModifiedFilesState, fileIndex: number) => void;
 	/** Optional: when provided, shows Create PR pill button */
 	onCreatePr?: (config?: PrGenerationConfig) => void;
 	/** Disables the Create PR button when true (e.g. while request in flight) */
@@ -91,6 +97,7 @@ let {
 	modifiedFilesState,
 	sessionId = null,
 	onEnterReviewMode,
+	onOpenFullscreenReview,
 	onCreatePr,
 	createPrLoading = false,
 	createPrLabel = null,
@@ -102,6 +109,9 @@ let {
 	currentModelId = null,
 	effectiveTheme = "dark",
 }: Props = $props();
+
+// Get review preference store at component initialization (not in handlers)
+const reviewPreferenceStore = getReviewPreferenceStore();
 
 let hasPromptDraft = $state(false);
 let promptDraft = $state("");
@@ -242,10 +252,28 @@ const canKeepAll = $derived.by(() => {
 
 const trailingControlsModel = $derived<AgentPanelModifiedFilesTrailingModel>({
 	reviewLabel: m.modified_files_review_button(),
+	reviewOptions: [
+		{
+			id: "panel",
+			label: m.modified_files_review_panel(),
+			kind: "panel",
+			onSelect: () => {
+				void reviewPreferenceStore.setPreferFullscreen(false);
+				if (modifiedFilesState) onEnterReviewMode?.(modifiedFilesState, 0);
+			},
+		},
+		{
+			id: "fullscreen",
+			label: m.modified_files_review_fullscreen(),
+			kind: "fullscreen",
+			onSelect: () => {
+				void reviewPreferenceStore.setPreferFullscreen(true);
+				if (modifiedFilesState) onOpenFullscreenReview?.(modifiedFilesState, 0);
+			},
+		},
+	],
 	onReview: () => {
-		if (modifiedFilesState) {
-			onEnterReviewMode?.(modifiedFilesState, 0);
-		}
+		handleReviewButtonClick(0);
 	},
 	keepState: isKeepAllApplied ? "applied" : canKeepAll ? "enabled" : "disabled",
 	keepLabel: m.review_keep(),
@@ -259,6 +287,16 @@ $effect(() => {
 	if (!sessionId) return;
 	sessionReviewStateStore.ensureLoaded(sessionId);
 });
+
+function handleReviewButtonClick(fileIndex: number): void {
+	if (!modifiedFilesState) return;
+	const preferFullscreen = reviewPreferenceStore.preferFullscreen;
+	if (preferFullscreen && onOpenFullscreenReview) {
+		onOpenFullscreenReview(modifiedFilesState, fileIndex);
+	} else {
+		onEnterReviewMode?.(modifiedFilesState, fileIndex);
+	}
+}
 
 function handleCreatePrClick(): void {
 	if (!onCreatePr) return;
@@ -387,7 +425,7 @@ function mapReviewStatus(status: FileReviewStatus | undefined): AgentPanelFileRe
 						additions: file.totalAdded,
 						deletions: file.totalRemoved,
 						onSelect: () => {
-							onEnterReviewMode?.(modifiedFilesState, index);
+							handleReviewButtonClick(index);
 						},
 					}}
 				/>
@@ -646,8 +684,8 @@ function mapReviewStatus(status: FileReviewStatus | undefined): AgentPanelFileRe
 				{/if}
 		{/snippet}
 
-		{#snippet trailingContent(isExpanded: boolean, toggleExpanded: () => void)}
-			<SharedAgentPanelModifiedFilesTrailingControls model={trailingControlsModel} {isExpanded} onToggle={toggleExpanded} />
+		{#snippet trailingContent(isExpanded: boolean)}
+			<SharedAgentPanelModifiedFilesTrailingControls model={trailingControlsModel} {isExpanded} />
 		{/snippet}
 	</SharedAgentPanelModifiedFilesHeader>
 {/if}

--- a/packages/desktop/src/lib/acp/components/modified-files/modified-files-header.svelte
+++ b/packages/desktop/src/lib/acp/components/modified-files/modified-files-header.svelte
@@ -268,7 +268,13 @@ const trailingControlsModel = $derived<AgentPanelModifiedFilesTrailingModel>({
 			kind: "fullscreen",
 			onSelect: () => {
 				void reviewPreferenceStore.setPreferFullscreen(true);
-				if (modifiedFilesState) onOpenFullscreenReview?.(modifiedFilesState, 0);
+				if (modifiedFilesState) {
+					if (onOpenFullscreenReview) {
+						onOpenFullscreenReview(modifiedFilesState, 0);
+					} else {
+						onEnterReviewMode?.(modifiedFilesState, 0);
+					}
+				}
 			},
 		},
 	],

--- a/packages/desktop/src/lib/acp/converters/stored-entry-converter.test.ts
+++ b/packages/desktop/src/lib/acp/converters/stored-entry-converter.test.ts
@@ -211,6 +211,26 @@ describe("stored-entry-converter", () => {
 					});
 				}
 			});
+
+			it("normalizes missing stored error source to unknown", () => {
+				const stored: StoredEntry = {
+					type: "error",
+					id: "error-1",
+					message: {
+						content: "Usage limit reached",
+						code: "429",
+						kind: "recoverable",
+					},
+					timestamp: "2026-04-15T00:00:00Z",
+				};
+
+				const result = convertStoredEntryToSessionEntry(stored, new Date("2026-04-15T00:00:00Z"));
+
+				expect(result.type).toBe("error");
+				if (result.type === "error") {
+					expect(result.message.source).toBe("unknown");
+				}
+			});
 		});
 
 		describe("user entries", () => {
@@ -309,6 +329,7 @@ describe("stored-entry-converter", () => {
 						content: "Rate limit reached",
 						code: "429",
 						kind: "recoverable",
+						source: "process",
 					},
 					timestamp: "2026-01-13T12:00:00Z",
 				};
@@ -323,6 +344,7 @@ describe("stored-entry-converter", () => {
 						content: "Rate limit reached",
 						code: "429",
 						kind: "recoverable",
+						source: "process",
 					},
 					timestamp,
 				});

--- a/packages/desktop/src/lib/acp/converters/stored-entry-converter.ts
+++ b/packages/desktop/src/lib/acp/converters/stored-entry-converter.ts
@@ -69,6 +69,7 @@ function convertStoredErrorMessage(stored: StoredErrorMessage): ErrorMessage {
 		content: stored.content,
 		code: stored.code ?? undefined,
 		kind: stored.kind,
+		source: stored.source ?? "unknown",
 	};
 }
 

--- a/packages/desktop/src/lib/acp/logic/__tests__/session-machine.test.ts
+++ b/packages/desktop/src/lib/acp/logic/__tests__/session-machine.test.ts
@@ -451,6 +451,7 @@ describe("Session Machine", () => {
 			expect(context.currentModeId).toBeNull();
 			expect(context.currentModelId).toBeNull();
 			expect(context.connectionError).toBeNull();
+			expect(context.turnFailure).toBeNull();
 			expect(context.contentError).toBeNull();
 		});
 	});
@@ -617,8 +618,13 @@ describe("Session Machine", () => {
 
 			actor.send({
 				type: ConnectionEvent.TURN_FAILED,
-				kind: "recoverable",
-				message: "Rate limit reached",
+				failure: {
+					turnId: "turn-1",
+					message: "Rate limit reached",
+					code: null,
+					kind: "recoverable",
+					source: "unknown",
+				},
 			});
 
 			const state = actor.getSnapshot().value as SessionMachineSnapshot;
@@ -628,7 +634,14 @@ describe("Session Machine", () => {
 			expect(uiState.showThinking).toBe(false);
 			expect(uiState.showStreaming).toBe(false);
 			expect(uiState.showError).toBe(false);
-			expect(context.connectionError).toBe("Rate limit reached");
+			expect(context.connectionError).toBeNull();
+			expect(context.turnFailure).toEqual({
+				turnId: "turn-1",
+				message: "Rate limit reached",
+				code: null,
+				kind: "recoverable",
+				source: "unknown",
+			});
 		});
 
 		it("should transition to error on fatal turn failure", () => {
@@ -644,8 +657,13 @@ describe("Session Machine", () => {
 
 			actor.send({
 				type: ConnectionEvent.TURN_FAILED,
-				kind: "fatal",
-				message: "Process transport is not ready",
+				failure: {
+					turnId: "turn-2",
+					message: "Process transport is not ready",
+					code: null,
+					kind: "fatal",
+					source: "process",
+				},
 			});
 
 			const state = actor.getSnapshot().value as SessionMachineSnapshot;
@@ -654,6 +672,36 @@ describe("Session Machine", () => {
 			expect(uiState.showThinking).toBe(false);
 			expect(uiState.showStreaming).toBe(false);
 			expect(uiState.showError).toBe(true);
+		});
+
+		it("clears stored turn failure when a new turn starts", () => {
+			const actor = createActor(sessionMachine, {
+				input: { sessionId: "turn-failure-reset" },
+			});
+			actor.start();
+
+			actor.send({ type: ContentEvent.LOAD });
+			actor.send({ type: ContentEvent.LOADED });
+			actor.send({ type: ConnectionEvent.CONNECT });
+			actor.send({ type: ConnectionEvent.SUCCESS });
+			actor.send({ type: ConnectionEvent.CAPABILITIES_LOADED });
+			actor.send({ type: ConnectionEvent.SEND_MESSAGE });
+			actor.send({
+				type: ConnectionEvent.TURN_FAILED,
+				failure: {
+					turnId: "turn-1",
+					message: "Rate limit reached",
+					code: null,
+					kind: "recoverable",
+					source: "unknown",
+				},
+			});
+
+			expect((actor.getSnapshot().context as SessionMachineContext).turnFailure).not.toBeNull();
+
+			actor.send({ type: ConnectionEvent.SEND_MESSAGE });
+
+			expect((actor.getSnapshot().context as SessionMachineContext).turnFailure).toBeNull();
 		});
 
 		it("should show streaming state for typewriter animation (THE TYPEWRITER FIX)", () => {

--- a/packages/desktop/src/lib/acp/logic/session-machine.ts
+++ b/packages/desktop/src/lib/acp/logic/session-machine.ts
@@ -11,6 +11,7 @@
 import { assign, setup } from "xstate";
 import type { Mode } from "../application/dto/mode.js";
 import type { Model } from "../application/dto/model.js";
+import type { ActiveTurnFailure } from "../types/turn-error.js";
 
 // ============================================
 // CONTENT REGION STATES
@@ -117,10 +118,13 @@ export const sessionMachine = setup({
 			connectionError: ({ event }) => (event as ConnectionErrorEvent).error ?? "Unknown error",
 		}),
 		storeTurnFailure: assign({
-			connectionError: ({ event }) => (event as TurnFailureEvent).message,
+			turnFailure: ({ event }) => (event as TurnFailureEvent).failure,
 		}),
 		clearConnectionError: assign({
 			connectionError: () => null,
+		}),
+		clearTurnFailure: assign({
+			turnFailure: () => null,
 		}),
 	},
 }).createMachine({
@@ -133,6 +137,7 @@ export const sessionMachine = setup({
 		currentModeId: null,
 		currentModelId: null,
 		connectionError: null,
+		turnFailure: null,
 		contentError: null,
 	}),
 	states: {
@@ -175,7 +180,7 @@ export const sessionMachine = setup({
 					on: {
 						[ConnectionEvent.SUCCESS]: {
 							target: ConnectionState.WARMING_UP,
-							actions: "clearConnectionError",
+							actions: ["clearConnectionError", "clearTurnFailure"],
 						},
 						[ConnectionEvent.ERROR]: {
 							target: ConnectionState.ERROR,
@@ -194,7 +199,10 @@ export const sessionMachine = setup({
 				},
 				[ConnectionState.READY]: {
 					on: {
-						[ConnectionEvent.SEND_MESSAGE]: ConnectionState.AWAITING_RESPONSE,
+						[ConnectionEvent.SEND_MESSAGE]: {
+							target: ConnectionState.AWAITING_RESPONSE,
+							actions: "clearTurnFailure",
+						},
 						[ConnectionEvent.DISCONNECT]: ConnectionState.DISCONNECTED,
 						[ConnectionEvent.ERROR]: {
 							target: ConnectionState.ERROR,
@@ -205,10 +213,13 @@ export const sessionMachine = setup({
 				[ConnectionState.AWAITING_RESPONSE]: {
 					on: {
 						[ConnectionEvent.RESPONSE_STARTED]: ConnectionState.STREAMING,
-						[ConnectionEvent.RESPONSE_COMPLETE]: ConnectionState.READY,
+						[ConnectionEvent.RESPONSE_COMPLETE]: {
+							target: ConnectionState.READY,
+							actions: "clearTurnFailure",
+						},
 						[ConnectionEvent.TURN_FAILED]: [
 							{
-								guard: ({ event }) => (event as TurnFailureEvent).kind === "fatal",
+								guard: ({ event }) => (event as TurnFailureEvent).failure.kind === "fatal",
 								target: ConnectionState.ERROR,
 								actions: "storeTurnFailure",
 							},
@@ -226,10 +237,13 @@ export const sessionMachine = setup({
 				},
 				[ConnectionState.STREAMING]: {
 					on: {
-						[ConnectionEvent.RESPONSE_COMPLETE]: ConnectionState.READY,
+						[ConnectionEvent.RESPONSE_COMPLETE]: {
+							target: ConnectionState.READY,
+							actions: "clearTurnFailure",
+						},
 						[ConnectionEvent.TURN_FAILED]: [
 							{
-								guard: ({ event }) => (event as TurnFailureEvent).kind === "fatal",
+								guard: ({ event }) => (event as TurnFailureEvent).failure.kind === "fatal",
 								target: ConnectionState.ERROR,
 								actions: "storeTurnFailure",
 							},
@@ -249,10 +263,13 @@ export const sessionMachine = setup({
 				[ConnectionState.PAUSED]: {
 					on: {
 						[ConnectionEvent.RESUME]: ConnectionState.STREAMING,
-						[ConnectionEvent.RESPONSE_COMPLETE]: ConnectionState.READY,
+						[ConnectionEvent.RESPONSE_COMPLETE]: {
+							target: ConnectionState.READY,
+							actions: "clearTurnFailure",
+						},
 						[ConnectionEvent.TURN_FAILED]: [
 							{
-								guard: ({ event }) => (event as TurnFailureEvent).kind === "fatal",
+								guard: ({ event }) => (event as TurnFailureEvent).failure.kind === "fatal",
 								target: ConnectionState.ERROR,
 								actions: "storeTurnFailure",
 							},
@@ -270,7 +287,10 @@ export const sessionMachine = setup({
 				},
 				[ConnectionState.ERROR]: {
 					on: {
-						[ConnectionEvent.RETRY]: ConnectionState.CONNECTING,
+						[ConnectionEvent.RETRY]: {
+							target: ConnectionState.CONNECTING,
+							actions: ["clearConnectionError", "clearTurnFailure"],
+						},
 						[ConnectionEvent.DISCONNECT]: ConnectionState.DISCONNECTED,
 					},
 				},
@@ -310,6 +330,7 @@ export interface SessionMachineContext {
 	currentModelId: string | null;
 	// Error state
 	connectionError: string | null;
+	turnFailure?: ActiveTurnFailure | null;
 	contentError: string | null;
 }
 
@@ -338,8 +359,7 @@ export type ConnectionErrorEvent = {
 
 export type TurnFailureEvent = {
 	type: typeof ConnectionEvent.TURN_FAILED;
-	kind: "recoverable" | "fatal";
-	message: string;
+	failure: ActiveTurnFailure;
 };
 
 /**

--- a/packages/desktop/src/lib/acp/store/__tests__/session-store-projection-state.vitest.ts
+++ b/packages/desktop/src/lib/acp/store/__tests__/session-store-projection-state.vitest.ts
@@ -1,0 +1,95 @@
+import { describe, expect, it } from "vitest";
+
+import type { SessionProjectionSnapshot } from "$lib/services/acp-types.js";
+
+import { SessionStore } from "../session-store.svelte.js";
+
+function createProjectionSnapshot(
+	overrides: Partial<SessionProjectionSnapshot["session"]> = {}
+): SessionProjectionSnapshot {
+	return {
+		session: {
+			session_id: "session-1",
+			agent_id: "codex",
+			last_event_seq: 7,
+			turn_state: "Failed",
+			message_count: 1,
+			last_agent_message_id: null,
+			active_tool_call_ids: [],
+			completed_tool_call_ids: [],
+			active_turn_failure: {
+				turn_id: "turn-1",
+				message: "Usage limit reached",
+				code: "429",
+				kind: "recoverable",
+				source: "process",
+			},
+			last_terminal_turn_id: "turn-1",
+			...overrides,
+		} as SessionProjectionSnapshot["session"],
+		operations: [],
+		interactions: [],
+	};
+}
+
+describe("SessionStore.applySessionProjection", () => {
+	it("hydrates canonical failed-turn state from the session projection", () => {
+		const store = new SessionStore();
+
+		store.applySessionProjection(createProjectionSnapshot());
+
+		expect(store.getHotState("session-1")).toMatchObject({
+			turnState: "error",
+			connectionError: null,
+			activeTurnFailure: {
+				turnId: "turn-1",
+				message: "Usage limit reached",
+				code: "429",
+				kind: "recoverable",
+				source: "process",
+			},
+			lastTerminalTurnId: "turn-1",
+		});
+	});
+
+	it("clears hydrated failed-turn state when the projection no longer has one", () => {
+		const store = new SessionStore();
+
+		store.applySessionProjection(createProjectionSnapshot());
+		store.applySessionProjection(
+			createProjectionSnapshot({
+				turn_state: "Completed",
+				active_turn_failure: null,
+				last_terminal_turn_id: "turn-1",
+			})
+		);
+
+		expect(store.getHotState("session-1")).toMatchObject({
+			turnState: "completed",
+			activeTurnFailure: null,
+			lastTerminalTurnId: "turn-1",
+		});
+	});
+
+	it("defaults missing projected failure source to unknown during hydration", () => {
+		const store = new SessionStore();
+
+		store.applySessionProjection(
+			createProjectionSnapshot({
+				active_turn_failure: {
+					turn_id: "turn-1",
+					message: "Usage limit reached",
+					code: "429",
+					kind: "recoverable",
+					source: null,
+				},
+			})
+		);
+
+		expect(store.getHotState("session-1")).toMatchObject({
+			activeTurnFailure: {
+				source: "unknown",
+			},
+		});
+	});
+});

--- a/packages/desktop/src/lib/acp/store/__tests__/session-work-projection.test.ts
+++ b/packages/desktop/src/lib/acp/store/__tests__/session-work-projection.test.ts
@@ -173,4 +173,23 @@ describe("deriveSessionWorkProjection", () => {
 		expect(projection.hasError).toBe(true);
 		expect(selectLegacySessionStatus(projection)).toBe("error");
 	});
+
+	it("maps active turn failure to error without a connection-level error", () => {
+		const projection = deriveSessionWorkProjection({
+			state: makeState(),
+			currentModeId: null,
+			connectionError: null,
+			activeTurnFailure: {
+				turnId: "turn-1",
+				message: "Usage limit reached",
+				code: "429",
+				kind: "recoverable",
+				source: "process",
+			},
+		});
+
+		expect(projection.hasError).toBe(true);
+		expect(selectSessionWorkBucket(projection)).toBe("error");
+		expect(selectLegacySessionStatus(projection)).toBe("error");
+	});
 });

--- a/packages/desktop/src/lib/acp/store/__tests__/tab-bar-utils.test.ts
+++ b/packages/desktop/src/lib/acp/store/__tests__/tab-bar-utils.test.ts
@@ -173,6 +173,25 @@ describe("panelToTab", () => {
 			expect(tab.workBucket).toBe("error");
 		});
 
+		it("classifies activeTurnFailure-only sessions as error work buckets", () => {
+			const tab = panelToTab(
+				makeInput({
+					hotState: makeHotState({
+						status: "ready",
+						activeTurnFailure: {
+							turnId: "turn-1",
+							message: "Usage limit reached",
+							code: "429",
+							kind: "recoverable",
+							source: "process",
+						},
+					}),
+				})
+			);
+			expect(tab.state.connection).toBe("connected");
+			expect(tab.workBucket).toBe("error");
+		});
+
 		it("derives disconnected state from status=idle (no session)", () => {
 			const tab = panelToTab(makeInput({ hotState: makeHotState({ status: "idle" }) }));
 			expect(tab.state.connection).toBe("disconnected");

--- a/packages/desktop/src/lib/acp/store/index.ts
+++ b/packages/desktop/src/lib/acp/store/index.ts
@@ -88,6 +88,11 @@ export {
 	type QueueStore,
 	type QueueUpdateInput,
 } from "./queue/index.js";
+export {
+	createReviewPreferenceStore,
+	getReviewPreferenceStore,
+	ReviewPreferenceStore,
+} from "./review-preference-store.svelte.js";
 export { LiveInteractionProjectionSync } from "./services/live-interaction-projection-sync.js";
 export { SessionProjectionHydrator } from "./services/session-projection-hydrator.js";
 // Session state model

--- a/packages/desktop/src/lib/acp/store/live-session-work.ts
+++ b/packages/desktop/src/lib/acp/store/live-session-work.ts
@@ -11,7 +11,10 @@ import type { SessionHotState } from "./types.js";
 
 export interface LiveSessionWorkInput {
 	readonly runtimeState: SessionRuntimeState | null;
-	readonly hotState: Pick<SessionHotState, "status" | "currentMode" | "connectionError">;
+	readonly hotState: Pick<
+		SessionHotState,
+		"status" | "currentMode" | "connectionError" | "activeTurnFailure"
+	>;
 	readonly currentStreamingToolCall: ToolCall | null;
 	readonly interactionSnapshot: Pick<
 		SessionOperationInteractionSnapshot,
@@ -101,6 +104,7 @@ export function deriveLiveSessionWorkProjection(
 		state,
 		currentModeId: input.hotState.currentMode ? input.hotState.currentMode.id : null,
 		connectionError: input.hotState.connectionError,
+		activeTurnFailure: input.hotState.activeTurnFailure ?? null,
 	});
 }
 

--- a/packages/desktop/src/lib/acp/store/queue/__tests__/queue-sections.test.ts
+++ b/packages/desktop/src/lib/acp/store/queue/__tests__/queue-sections.test.ts
@@ -177,6 +177,22 @@ describe("classifyItem", () => {
 		expect(classifyItem(makeItem({ hasError: true, status: "error" }))).toBe("error");
 	});
 
+	it("should classify active turn failure as error without connectionError", () => {
+		expect(
+			classifyItem(
+				makeItem({
+					activeTurnFailure: {
+						turnId: "turn-1",
+						message: "Usage limit reached",
+						code: "429",
+						kind: "recoverable",
+						source: "process",
+					},
+				})
+			)
+		).toBe("error");
+	});
+
 	it("should classify streaming without plan mode as working", () => {
 		expect(
 			classifyItem(makeItem({ status: "streaming", isStreaming: true, currentModeId: "code" }))

--- a/packages/desktop/src/lib/acp/store/queue/__tests__/queue-utils.test.ts
+++ b/packages/desktop/src/lib/acp/store/queue/__tests__/queue-utils.test.ts
@@ -161,6 +161,43 @@ describe("buildQueueItem", () => {
 		expect(item.connectionError).toBe("Resume failed");
 		expect(classifyItem(item)).toBe("error");
 	});
+
+	it("classifies recoverable turn failures from activeTurnFailure", () => {
+		const item = buildQueueItem(
+			createSession({
+				state: deriveSessionState({
+					connectionState: "ready",
+					modeId: "plan",
+					tool: null,
+					pendingQuestion: null,
+					pendingPlanApproval: null,
+					pendingPermission: null,
+					hasUnseenCompletion: false,
+				}),
+				status: "error",
+				activeTurnFailure: {
+					turnId: "turn-1",
+					message: "Usage limit reached",
+					code: "429",
+					kind: "recoverable",
+					source: "process",
+				},
+			}),
+			null,
+			DEFAULT_URGENCY,
+			false,
+			false,
+			false,
+			null,
+			null,
+			null,
+			null
+		);
+
+		expect(item.connectionError).toBeNull();
+		expect(item.activeTurnFailure?.message).toBe("Usage limit reached");
+		expect(classifyItem(item)).toBe("error");
+	});
 });
 
 describe("buildQueueSessionSnapshot", () => {

--- a/packages/desktop/src/lib/acp/store/queue/queue-section-utils.ts
+++ b/packages/desktop/src/lib/acp/store/queue/queue-section-utils.ts
@@ -40,13 +40,16 @@ const SECTION_ORDER: readonly QueueSectionId[] = [
  * - The LLM turn has reached ready state
  * - The completion is still unseen by the user
  */
-export function isNeedsReview(item: Pick<QueueItem, "status" | "state" | "connectionError">): boolean {
+export function isNeedsReview(
+	item: Pick<QueueItem, "status" | "state" | "connectionError" | "activeTurnFailure">
+): boolean {
 	return (
 		selectSessionWorkBucket(
 			deriveSessionWorkProjection({
 				state: item.state,
 				currentModeId: null,
 				connectionError: item.connectionError,
+				activeTurnFailure: item.activeTurnFailure ?? null,
 			})
 		) === "needs_review"
 	);
@@ -61,6 +64,7 @@ export function classifyItem(item: QueueItem): QueueSectionId | null {
 			state: item.state,
 			currentModeId: item.currentModeId,
 			connectionError: item.connectionError,
+			activeTurnFailure: item.activeTurnFailure ?? null,
 		})
 	);
 }

--- a/packages/desktop/src/lib/acp/store/queue/types.ts
+++ b/packages/desktop/src/lib/acp/store/queue/types.ts
@@ -8,6 +8,7 @@ import type { PlanApprovalInteraction } from "../../types/interaction.js";
 import type { QuestionRequest } from "../../types/question.js";
 import type { ToolCall } from "../../types/tool-call.js";
 import type { ToolKind } from "../../types/tool-kind.js";
+import type { ActiveTurnFailure } from "../../types/turn-error.js";
 import type { SessionState } from "../session-state.js";
 import type { UrgencyInfo } from "../urgency.js";
 
@@ -61,6 +62,8 @@ export interface QueueItem {
 	readonly status: SessionStatus;
 	/** Connection/agent error message when present */
 	readonly connectionError: string | null;
+	/** Canonical failed-turn state when the latest turn ended in error. */
+	readonly activeTurnFailure?: ActiveTurnFailure | null;
 	/**
 	 * Unified session state model.
 	 * Use this for queue classification instead of individual boolean flags.

--- a/packages/desktop/src/lib/acp/store/queue/utils.ts
+++ b/packages/desktop/src/lib/acp/store/queue/utils.ts
@@ -10,6 +10,7 @@ import type { PlanApprovalInteraction } from "../../types/interaction.js";
 import type { PermissionRequest } from "../../types/permission.js";
 import type { QuestionRequest } from "../../types/question.js";
 import type { ToolCall } from "../../types/tool-call.js";
+import type { ActiveTurnFailure } from "../../types/turn-error.js";
 import { computeStatsFromCheckpoints } from "../../utils/checkpoint-diff-utils.js";
 import { extractProjectName } from "../../utils/path-utils.js";
 import { generateFallbackProjectColor } from "../../utils/project-utils.js";
@@ -47,6 +48,7 @@ export interface QueueSessionSnapshot {
 	readonly currentModeId: string | null;
 	/** Connection/agent error message (e.g. acp_resume_session failure) */
 	readonly connectionError?: string | null;
+	readonly activeTurnFailure?: ActiveTurnFailure | null;
 }
 
 export interface BuildQueueSessionSnapshotInput {
@@ -57,7 +59,10 @@ export interface BuildQueueSessionSnapshotInput {
 	readonly entries: ReadonlyArray<SessionEntry>;
 	readonly updatedAt: Date;
 	readonly runtimeState: SessionRuntimeState | null;
-	readonly hotState: Pick<SessionHotState, "status" | "currentMode" | "connectionError">;
+	readonly hotState: Pick<
+		SessionHotState,
+		"status" | "currentMode" | "connectionError" | "activeTurnFailure"
+	>;
 	readonly interactionSnapshot: Pick<
 		SessionOperationInteractionSnapshot,
 		"pendingPlanApproval" | "pendingPermission" | "pendingQuestion"
@@ -172,11 +177,13 @@ export function buildQueueSessionSnapshot(
 				state,
 				currentModeId: input.hotState.currentMode ? input.hotState.currentMode.id : null,
 				connectionError: input.hotState.connectionError,
+				activeTurnFailure: input.hotState.activeTurnFailure ?? null,
 			})
 		),
 		updatedAt: input.updatedAt,
 		currentModeId: input.hotState.currentMode ? input.hotState.currentMode.id : null,
 		connectionError: input.hotState.connectionError,
+		activeTurnFailure: input.hotState.activeTurnFailure ?? null,
 	};
 }
 
@@ -232,6 +239,7 @@ export function buildQueueItem(
 		pendingPlanApproval,
 		status: session.status,
 		connectionError: session.connectionError ?? null,
+		activeTurnFailure: session.activeTurnFailure ?? null,
 		state: session.state,
 	};
 }
@@ -252,5 +260,6 @@ export function calculateSessionUrgency(
 		pendingQuestionText,
 		statusChangedAt: session.updatedAt.getTime(),
 		connectionError: session.connectionError ?? null,
+		activeTurnFailure: session.activeTurnFailure ?? null,
 	});
 }

--- a/packages/desktop/src/lib/acp/store/review-preference-store.svelte.ts
+++ b/packages/desktop/src/lib/acp/store/review-preference-store.svelte.ts
@@ -1,0 +1,45 @@
+/**
+ * Review Preference Store - Persisted preference for review view mode.
+ *
+ * When "prefer fullscreen" is true, clicking Review opens the full-screen overlay.
+ * When false, Review opens the inline panel review.
+ */
+
+import { getContext, setContext } from "svelte";
+import type { UserSettingKey } from "$lib/services/converted-session-types.js";
+import { tauriClient } from "$lib/utils/tauri-client.js";
+
+const REVIEW_PREFER_FULLSCREEN_KEY: UserSettingKey = "review_prefer_fullscreen";
+
+const STORE_KEY = Symbol("review-preference-store");
+
+export class ReviewPreferenceStore {
+	preferFullscreen = $state(false);
+
+	private initialized = false;
+
+	async initialize(): Promise<void> {
+		if (this.initialized) return;
+		this.initialized = true;
+
+		const result = await tauriClient.settings.get<boolean>(REVIEW_PREFER_FULLSCREEN_KEY);
+		if (result.isOk() && result.value === true) {
+			this.preferFullscreen = true;
+		}
+	}
+
+	async setPreferFullscreen(value: boolean): Promise<void> {
+		this.preferFullscreen = value;
+		tauriClient.settings.set(REVIEW_PREFER_FULLSCREEN_KEY, value).mapErr(() => {});
+	}
+}
+
+export function createReviewPreferenceStore(): ReviewPreferenceStore {
+	const store = new ReviewPreferenceStore();
+	setContext(STORE_KEY, store);
+	return store;
+}
+
+export function getReviewPreferenceStore(): ReviewPreferenceStore {
+	return getContext<ReviewPreferenceStore>(STORE_KEY);
+}

--- a/packages/desktop/src/lib/acp/store/services/__tests__/session-messaging-service-stream-lifecycle.test.ts
+++ b/packages/desktop/src/lib/acp/store/services/__tests__/session-messaging-service-stream-lifecycle.test.ts
@@ -133,6 +133,8 @@ describe("SessionMessagingService.handleStreamComplete", () => {
 		expect(deps.hotStateManager.updateHotState).toHaveBeenCalledWith(sessionId, {
 			status: "ready",
 			turnState: "completed",
+			activeTurnFailure: null,
+			lastTerminalTurnId: null,
 		});
 	});
 
@@ -161,6 +163,30 @@ describe("SessionMessagingService.handleStreamComplete", () => {
 	it("is idempotent when the turn is already completed", () => {
 		(deps.hotStateManager.getHotState as ReturnType<typeof vi.fn>).mockReturnValue({
 			turnState: "completed",
+		});
+
+		service.handleStreamComplete(sessionId);
+
+		expect(deps.connectionManager.sendResponseComplete).not.toHaveBeenCalled();
+		expect(deps.hotStateManager.updateHotState).not.toHaveBeenCalled();
+	});
+
+	it("ignores a late turnComplete for a turn that already failed", () => {
+		(deps.hotStateManager.getHotState as ReturnType<typeof vi.fn>).mockReturnValue({
+			turnState: "error",
+			lastTerminalTurnId: "turn-1",
+		});
+
+		service.handleStreamComplete(sessionId, "turn-1");
+
+		expect(deps.connectionManager.sendResponseComplete).not.toHaveBeenCalled();
+		expect(deps.hotStateManager.updateHotState).not.toHaveBeenCalled();
+	});
+
+	it("ignores a late turnComplete when both terminal updates have null turn ids", () => {
+		(deps.hotStateManager.getHotState as ReturnType<typeof vi.fn>).mockReturnValue({
+			turnState: "error",
+			lastTerminalTurnId: null,
 		});
 
 		service.handleStreamComplete(sessionId);
@@ -256,6 +282,8 @@ describe("SessionMessagingService.handleStreamError", () => {
 			status: "error",
 			turnState: "error",
 			connectionError: "stream broke",
+			activeTurnFailure: null,
+			lastTerminalTurnId: null,
 		});
 	});
 
@@ -284,6 +312,16 @@ describe("SessionMessagingService.handleStreamError", () => {
 
 describe("SessionMessagingService.handleTurnError", () => {
 	const sessionId = "session-1";
+	const turnErrorUpdate = {
+		type: "turnError" as const,
+		session_id: sessionId,
+		turn_id: "turn-1",
+		error: {
+			message: "You're out of extra usage",
+			kind: "recoverable" as const,
+			source: "unknown" as const,
+		},
+	};
 	let service: InstanceType<typeof SessionMessagingService>;
 	let deps: ReturnType<typeof createMockDeps>;
 
@@ -302,60 +340,162 @@ describe("SessionMessagingService.handleTurnError", () => {
 		);
 	});
 
-	it("adds an inline error entry for recoverable turn errors", () => {
-		service.handleTurnError(sessionId, {
-			message: "You're out of extra usage",
-			kind: "recoverable",
-			source: "unknown",
-		});
+	it("stores recoverable turn failures in hot state instead of appending transcript entries", () => {
+		service.handleTurnError(sessionId, turnErrorUpdate);
 
-		expect(deps.entryManager.addEntry).toHaveBeenCalledWith(
-			sessionId,
-			expect.objectContaining({
-				type: "error",
-				message: {
-					content: "You're out of extra usage",
-					kind: "recoverable",
-					source: "unknown",
-				},
-			})
-		);
+		expect(deps.entryManager.addEntry).not.toHaveBeenCalled();
+		expect(deps.hotStateManager.updateHotState).toHaveBeenCalledWith(sessionId, {
+			status: "ready",
+			turnState: "error",
+			connectionError: null,
+			activeTurnFailure: {
+				turnId: "turn-1",
+				message: "You're out of extra usage",
+				code: null,
+				kind: "recoverable",
+				source: "unknown",
+			},
+			lastTerminalTurnId: "turn-1",
+		});
 	});
 
-	it("stringifies numeric turn error codes for inline error entries", () => {
+	it("stringifies numeric turn error codes in canonical failed-turn state", () => {
 		service.handleTurnError(sessionId, {
-			message: "Rate limit reached",
-			kind: "recoverable",
-			source: "unknown",
-			code: 429,
-		});
-
-		expect(deps.entryManager.addEntry).toHaveBeenCalledWith(
-			sessionId,
-			expect.objectContaining({
-				type: "error",
-				message: expect.objectContaining({
-					content: "Rate limit reached",
-					code: "429",
-					kind: "recoverable",
-					source: "unknown",
-				}),
-			})
-		);
-	});
-
-	it("does not populate header-level connectionError for recoverable turn errors", () => {
-		service.handleTurnError(sessionId, {
-			message: "You're out of extra usage",
-			kind: "recoverable",
-			source: "unknown",
+			type: "turnError",
+			session_id: sessionId,
+			turn_id: "turn-1",
+			error: {
+				message: "Rate limit reached",
+				kind: "recoverable",
+				source: "unknown",
+				code: 429,
+			},
 		});
 
 		expect(deps.hotStateManager.updateHotState).toHaveBeenCalledWith(sessionId, {
 			status: "ready",
 			turnState: "error",
 			connectionError: null,
+			activeTurnFailure: {
+				turnId: "turn-1",
+				message: "Rate limit reached",
+				code: "429",
+				kind: "recoverable",
+				source: "unknown",
+			},
+			lastTerminalTurnId: "turn-1",
 		});
+	});
+
+	it("does not populate header-level connectionError for recoverable turn errors", () => {
+		service.handleTurnError(sessionId, turnErrorUpdate);
+
+		expect(deps.hotStateManager.updateHotState).toHaveBeenCalledWith(sessionId, {
+			status: "ready",
+			turnState: "error",
+			connectionError: null,
+			activeTurnFailure: {
+				turnId: "turn-1",
+				message: "You're out of extra usage",
+				code: null,
+				kind: "recoverable",
+				source: "unknown",
+			},
+			lastTerminalTurnId: "turn-1",
+		});
+	});
+
+	it("ignores duplicate terminal errors for the same turn", () => {
+		(
+			deps.hotStateManager.getHotState as ReturnType<typeof vi.fn>
+		).mockReturnValueOnce({
+			turnState: "error",
+			activeTurnFailure: {
+				turnId: "turn-1",
+				message: "You're out of extra usage",
+				code: null,
+				kind: "recoverable",
+				source: "unknown",
+			},
+			lastTerminalTurnId: "turn-1",
+		});
+
+		service.handleTurnError(sessionId, turnErrorUpdate);
+
+		expect(deps.connectionManager.sendTurnFailed).not.toHaveBeenCalled();
+		expect(deps.hotStateManager.updateHotState).not.toHaveBeenCalled();
+	});
+
+	it("ignores duplicate terminal errors when both turn ids are null", () => {
+		(
+			deps.hotStateManager.getHotState as ReturnType<typeof vi.fn>
+		).mockReturnValueOnce({
+			turnState: "error",
+			activeTurnFailure: {
+				turnId: null,
+				message: "You're out of extra usage",
+				code: null,
+				kind: "recoverable",
+				source: "unknown",
+			},
+			lastTerminalTurnId: null,
+		});
+
+		service.handleTurnError(sessionId, {
+			type: "turnError",
+			session_id: sessionId,
+			turn_id: null,
+			error: {
+				message: "You're out of extra usage",
+				kind: "recoverable",
+				source: "unknown",
+			},
+		});
+
+		expect(deps.connectionManager.sendTurnFailed).not.toHaveBeenCalled();
+		expect(deps.hotStateManager.updateHotState).not.toHaveBeenCalled();
+	});
+});
+
+describe("SessionMessagingService.ensureStreamingState", () => {
+	const sessionId = "session-1";
+	let service: InstanceType<typeof SessionMessagingService>;
+	let deps: ReturnType<typeof createMockDeps>;
+
+	beforeAll(async () => {
+		const module = await import("../session-messaging-service.js");
+		SessionMessagingService = module.SessionMessagingService;
+	});
+
+	beforeEach(() => {
+		deps = createMockDeps();
+		service = new SessionMessagingService(
+			deps.stateReader,
+			deps.hotStateManager,
+			deps.entryManager,
+			deps.connectionManager
+		);
+	});
+
+	it("keeps a failed turn terminal when late provider updates arrive", () => {
+		(deps.hotStateManager.getHotState as ReturnType<typeof vi.fn>).mockReturnValue({
+			turnState: "error",
+			activeTurnFailure: {
+				turnId: "turn-1",
+				message: "Usage limit reached",
+				code: "429",
+				kind: "recoverable",
+				source: "process",
+			},
+		});
+		(deps.connectionManager.getState as ReturnType<typeof vi.fn>).mockReturnValue({
+			connection: "streaming",
+		});
+
+		service.ensureStreamingState(sessionId);
+
+		expect(deps.connectionManager.sendResponseStarted).not.toHaveBeenCalled();
+		expect(deps.hotStateManager.updateHotState).not.toHaveBeenCalled();
 	});
 });
 

--- a/packages/desktop/src/lib/acp/store/services/interfaces/connection-manager.ts
+++ b/packages/desktop/src/lib/acp/store/services/interfaces/connection-manager.ts
@@ -11,6 +11,8 @@ import type { SessionMachineActor } from "../../session-connection-service.svelt
 /**
  * Interface for managing connection state machines.
  */
+import type { ActiveTurnFailure } from "../../../types/turn-error.js";
+
 export interface IConnectionManager {
 	// ============================================
 	// STATE MACHINE ACCESS
@@ -96,7 +98,7 @@ export interface IConnectionManager {
 	 */
 	sendTurnFailed(
 		sessionId: string,
-		failure: { kind: "recoverable" | "fatal"; message: string }
+		failure: ActiveTurnFailure
 	): void;
 
 	/**

--- a/packages/desktop/src/lib/acp/store/services/session-messaging-service.ts
+++ b/packages/desktop/src/lib/acp/store/services/session-messaging-service.ts
@@ -233,6 +233,9 @@ export class SessionMessagingService {
 			hotState?.turnState === "error" &&
 			matchesTurnId(hotState.lastTerminalTurnId, turnId ?? null)
 		) {
+			// Still finalize streaming entries — tool calls may have been streaming when
+			// the error occurred and need to stop shimmering.
+			this.entryManager.finalizeStreamingEntries(sessionId);
 			return;
 		}
 

--- a/packages/desktop/src/lib/acp/store/services/session-messaging-service.ts
+++ b/packages/desktop/src/lib/acp/store/services/session-messaging-service.ts
@@ -26,8 +26,8 @@ import { aggregateFileEdits } from "../../logic/aggregate-file-edits.js";
 import { ConnectionState } from "../../logic/session-machine.js";
 import type { AvailableCommand } from "../../types/available-command.js";
 import type { ToolCallUpdate } from "../../types/tool-call.js";
-import type { TurnErrorPayload } from "../../types/turn-error.js";
-import { normalizeTurnError } from "../../types/turn-error.js";
+import type { TurnCompleteUpdate, TurnErrorUpdate } from "../../types/turn-error.js";
+import { normalizeActiveTurnFailure } from "../../types/turn-error.js";
 import { createLogger } from "../../utils/logger.js";
 import { api } from "../api.js";
 import { checkpointStore } from "../checkpoint-store.svelte.js";
@@ -41,6 +41,14 @@ import type {
 } from "./interfaces/index.js";
 
 const logger = createLogger({ id: "session-messaging-service", name: "SessionMessagingService" });
+
+function matchesTurnId(previousTurnId: string | null | undefined, nextTurnId: string | null | undefined): boolean {
+	if (previousTurnId == null || nextTurnId == null) {
+		return previousTurnId == null && nextTurnId == null;
+	}
+
+	return previousTurnId === nextTurnId;
+}
 
 /**
  * Service for messaging and streaming operations.
@@ -137,6 +145,8 @@ export class SessionMessagingService {
 			status: "streaming",
 			turnState: "streaming",
 			connectionError: null, // Clear any previous turn error
+			activeTurnFailure: null,
+			lastTerminalTurnId: null,
 		});
 		logger.debug("Sending message (optimistic)", { sessionId });
 
@@ -162,13 +172,18 @@ export class SessionMessagingService {
 				// accept messages. Must pair machine event with hot-state update per the
 				// reactive anchor pattern to prevent stuck UI.
 				this.connectionManager.sendTurnFailed(sessionId, {
+					turnId: null,
 					kind: "fatal",
 					message: error.message,
+					code: null,
+					source: "unknown",
 				});
 				this.hotStateManager.updateHotState(sessionId, {
 					status: "error",
 					turnState: "error",
 					connectionError: error.message,
+					activeTurnFailure: null,
+					lastTerminalTurnId: null,
 				});
 				logger.error("Failed to send message, rolling back", {
 					sessionId,
@@ -208,9 +223,16 @@ export class SessionMessagingService {
 	/**
 	 * Handle stream complete from Tauri events.
 	 */
-	handleStreamComplete(sessionId: string): void {
+	handleStreamComplete(sessionId: string, turnId?: TurnCompleteUpdate["turn_id"]): void {
 		const hotState = this.hotStateManager.getHotState(sessionId);
 		if (hotState?.turnState === "completed") {
+			return;
+		}
+
+		if (
+			hotState?.turnState === "error" &&
+			matchesTurnId(hotState.lastTerminalTurnId, turnId ?? null)
+		) {
 			return;
 		}
 
@@ -224,6 +246,8 @@ export class SessionMessagingService {
 		this.hotStateManager.updateHotState(sessionId, {
 			status: "ready",
 			turnState: "completed",
+			activeTurnFailure: null,
+			lastTerminalTurnId: turnId ?? null,
 		});
 
 		// Mark any still-streaming tool call entries as not streaming
@@ -337,6 +361,8 @@ export class SessionMessagingService {
 			status: "error",
 			turnState: "error",
 			connectionError: error.message,
+			activeTurnFailure: null,
+			lastTerminalTurnId: null,
 		});
 		logger.error("Stream error", { sessionId, error });
 	}
@@ -345,50 +371,52 @@ export class SessionMessagingService {
 	 * Handle turn error from agent (e.g., usage limit reached).
 	 * Uses explicit turn failure semantics from the backend.
 	 */
-	handleTurnError(sessionId: string, error: TurnErrorPayload): void {
-		this.entryManager.clearStreamingAssistantEntry(sessionId);
-		const normalized = normalizeTurnError(error);
-		const errorEntry: SessionEntry = {
-			id: crypto.randomUUID(),
-			type: "error",
-			message: {
-				content: normalized.message,
-				code: normalized.code != null ? String(normalized.code) : undefined,
-				kind: normalized.kind,
-				source: normalized.source ?? undefined,
-			},
-			timestamp: new Date(),
-		};
-		this.entryManager.addEntry(sessionId, errorEntry);
+	handleTurnError(sessionId: string, update: TurnErrorUpdate): void {
+		const hotState = this.hotStateManager.getHotState(sessionId);
+		const normalized = normalizeActiveTurnFailure(update);
+		if (
+			hotState?.turnState === "error" &&
+			matchesTurnId(hotState.lastTerminalTurnId, normalized.turnId)
+		) {
+			logger.warn("Ignoring duplicate turn error for terminal turn", {
+				sessionId,
+				turnId: normalized.turnId,
+			});
+			return;
+		}
 
-		this.connectionManager.sendTurnFailed(sessionId, {
-			kind: normalized.kind,
-			message: normalized.message,
-		});
+		this.entryManager.clearStreamingAssistantEntry(sessionId);
+		this.connectionManager.sendTurnFailed(sessionId, normalized);
 
 		if (normalized.kind === "fatal") {
 			this.hotStateManager.updateHotState(sessionId, {
 				status: "error",
 				turnState: "error",
 				connectionError: null,
+				activeTurnFailure: normalized,
+				lastTerminalTurnId: normalized.turnId,
 			});
 			logger.error("Fatal turn error", {
 				sessionId,
 				error: normalized.message,
 				code: normalized.code ?? undefined,
-				source: normalized.source ?? undefined,
+				source: normalized.source,
+				turnId: normalized.turnId,
 			});
 		} else {
 			this.hotStateManager.updateHotState(sessionId, {
 				status: "ready",
 				turnState: "error",
 				connectionError: null,
+				activeTurnFailure: normalized,
+				lastTerminalTurnId: normalized.turnId,
 			});
 			logger.error("Recoverable turn error", {
 				sessionId,
 				error: normalized.message,
 				code: normalized.code ?? undefined,
-				source: normalized.source ?? undefined,
+				source: normalized.source,
+				turnId: normalized.turnId,
 			});
 		}
 	}
@@ -426,6 +454,10 @@ export class SessionMessagingService {
 	ensureStreamingState(sessionId: string): void {
 		const hotState = this.hotStateManager.getHotState(sessionId);
 		const machineState = this.connectionManager.getState(sessionId);
+
+		if (hotState.turnState === "error" && hotState.activeTurnFailure !== null) {
+			return;
+		}
 
 		// Transition connection state from awaitingResponse to streaming
 		// This hides the "Thinking_" indicator when response starts

--- a/packages/desktop/src/lib/acp/store/session-connection-service.svelte.ts
+++ b/packages/desktop/src/lib/acp/store/session-connection-service.svelte.ts
@@ -15,6 +15,7 @@
 
 import { SvelteMap, SvelteSet } from "svelte/reactivity";
 import { createActor } from "xstate";
+import type { ActiveTurnFailure } from "../types/turn-error.js";
 import {
 	ConnectionEvent,
 	ContentEvent,
@@ -211,14 +212,13 @@ export class SessionConnectionService implements IConnectionManager {
 	 */
 	sendTurnFailed(
 		sessionId: string,
-		failure: { kind: "recoverable" | "fatal"; message: string }
+		failure: ActiveTurnFailure
 	): void {
 		const machine = this.getMachine(sessionId);
 		if (machine) {
 			machine.send({
 				type: ConnectionEvent.TURN_FAILED,
-				kind: failure.kind,
-				message: failure.message,
+				failure,
 			});
 		}
 	}

--- a/packages/desktop/src/lib/acp/store/session-event-handler.ts
+++ b/packages/desktop/src/lib/acp/store/session-event-handler.ts
@@ -15,7 +15,7 @@ import type {
 import type { AppError } from "../errors/app-error.js";
 import type { AvailableCommand } from "../types/available-command.js";
 import type { ToolCallUpdate } from "../types/tool-call.js";
-import type { TurnErrorPayload } from "../types/turn-error.js";
+import type { TurnCompleteUpdate, TurnErrorUpdate } from "../types/turn-error.js";
 import type { SessionCold, SessionEntry, SessionHotState } from "./types.js";
 
 /**
@@ -92,13 +92,13 @@ export interface SessionEventHandler {
 	 * Handle stream completion for a session.
 	 * Called when the agent's turn is complete.
 	 */
-	handleStreamComplete(sessionId: string): void;
+	handleStreamComplete(sessionId: string, turnId?: TurnCompleteUpdate["turn_id"]): void;
 
 	/**
 	 * Handle a turn error for a session.
 	 * Called when the agent's turn fails with an error (e.g., usage limit).
 	 */
-	handleTurnError(sessionId: string, error: TurnErrorPayload): void;
+	handleTurnError(sessionId: string, update: TurnErrorUpdate): void;
 
 	/**
 	 * Clear in-progress assistant streaming aggregation state.

--- a/packages/desktop/src/lib/acp/store/session-event-service.svelte.ts
+++ b/packages/desktop/src/lib/acp/store/session-event-service.svelte.ts
@@ -509,10 +509,9 @@ export class SessionEventService {
 			if (
 				!hasActiveTurn &&
 				update.type === "toolCall" &&
-				isPendingToolCallStatus(update.tool_call.status) &&
 				hasToolCallEntry(handler, sessionId, update.tool_call.id)
 			) {
-				logger.debug("Dropping replayed pending tool call already present in session", {
+				logger.debug("Dropping replayed tool call already present in session", {
 					sessionId,
 					toolCallId: update.tool_call.id,
 				});

--- a/packages/desktop/src/lib/acp/store/session-event-service.svelte.ts
+++ b/packages/desktop/src/lib/acp/store/session-event-service.svelte.ts
@@ -83,25 +83,6 @@ function isPendingToolCallStatus(status: string | null | undefined): boolean {
 	return status === "pending" || status === "in_progress";
 }
 
-function isTerminalToolCallStatus(status: string | null | undefined): boolean {
-	return status === "completed" || status === "failed";
-}
-
-function isContentBearingToolCallUpdate(
-	update: ToolCallUpdateData
-): boolean {
-	return (
-		update.result !== null ||
-		update.result !== undefined ||
-		update.rawOutput !== null ||
-		update.rawOutput !== undefined ||
-		update.content !== null ||
-		update.content !== undefined ||
-		update.locations !== null ||
-		update.locations !== undefined
-	);
-}
-
 function hasToolCallEntry(
 	handler: SessionEventHandler,
 	sessionId: string,
@@ -525,47 +506,15 @@ export class SessionEventService {
 		// suppression armed so any later idle-time replay bursts are still blocked.
 		if (this.replaySuppressedSessionIds.has(sessionId)) {
 			const hasActiveTurn = hotState?.turnState !== undefined && hotState.turnState !== "idle";
-			const hasExistingToolEntryForReplay =
-				update.type === "toolCall"
-					? hasToolCallEntry(handler, sessionId, update.tool_call.id)
-					: update.type === "toolCallUpdate"
-						? hasToolCallEntry(handler, sessionId, update.update.toolCallId)
-						: false;
 			if (
 				!hasActiveTurn &&
 				update.type === "toolCall" &&
 				isPendingToolCallStatus(update.tool_call.status) &&
-				hasExistingToolEntryForReplay
+				hasToolCallEntry(handler, sessionId, update.tool_call.id)
 			) {
 				logger.debug("Dropping replayed pending tool call already present in session", {
 					sessionId,
 					toolCallId: update.tool_call.id,
-				});
-				return;
-			}
-			if (
-				!hasActiveTurn &&
-				update.type === "toolCall" &&
-				!hasExistingToolEntryForReplay &&
-				isTerminalToolCallStatus(update.tool_call.status)
-			) {
-				logger.debug("Dropping replayed terminal tool call missing a canonical entry", {
-					sessionId,
-					toolCallId: update.tool_call.id,
-				});
-				return;
-			}
-			if (
-				!hasActiveTurn &&
-				update.type === "toolCallUpdate" &&
-				!hasExistingToolEntryForReplay &&
-				(isTerminalToolCallStatus(update.update.status) ||
-					isContentBearingToolCallUpdate(update.update))
-			) {
-				logger.debug("Dropping replayed orphan tool call update while session is idle", {
-					sessionId,
-					toolCallId: update.update.toolCallId,
-					status: update.update.status ?? "unknown",
 				});
 				return;
 			}
@@ -762,8 +711,9 @@ export class SessionEventService {
 				logger.info("Turn complete - calling handleStreamComplete", {
 					sessionId,
 					updateSessionId: update.session_id,
+					turnId: update.turn_id,
 				});
-				handler.handleStreamComplete(sessionId);
+				handler.handleStreamComplete(sessionId, update.turn_id);
 				this.callbacks.onTurnComplete?.(sessionId);
 				break;
 
@@ -771,8 +721,9 @@ export class SessionEventService {
 				logger.error("Turn error received", {
 					sessionId,
 					error: update.error,
+					turnId: update.turn_id,
 				});
-				handler.handleTurnError(sessionId, update.error);
+				handler.handleTurnError(sessionId, update);
 				break;
 
 			case "plan":
@@ -780,7 +731,7 @@ export class SessionEventService {
 				if (
 					this.shouldTreatPlanAsTurnComplete(update.plan, handler.getHotState(sessionId).turnState)
 				) {
-					handler.handleStreamComplete(sessionId);
+					handler.handleStreamComplete(sessionId, null);
 				}
 				break;
 

--- a/packages/desktop/src/lib/acp/store/session-store.svelte.ts
+++ b/packages/desktop/src/lib/acp/store/session-store.svelte.ts
@@ -11,6 +11,7 @@
 import { errAsync, okAsync, type ResultAsync } from "neverthrow";
 import { getContext, setContext } from "svelte";
 import { SvelteSet } from "svelte/reactivity";
+import type { SessionProjectionSnapshot } from "../../services/acp-types.js";
 import type { HistoryEntry } from "../../services/claude-history-types.js";
 import type {
 	ContentBlock,
@@ -32,7 +33,7 @@ import type { PermissionRequest } from "../types/permission";
 import type { QuestionRequest } from "../types/question";
 import type { SessionUpdate } from "../types/session-update";
 import type { ToolCallUpdate } from "../types/tool-call";
-import type { TurnErrorPayload } from "../types/turn-error.js";
+import type { ActiveTurnFailure, TurnCompleteUpdate, TurnErrorUpdate } from "../types/turn-error.js";
 import type { ISessionStateReader, ISessionStateWriter } from "./services/interfaces/index.js";
 import {
 	SessionConnectionService,
@@ -71,6 +72,68 @@ import { getTitleUpdateFromUserMessage } from "./session-title-policy.js";
 const logger = createLogger({ id: "session-store", name: "SessionStore" });
 
 const SESSION_STORE_KEY = Symbol("session-store");
+
+type ProjectionTurnFailure = {
+	readonly turn_id?: string | null;
+	readonly message: string;
+	readonly code?: string | null;
+	readonly kind: "recoverable" | "fatal";
+	readonly source?: "json_rpc" | "transport" | "process" | "unknown" | null;
+};
+
+type ProjectionSessionState = NonNullable<SessionProjectionSnapshot["session"]> & {
+	readonly active_turn_failure?: ProjectionTurnFailure | null;
+	readonly last_terminal_turn_id?: string | null;
+};
+
+function resolveProjectionSessionId(projection: SessionProjectionSnapshot): string | null {
+	if (projection.session?.session_id !== undefined) {
+		return projection.session.session_id;
+	}
+
+	if (projection.operations[0]?.session_id !== undefined) {
+		return projection.operations[0].session_id;
+	}
+
+	if (projection.interactions[0]?.session_id !== undefined) {
+		return projection.interactions[0].session_id;
+	}
+
+	return null;
+}
+
+function mapProjectionTurnState(turnState: ProjectionSessionState["turn_state"]):
+	| "idle"
+	| "streaming"
+	| "completed"
+	| "error" {
+	switch (turnState) {
+		case "Idle":
+			return "idle";
+		case "Running":
+			return "streaming";
+		case "Completed":
+			return "completed";
+		case "Failed":
+			return "error";
+	}
+}
+
+function mapProjectionTurnFailure(
+	failure: ProjectionTurnFailure | null | undefined
+): ActiveTurnFailure | null {
+	if (failure == null) {
+		return null;
+	}
+
+	return {
+		turnId: failure.turn_id ?? null,
+		message: failure.message,
+		code: failure.code ?? null,
+		kind: failure.kind,
+		source: failure.source ?? "unknown",
+	};
+}
 const PR_STATE_CACHE_TTL_MS = 60_000;
 
 interface CachedPrDetails {
@@ -387,6 +450,39 @@ export class SessionStore implements SessionEventHandler, ISessionStateReader, I
 		const entries = this.entryStore.getEntries(sessionId);
 		const lastEntry = entries.length > 0 ? entries[entries.length - 1] : null;
 		return deriveSessionRuntimeState(state, lastEntry);
+	}
+
+	applySessionProjection(projection: SessionProjectionSnapshot): void {
+		const sessionId = resolveProjectionSessionId(projection);
+		if (sessionId === null) {
+			return;
+		}
+
+		const projectionSession = projection.session as ProjectionSessionState | null;
+		if (projectionSession === null) {
+			this.hotStateStore.updateHotState(sessionId, {
+				activeTurnFailure: null,
+				lastTerminalTurnId: null,
+			});
+			return;
+		}
+
+		const activeTurnFailure = mapProjectionTurnFailure(projectionSession.active_turn_failure);
+		const updates: Partial<import("./types.js").SessionHotState> = {
+			turnState: mapProjectionTurnState(projectionSession.turn_state),
+			activeTurnFailure,
+			lastTerminalTurnId: projectionSession.last_terminal_turn_id ?? null,
+			connectionError: activeTurnFailure !== null ? null : undefined,
+		};
+
+		this.hotStateStore.updateHotState(sessionId, updates);
+	}
+
+	clearSessionProjection(sessionId: string): void {
+		this.hotStateStore.updateHotState(sessionId, {
+			activeTurnFailure: null,
+			lastTerminalTurnId: null,
+		});
 	}
 
 	// ============================================
@@ -752,8 +848,8 @@ export class SessionStore implements SessionEventHandler, ISessionStateReader, I
 	/**
 	 * Handle stream complete from Tauri events.
 	 */
-	handleStreamComplete(sessionId: string): void {
-		this.messagingSvc.handleStreamComplete(sessionId);
+	handleStreamComplete(sessionId: string, turnId?: TurnCompleteUpdate["turn_id"]): void {
+		this.messagingSvc.handleStreamComplete(sessionId, turnId);
 	}
 
 	/**
@@ -766,8 +862,8 @@ export class SessionStore implements SessionEventHandler, ISessionStateReader, I
 	/**
 	 * Handle turn error from agent (e.g., usage limit reached).
 	 */
-	handleTurnError(sessionId: string, error: TurnErrorPayload): void {
-		this.messagingSvc.handleTurnError(sessionId, error);
+	handleTurnError(sessionId: string, update: TurnErrorUpdate): void {
+		this.messagingSvc.handleTurnError(sessionId, update);
 		this.callbacks.onTurnError?.(sessionId);
 	}
 

--- a/packages/desktop/src/lib/acp/store/session-store.svelte.ts
+++ b/packages/desktop/src/lib/acp/store/session-store.svelte.ts
@@ -479,6 +479,9 @@ export class SessionStore implements SessionEventHandler, ISessionStateReader, I
 	}
 
 	clearSessionProjection(sessionId: string): void {
+		if (!this.hotStateStore.hasHotState(sessionId)) {
+			return;
+		}
 		this.hotStateStore.updateHotState(sessionId, {
 			activeTurnFailure: null,
 			lastTerminalTurnId: null,

--- a/packages/desktop/src/lib/acp/store/session-work-projection.ts
+++ b/packages/desktop/src/lib/acp/store/session-work-projection.ts
@@ -1,5 +1,6 @@
 import type { SessionStatus } from "../application/dto/session-status.js";
 import type { SessionState } from "./session-state.js";
+import type { ActiveTurnFailure } from "../types/turn-error.js";
 
 export type SessionWorkBucket =
 	| "answer_needed"
@@ -17,6 +18,7 @@ export interface SessionWorkProjectionInput {
 	readonly state: SessionState;
 	readonly currentModeId: string | null;
 	readonly connectionError: string | null;
+	readonly activeTurnFailure?: ActiveTurnFailure | null;
 }
 
 export interface SessionWorkProjection {
@@ -84,7 +86,10 @@ export function deriveSessionWorkProjection(
 ): SessionWorkProjection {
 	const effectiveModeId = resolveEffectiveModeId(input);
 	const hasPendingInput = input.state.pendingInput.kind !== "none";
-	const hasError = input.state.connection === "error" || input.connectionError != null;
+	const hasError =
+		input.state.connection === "error" ||
+		input.connectionError != null ||
+		input.activeTurnFailure != null;
 	const needsReview = input.state.activity.kind === "idle" && input.state.attention.hasUnseenCompletion;
 
 	return {

--- a/packages/desktop/src/lib/acp/store/thread-board/__tests__/build-thread-board.test.ts
+++ b/packages/desktop/src/lib/acp/store/thread-board/__tests__/build-thread-board.test.ts
@@ -91,6 +91,8 @@ function makeSource(overrides: Partial<ThreadBoardSource> = {}): ThreadBoardSour
 		deletions: overrides.deletions !== undefined ? overrides.deletions : 0,
 		todoProgress: overrides.todoProgress !== undefined ? overrides.todoProgress : null,
 		connectionError: overrides.connectionError !== undefined ? overrides.connectionError : null,
+		activeTurnFailure:
+			overrides.activeTurnFailure !== undefined ? overrides.activeTurnFailure : null,
 		state: overrides.state !== undefined ? overrides.state : makeState(),
 		sequenceId: overrides.sequenceId !== undefined ? overrides.sequenceId : null,
 	};
@@ -141,6 +143,21 @@ describe("classifyThreadBoardStatus", () => {
 		const source = makeSource({
 			connectionError: "Session failed",
 			state: makeState({ connection: "error", hasUnseenCompletion: true }),
+		});
+
+		expect(classifyThreadBoardStatus(source)).toBe("error");
+	});
+
+	it("maps active turn failure threads to error without connectionError", () => {
+		const source = makeSource({
+			activeTurnFailure: {
+				turnId: "turn-1",
+				message: "Usage limit reached",
+				code: "429",
+				kind: "recoverable",
+				source: "process",
+			},
+			state: makeState({ hasUnseenCompletion: true }),
 		});
 
 		expect(classifyThreadBoardStatus(source)).toBe("error");

--- a/packages/desktop/src/lib/acp/store/thread-board/build-thread-board.ts
+++ b/packages/desktop/src/lib/acp/store/thread-board/build-thread-board.ts
@@ -6,6 +6,7 @@ import { THREAD_BOARD_STATUS_ORDER, type ThreadBoardStatus } from "./thread-boar
 export interface ThreadBoardStatusInput {
 	readonly currentModeId: string | null;
 	readonly connectionError: string | null;
+	readonly activeTurnFailure: ThreadBoardSource["activeTurnFailure"];
 	readonly state: ThreadBoardSource["state"];
 }
 
@@ -15,6 +16,7 @@ export function classifyThreadBoardState(input: ThreadBoardStatusInput): ThreadB
 			state: input.state,
 			currentModeId: input.currentModeId,
 			connectionError: input.connectionError,
+			activeTurnFailure: input.activeTurnFailure ?? null,
 		})
 	);
 }
@@ -23,6 +25,7 @@ export function classifyThreadBoardStatus(source: ThreadBoardSource): ThreadBoar
 	return classifyThreadBoardState({
 		currentModeId: source.currentModeId,
 		connectionError: source.connectionError,
+		activeTurnFailure: source.activeTurnFailure ?? null,
 		state: source.state,
 	});
 }
@@ -48,6 +51,7 @@ function toThreadBoardItem(source: ThreadBoardSource, status: ThreadBoardStatus)
 		deletions: source.deletions,
 		todoProgress: source.todoProgress,
 		connectionError: source.connectionError,
+		activeTurnFailure: source.activeTurnFailure ?? null,
 		state: source.state,
 		sequenceId: source.sequenceId ?? null,
 		worktreePath: source.worktreePath ?? null,

--- a/packages/desktop/src/lib/acp/store/thread-board/thread-board-item.ts
+++ b/packages/desktop/src/lib/acp/store/thread-board/thread-board-item.ts
@@ -1,6 +1,7 @@
 import type { TodoProgressInfo } from "$lib/acp/components/session-list/session-list-types.js";
 import type { ToolCall } from "$lib/acp/types/tool-call.js";
 import type { ToolKind } from "$lib/acp/types/tool-kind.js";
+import type { ActiveTurnFailure } from "$lib/acp/types/turn-error.js";
 
 import type { SessionState } from "../session-state.js";
 
@@ -26,6 +27,7 @@ export interface ThreadBoardSource {
 	readonly deletions: number;
 	readonly todoProgress: TodoProgressInfo | null;
 	readonly connectionError: string | null;
+	readonly activeTurnFailure?: ActiveTurnFailure | null;
 	readonly state: SessionState;
 	readonly sequenceId: number | null;
 	readonly worktreePath?: string | null;
@@ -52,6 +54,7 @@ export interface ThreadBoardItem {
 	readonly deletions: number;
 	readonly todoProgress: TodoProgressInfo | null;
 	readonly connectionError: string | null;
+	readonly activeTurnFailure?: ActiveTurnFailure | null;
 	readonly state: SessionState;
 	readonly sequenceId: number | null;
 	readonly worktreePath?: string | null;

--- a/packages/desktop/src/lib/acp/store/types.ts
+++ b/packages/desktop/src/lib/acp/store/types.ts
@@ -37,6 +37,7 @@ import type { ConfigOptionData } from "../../services/converted-session-types.js
 import type { Mode, Model, SessionStatus } from "../application/dto/session";
 import type { ComposerRestoreSnapshot } from "../components/agent-input/logic/first-send-recovery.js";
 import type { ModifiedFilesState } from "../components/modified-files/types/modified-files-state";
+import type { ActiveTurnFailure } from "../types/turn-error.js";
 import type { PreparedWorktreeLaunch } from "../types/worktree-info.js";
 import type { AvailableCommand } from "../types/available-command";
 import type { ModifiedFileEntry } from "../types/modified-file-entry.js";
@@ -102,6 +103,8 @@ export interface SessionHotState {
 	readonly turnState: TurnState;
 	readonly acpSessionId: string | null;
 	readonly connectionError: string | null;
+	readonly activeTurnFailure?: ActiveTurnFailure | null;
+	readonly lastTerminalTurnId?: string | null;
 	readonly autonomousEnabled: boolean;
 	readonly autonomousTransition: "idle" | "enabling" | "disabling";
 	readonly currentModel: Model | null;
@@ -125,6 +128,8 @@ export const DEFAULT_HOT_STATE: SessionHotState = {
 	turnState: "idle",
 	acpSessionId: null,
 	connectionError: null,
+	activeTurnFailure: null,
+	lastTerminalTurnId: null,
 	autonomousEnabled: false,
 	autonomousTransition: "idle",
 	currentModel: null,
@@ -500,6 +505,8 @@ export interface PersistedWorkspaceState {
 	readonly fullscreenPanelIndex?: number | null;
 	/** SQL Studio state (added in version 4) */
 	readonly sqlStudio?: PersistedSqlStudioState;
+	/** Full-screen review overlay state (added in version 5) */
+	readonly reviewFullscreen?: PersistedReviewFullscreenState;
 	/** Open terminal panels persisted across app restarts (added in version 7, legacy flat shape) */
 	readonly terminalPanels?: ReadonlyArray<PersistedTerminalPanelState>;
 	/** Explicit top-level terminal groups persisted across app restarts (added in version 10). */
@@ -534,6 +541,15 @@ export interface PersistedSqlStudioState {
 	readonly selectedConnectionId: string | null;
 	readonly selectedSchemaName: string | null;
 	readonly selectedTableName: string | null;
+}
+
+/**
+ * Persisted full-screen review overlay state.
+ */
+export interface PersistedReviewFullscreenState {
+	readonly open: boolean;
+	readonly sessionId: string | null;
+	readonly fileIndex: number;
 }
 
 /**

--- a/packages/desktop/src/lib/acp/store/urgency-tabs-store.svelte.ts
+++ b/packages/desktop/src/lib/acp/store/urgency-tabs-store.svelte.ts
@@ -195,7 +195,12 @@ export class UrgencyTabsStore {
 		const sessionMetadata = sessionId ? this.sessionStore.getSessionMetadata(sessionId) : null;
 		const hotState = sessionId
 			? this.sessionStore.getHotState(sessionId)
-			: { status: "idle" as const, statusChangedAt: Date.now(), connectionError: null };
+			: {
+					status: "idle" as const,
+					statusChangedAt: Date.now(),
+					connectionError: null,
+					activeTurnFailure: null,
+				};
 
 		// Get pending question for this session
 		const interactionSnapshot =
@@ -221,6 +226,7 @@ export class UrgencyTabsStore {
 			pendingQuestionText: pendingQuestion?.questions[0]?.question ?? null,
 			statusChangedAt: hotState.statusChangedAt,
 			connectionError: hotState.connectionError,
+			activeTurnFailure: hotState.activeTurnFailure ?? null,
 		});
 
 		return {

--- a/packages/desktop/src/lib/acp/store/urgency.ts
+++ b/packages/desktop/src/lib/acp/store/urgency.ts
@@ -8,6 +8,7 @@
  */
 
 import type { SessionStatus } from "../application/dto/session.js";
+import type { ActiveTurnFailure } from "../types/turn-error.js";
 
 /**
  * Urgency level for tab ordering.
@@ -43,6 +44,8 @@ export interface UrgencyInput {
 	readonly statusChangedAt: number;
 	/** Connection error message (if any) */
 	readonly connectionError: string | null;
+	/** Canonical turn failure when the latest turn failed without a connection-level error. */
+	readonly activeTurnFailure?: ActiveTurnFailure | null;
 }
 
 /**
@@ -54,8 +57,14 @@ export interface UrgencyInput {
  * - LOW: Streaming/connecting/loading (in progress)
  */
 export function deriveUrgency(input: UrgencyInput): UrgencyInfo {
-	const { status, hasPendingQuestion, pendingQuestionText, statusChangedAt, connectionError } =
-		input;
+	const {
+		status,
+		hasPendingQuestion,
+		pendingQuestionText,
+		statusChangedAt,
+		connectionError,
+		activeTurnFailure,
+	} = input;
 
 	// HIGH: Question pending or error state
 	if (hasPendingQuestion) {
@@ -72,7 +81,7 @@ export function deriveUrgency(input: UrgencyInput): UrgencyInfo {
 			level: "high",
 			reason: "Error occurred",
 			timestamp: statusChangedAt,
-			detail: connectionError,
+			detail: connectionError ?? activeTurnFailure?.message ?? null,
 		};
 	}
 

--- a/packages/desktop/src/lib/acp/store/workspace-store.svelte.ts
+++ b/packages/desktop/src/lib/acp/store/workspace-store.svelte.ts
@@ -29,6 +29,7 @@ import {
 	type PersistedBrowserWorkspacePanelState,
 	type PersistedFilePanelState,
 	type PersistedFileWorkspacePanelState,
+	type PersistedReviewFullscreenState,
 	type PersistedReviewWorkspacePanelState,
 	type PersistedSqlStudioState,
 	type PersistedTerminalPanelGroupState,
@@ -436,6 +437,10 @@ export interface WorkspaceStateProviders {
 	getSqlStudioState?: () => PersistedSqlStudioState;
 	/** Set SQL Studio state on restore */
 	setSqlStudioState?: (state: PersistedSqlStudioState) => void;
+	/** Get full-screen review overlay state */
+	getReviewFullscreenState?: () => PersistedReviewFullscreenState;
+	/** Set full-screen review overlay state on restore */
+	setReviewFullscreenState?: (state: PersistedReviewFullscreenState) => void;
 	/** Get collapsed project paths */
 	getCollapsedProjectPaths?: () => string[];
 	/** Set collapsed project paths on restore */
@@ -530,6 +535,8 @@ export class WorkspaceStore {
 					: null,
 				// SQL Studio state
 				sqlStudio: this.providers.getSqlStudioState?.(),
+				// Full-screen review state
+				reviewFullscreen: this.providers.getReviewFullscreenState?.(),
 				// Terminal + browser panels (version 7+)
 				terminalPanels: serializeTerminalPanels(this.panelStore.terminalPanels),
 				terminalPanelGroups: serializeTerminalPanelGroups(this.panelStore.terminalPanelGroups),
@@ -577,6 +584,9 @@ export class WorkspaceStore {
 		}
 		if (state.sqlStudio) {
 			this.providers.setSqlStudioState?.(state.sqlStudio);
+		}
+		if (state.reviewFullscreen) {
+			this.providers.setReviewFullscreenState?.(state.reviewFullscreen);
 		}
 		if (state.collapsedProjectPaths !== undefined) {
 			this.providers.setCollapsedProjectPaths?.(Array.from(state.collapsedProjectPaths));

--- a/packages/desktop/src/lib/acp/types/turn-error.ts
+++ b/packages/desktop/src/lib/acp/types/turn-error.ts
@@ -1,11 +1,21 @@
-import type { TurnErrorInfo } from "../../services/converted-session-types.js";
+import type {
+	TurnErrorInfo,
+	TurnErrorSource,
+} from "../../services/converted-session-types.js";
 import type { SessionUpdate } from "./session-update.js";
 
 export type TurnFailureKind = TurnErrorInfo["kind"];
+export type TurnErrorUpdate = Extract<SessionUpdate, { type: "turnError" }>;
+export type TurnCompleteUpdate = Extract<SessionUpdate, { type: "turnComplete" }>;
+export type TurnErrorPayload = TurnErrorUpdate["error"] | TurnErrorInfo;
 
-export type TurnErrorPayload =
-	| Extract<SessionUpdate, { type: "turnError" }>["error"]
-	| TurnErrorInfo;
+export interface ActiveTurnFailure {
+	readonly turnId: string | null;
+	readonly message: string;
+	readonly code: string | null;
+	readonly kind: TurnFailureKind;
+	readonly source: TurnErrorSource;
+}
 
 export function normalizeTurnError(error: TurnErrorPayload): TurnErrorInfo {
 	if (typeof error === "string") {
@@ -17,4 +27,16 @@ export function normalizeTurnError(error: TurnErrorPayload): TurnErrorInfo {
 	}
 
 	return error;
+}
+
+export function normalizeActiveTurnFailure(update: TurnErrorUpdate): ActiveTurnFailure {
+	const error = normalizeTurnError(update.error);
+
+	return {
+		turnId: update.turn_id ?? null,
+		message: error.message,
+		code: error.code != null ? String(error.code) : null,
+		kind: error.kind,
+		source: error.source ?? "unknown",
+	};
 }

--- a/packages/desktop/src/lib/components/main-app-view.svelte
+++ b/packages/desktop/src/lib/components/main-app-view.svelte
@@ -32,6 +32,7 @@ import {
 	createPlanStore,
 	createQuestionStore,
 	createQueueStore,
+	createReviewPreferenceStore,
 	createSessionStore,
 	LiveInteractionProjectionSync,
 	SessionProjectionHydrator,
@@ -107,6 +108,7 @@ import {
 	installDownloadedUpdate,
 	predownloadUpdate,
 } from "./main-app-view/logic/updater-workflow.js";
+import { ReviewFullscreenPage } from "./review-fullscreen/index.js";
 import { SettingsPage } from "./settings-page/index.js";
 import SqlStudioPage from "./sql-studio/sql-studio-page.svelte";
 import { TopBar } from "./top-bar/index.js";
@@ -146,7 +148,16 @@ const agentStore = createAgentStore();
 const agentPreferencesStore = createAgentPreferencesStore();
 const sessionStore = createSessionStore();
 const interactionStore = createInteractionStore();
-const sessionProjectionHydrator = new SessionProjectionHydrator(interactionStore);
+const sessionProjectionHydrator = new SessionProjectionHydrator({
+	replaceSessionProjection(projection) {
+		interactionStore.replaceSessionProjection(projection);
+		sessionStore.applySessionProjection(projection);
+	},
+	clearSession(sessionId) {
+		interactionStore.clearSession(sessionId);
+		sessionStore.clearSessionProjection(sessionId);
+	},
+});
 const sessionDomainEventSubscriber = new SessionDomainEventSubscriber();
 const liveInteractionProjectionSync = new LiveInteractionProjectionSync(
 	sessionDomainEventSubscriber,
@@ -170,6 +181,8 @@ sessionStore.onSessionRemoved((id) => {
 const unseenStore = createUnseenStore();
 // ConnectionStore is accessed via getConnectionStore() context, no direct reference needed
 createConnectionStore();
+// Review preference (panel vs fullscreen)
+const reviewPreferenceStore = createReviewPreferenceStore();
 // Plan preference (inline vs sidebar)
 const planPreferenceStore = createPlanPreferenceStore();
 // Chat preferences (thinking block collapsed by default, etc.)
@@ -937,7 +950,9 @@ onMount(async () => {
 	// Initialize the app state (handles all initialization logic including background scan)
 	const initResult = await viewState.initialize();
 
+	// Initialize review preference (load persisted setting)
 	await chatPreferencesStore.initialize();
+	reviewPreferenceStore.initialize();
 	planPreferenceStore.initialize();
 
 	// Initialize notification popup stores
@@ -980,6 +995,7 @@ $effect(() => {
 		"modalOpen",
 		viewState.settingsModalOpen ||
 			viewState.sqlStudioModalOpen ||
+			viewState.reviewFullscreenOpen ||
 			viewState.fileExplorerVisible
 	);
 });
@@ -1076,7 +1092,10 @@ const showSidebar = $derived(
 
 /** Tab bar above main/panel column (only shown in session fullscreen when there is something to switch) */
 const showTabBarStrip = $derived(
-	viewState.isFullscreen && tabBarStore.tabs.length > 1 && viewState.topBarVisible
+	!viewState.reviewFullscreenOpen &&
+		viewState.isFullscreen &&
+		tabBarStore.tabs.length > 1 &&
+		viewState.topBarVisible
 );
 
 // Cleanup on destroy
@@ -1143,71 +1162,73 @@ onDestroy(() => {
 				{/snippet}
 			</TopBar>
 		</div>
-		<div class="flex-1 flex min-h-0 gap-0.5 overflow-hidden transition-[padding] duration-200 ease-out">
-			{#if showSidebar}
-				<div class="shrink-0 flex flex-col h-full min-h-0 overflow-hidden transition-[width,opacity] duration-200 ease-out {viewState.sidebarOpen ? 'opacity-100' : 'w-0 opacity-0 pointer-events-none'}">
-					<svelte:boundary onerror={(e) => console.error('[boundary:sidebar]', e)}>
-						<AppSidebar {projectManager} state={viewState} />
+		{#if !viewState.reviewFullscreenOpen}
+			<div class="flex-1 flex min-h-0 gap-0.5 overflow-hidden transition-[padding] duration-200 ease-out">
+				{#if showSidebar}
+					<div class="shrink-0 flex flex-col h-full min-h-0 overflow-hidden transition-[width,opacity] duration-200 ease-out {viewState.sidebarOpen ? 'opacity-100' : 'w-0 opacity-0 pointer-events-none'}">
+						<svelte:boundary onerror={(e) => console.error('[boundary:sidebar]', e)}>
+							<AppSidebar {projectManager} state={viewState} />
+							{#snippet failed(error, reset)}
+								<div class="flex flex-1 items-center justify-center p-4">
+									<div class="flex flex-col items-center gap-2 text-muted-foreground text-xs">
+										<span>{m.error_boundary_sidebar_failed()}</span>
+										<button class="underline hover:text-foreground" onclick={reset}>{m.error_boundary_retry()}</button>
+									</div>
+								</div>
+							{/snippet}
+						</svelte:boundary>
+					</div>
+				{/if}
+				<main
+					class="flex-1 flex min-h-0 flex-col gap-0.5 overflow-hidden transition-[background-color] duration-200 ease-out {showPanelsContainer
+						? ''
+						: 'justify-center items-center overflow-x-auto'}"
+				>
+					<!-- Tab bar (project cards + tabs): only above panel column, aligned with main -->
+					{#if showTabBarStrip}
+						<div class="shrink-0 overflow-hidden">
+							<TabBar
+								groupedTabs={tabBarStore.groupedTabs}
+								onSelectTab={(panelId) => {
+									panelStore.focusAndSwitchToPanel(panelId);
+									acknowledgeExplicitPanelReveal(unseenStore, panelStore.getPanel(panelId));
+								}}
+								onCloseTab={(panelId) => viewState.handleClosePanel(panelId)}
+							/>
+						</div>
+					{/if}
+					<svelte:boundary onerror={(e) => console.error('[boundary:main-content]', e)}>
+						{#if showPanelsContainer}
+							<div class="flex min-h-0 flex-1 flex-col overflow-hidden">
+								<PanelsContainer
+									{projectManager}
+									state={viewState}
+									onFocusPanel={(panelId) => {
+										viewState.handleFocusPanel(panelId);
+										acknowledgeExplicitPanelReveal(unseenStore, panelStore.getPanel(panelId));
+									}}
+									onToggleFullscreenPanel={(panelId) => {
+										performExplicitPanelReveal(unseenStore, panelStore.getPanel(panelId), () => {
+											viewState.handleToggleFullscreen(panelId);
+										});
+									}}
+								/>
+							</div>
+						{:else if viewState.initializationComplete}
+							<EmptyStates {projectManager} onSessionCreated={handleSessionCreated} />
+						{/if}
 						{#snippet failed(error, reset)}
 							<div class="flex flex-1 items-center justify-center p-4">
-								<div class="flex flex-col items-center gap-2 text-muted-foreground text-xs">
-									<span>{m.error_boundary_sidebar_failed()}</span>
-									<button class="underline hover:text-foreground" onclick={reset}>{m.error_boundary_retry()}</button>
+								<div class="flex flex-col items-center gap-2 text-muted-foreground text-sm">
+									<span>{m.error_boundary_panel_failed()}</span>
+									<button class="text-xs underline hover:text-foreground" onclick={reset}>{m.error_boundary_retry()}</button>
 								</div>
 							</div>
 						{/snippet}
 					</svelte:boundary>
-				</div>
-			{/if}
-			<main
-				class="flex-1 flex min-h-0 flex-col gap-0.5 overflow-hidden transition-[background-color] duration-200 ease-out {showPanelsContainer
-					? ''
-					: 'justify-center items-center overflow-x-auto'}"
-			>
-				<!-- Tab bar (project cards + tabs): only above panel column, aligned with main -->
-				{#if showTabBarStrip}
-					<div class="shrink-0 overflow-hidden">
-						<TabBar
-							groupedTabs={tabBarStore.groupedTabs}
-							onSelectTab={(panelId) => {
-								panelStore.focusAndSwitchToPanel(panelId);
-								acknowledgeExplicitPanelReveal(unseenStore, panelStore.getPanel(panelId));
-							}}
-							onCloseTab={(panelId) => viewState.handleClosePanel(panelId)}
-						/>
-					</div>
-				{/if}
-				<svelte:boundary onerror={(e) => console.error('[boundary:main-content]', e)}>
-					{#if showPanelsContainer}
-						<div class="flex min-h-0 flex-1 flex-col overflow-hidden">
-							<PanelsContainer
-								{projectManager}
-								state={viewState}
-								onFocusPanel={(panelId) => {
-									viewState.handleFocusPanel(panelId);
-									acknowledgeExplicitPanelReveal(unseenStore, panelStore.getPanel(panelId));
-								}}
-								onToggleFullscreenPanel={(panelId) => {
-									performExplicitPanelReveal(unseenStore, panelStore.getPanel(panelId), () => {
-										viewState.handleToggleFullscreen(panelId);
-									});
-								}}
-							/>
-						</div>
-					{:else if viewState.initializationComplete}
-						<EmptyStates {projectManager} onSessionCreated={handleSessionCreated} />
-					{/if}
-					{#snippet failed(error, reset)}
-						<div class="flex flex-1 items-center justify-center p-4">
-							<div class="flex flex-col items-center gap-2 text-muted-foreground text-sm">
-								<span>{m.error_boundary_panel_failed()}</span>
-								<button class="text-xs underline hover:text-foreground" onclick={reset}>{m.error_boundary_retry()}</button>
-							</div>
-						</div>
-					{/snippet}
-				</svelte:boundary>
-			</main>
-		</div>
+				</main>
+			</div>
+		{/if}
 	</div>
 	<AppOverlays state={viewState} {commandPalette} />
 	<SourceControlDialog {projectManager} />
@@ -1262,6 +1283,34 @@ onDestroy(() => {
 				<SqlStudioPage onClose={() => viewState.closeSqlStudio()} />
 			</div>
 		</div>
+	{/if}
+
+	<!-- Full-screen Review Overlay (kept alive when hidden to preserve hunk decisions) -->
+	{#if viewState.reviewFullscreenSessionId}
+		{#key viewState.reviewFullscreenSessionId}
+			<div
+				class="fixed inset-0 z-[var(--app-modal-z)] bg-background"
+				role="dialog"
+				aria-modal={viewState.reviewFullscreenOpen ? "true" : undefined}
+				aria-label="Review changes"
+				tabindex="-1"
+				aria-hidden={!viewState.reviewFullscreenOpen}
+				style:display={viewState.reviewFullscreenOpen ? undefined : "none"}
+				onkeydown={(e) => {
+					if (e.key === "Escape") {
+						e.stopPropagation();
+						viewState.closeReviewFullscreen();
+					}
+				}}
+			>
+				<ReviewFullscreenPage
+					sessionId={viewState.reviewFullscreenSessionId}
+					fileIndex={viewState.reviewFullscreenFileIndex}
+					onClose={() => viewState.closeReviewFullscreen()}
+					onFileIndexChange={(index) => viewState.setReviewFullscreenFileIndex(index)}
+				/>
+			</div>
+		{/key}
 	{/if}
 
 	<!-- Settings Modal -->

--- a/packages/desktop/src/lib/components/main-app-view/components/content/kanban-view.svelte
+++ b/packages/desktop/src/lib/components/main-app-view/components/content/kanban-view.svelte
@@ -327,6 +327,7 @@ const threadBoardSources = $derived.by((): readonly ThreadBoardSource[] => {
 			deletions: queueItem.deletions,
 			todoProgress: queueItem.todoProgress,
 			connectionError: snapshot.connectionError ? snapshot.connectionError : null,
+			activeTurnFailure: snapshot.activeTurnFailure ?? null,
 			state: queueItem.state,
 			sequenceId: metadata
 				? metadata.sequenceId !== undefined
@@ -1420,6 +1421,7 @@ function handleRejectPlanApproval(sessionId: string): void {
 								state: item.state,
 								currentModeId: item.currentModeId,
 								connectionError: item.connectionError,
+								activeTurnFailure: item.activeTurnFailure ?? null,
 							})
 						)}
 						isStreaming={card.isStreaming}

--- a/packages/desktop/src/lib/components/main-app-view/logic/main-app-view-state.svelte.ts
+++ b/packages/desktop/src/lib/components/main-app-view/logic/main-app-view-state.svelte.ts
@@ -28,6 +28,7 @@ import type { SessionProjectionHydrator } from "$lib/acp/store/services/session-
 import type { SessionStore } from "$lib/acp/store/session-store.svelte.js";
 import type {
 	Panel,
+	PersistedReviewFullscreenState,
 	PersistedSqlStudioState,
 	ViewMode,
 } from "$lib/acp/store/types.js";
@@ -70,6 +71,21 @@ export class MainAppViewState {
 	 * Whether the SQL Studio overlay is open.
 	 */
 	sqlStudioModalOpen = $state(false);
+
+	/**
+	 * Whether the full-screen review overlay is open.
+	 */
+	reviewFullscreenOpen = $state(false);
+
+	/**
+	 * Session ID for the full-screen review overlay (when open).
+	 */
+	reviewFullscreenSessionId = $state<string | null>(null);
+
+	/**
+	 * Selected file index in the full-screen review overlay.
+	 */
+	reviewFullscreenFileIndex = $state(0);
 
 	/**
 	 * Whether the command palette is open.
@@ -389,6 +405,18 @@ export class MainAppViewState {
 			getQueueExpanded: () => this.queueExpanded,
 			setQueueExpanded: (expanded) => {
 				this.queueExpanded = expanded;
+			},
+			getReviewFullscreenState: () => ({
+				open: this.reviewFullscreenOpen,
+				sessionId: this.reviewFullscreenSessionId,
+				fileIndex: this.reviewFullscreenFileIndex,
+			}),
+			setReviewFullscreenState: (state: PersistedReviewFullscreenState) => {
+				if (state.open && state.sessionId) {
+					this.reviewFullscreenOpen = true;
+					this.reviewFullscreenSessionId = state.sessionId;
+					this.reviewFullscreenFileIndex = state.fileIndex ?? 0;
+				}
 			},
 		});
 	}
@@ -775,6 +803,48 @@ export class MainAppViewState {
 		} else {
 			this.openFileExplorer();
 		}
+	}
+
+	/**
+	 * Opens the full-screen review overlay for a session.
+	 */
+	openReviewFullscreen(sessionId: string, fileIndex: number = 0): void {
+		if (this.showSplash === true) return;
+		this.reviewFullscreenOpen = true;
+		this.reviewFullscreenSessionId = sessionId;
+		this.reviewFullscreenFileIndex = fileIndex;
+		this.workspaceStore.persist();
+	}
+
+	/**
+	 * Closes the full-screen review overlay.
+	 * Preserves sessionId and fileIndex so the component stays alive
+	 * and hunk accept/reject decisions survive re-open.
+	 */
+	closeReviewFullscreen(): void {
+		this.reviewFullscreenOpen = false;
+		// Keep reviewFullscreenSessionId and reviewFullscreenFileIndex
+		// so the overlay component survives in hidden state.
+		this.workspaceStore.persist();
+	}
+
+	/**
+	 * Fully clears review fullscreen state.
+	 * Called when the session is no longer valid (e.g., deleted).
+	 */
+	clearReviewFullscreen(): void {
+		this.reviewFullscreenOpen = false;
+		this.reviewFullscreenSessionId = null;
+		this.reviewFullscreenFileIndex = 0;
+		this.workspaceStore.persist();
+	}
+
+	/**
+	 * Updates the selected file index in the full-screen review overlay.
+	 */
+	setReviewFullscreenFileIndex(index: number): void {
+		this.reviewFullscreenFileIndex = index;
+		this.workspaceStore.persist();
 	}
 
 	/**

--- a/packages/desktop/src/lib/components/review-fullscreen/index.ts
+++ b/packages/desktop/src/lib/components/review-fullscreen/index.ts
@@ -1,0 +1,1 @@
+export { default as ReviewFullscreenPage } from "./review-fullscreen-page.svelte";

--- a/packages/desktop/src/lib/components/review-fullscreen/review-fullscreen-page.svelte
+++ b/packages/desktop/src/lib/components/review-fullscreen/review-fullscreen-page.svelte
@@ -1,0 +1,66 @@
+<script lang="ts">
+import { IconX } from "@tabler/icons-svelte";
+import AgentPanelReviewContent from "$lib/acp/components/agent-panel/components/agent-panel-review-content.svelte";
+import { aggregateFileEdits } from "$lib/acp/components/modified-files/logic/aggregate-file-edits.js";
+import { getSessionStore } from "$lib/acp/store/session-store.svelte.js";
+import { Button } from "$lib/components/ui/button/index.js";
+import * as m from "$lib/messages.js";
+
+interface Props {
+	sessionId: string;
+	fileIndex: number;
+	onClose: () => void;
+	onFileIndexChange: (index: number) => void;
+}
+
+let { sessionId, fileIndex, onClose, onFileIndexChange }: Props = $props();
+
+const sessionStore = getSessionStore();
+const entries = $derived(sessionStore.getEntries(sessionId));
+const identity = $derived(sessionStore.getSessionIdentity(sessionId));
+const modifiedFilesState = $derived.by(() => aggregateFileEdits(entries));
+const projectPath = $derived(identity?.projectPath ?? null);
+
+const hasModifications = $derived(modifiedFilesState.fileCount > 0);
+const isValidIndex = $derived(fileIndex >= 0 && fileIndex < modifiedFilesState.files.length);
+const effectiveFileIndex = $derived(
+	isValidIndex ? fileIndex : Math.min(fileIndex, Math.max(0, modifiedFilesState.files.length - 1))
+);
+
+function handleFileIndexChange(index: number): void {
+	onFileIndexChange(index);
+}
+</script>
+
+<div class="flex flex-col h-full bg-background">
+	<!-- Header with close button - add top padding for macOS title bar -->
+	<div
+		class="flex items-center justify-between px-4 py-2 pt-[46px] border-b border-border shrink-0"
+	>
+		<h1 class="text-lg font-medium">{m.modified_files_review_title()}</h1>
+		<Button variant="ghost" size="icon" onclick={onClose} aria-label={m.common_close()}>
+			<IconX class="h-5 w-5" />
+		</Button>
+	</div>
+
+	{#if !identity}
+		<div class="flex-1 flex items-center justify-center text-muted-foreground">
+			{m.common_loading()}
+		</div>
+	{:else if !hasModifications}
+		<div class="flex-1 flex items-center justify-center text-muted-foreground px-4">
+			{m.modified_files_count({ count: 0 })} – {m.common_close()}
+		</div>
+	{:else}
+		<div class="flex-1 flex flex-col min-h-0 overflow-hidden">
+			<AgentPanelReviewContent
+				{modifiedFilesState}
+				selectedFileIndex={effectiveFileIndex}
+				{sessionId}
+				{projectPath}
+				{onClose}
+				onFileIndexChange={handleFileIndexChange}
+			/>
+		</div>
+	{/if}
+</div>

--- a/packages/desktop/src/lib/components/review-fullscreen/review-fullscreen-page.svelte
+++ b/packages/desktop/src/lib/components/review-fullscreen/review-fullscreen-page.svelte
@@ -24,7 +24,7 @@ const projectPath = $derived(identity?.projectPath ?? null);
 const hasModifications = $derived(modifiedFilesState.fileCount > 0);
 const isValidIndex = $derived(fileIndex >= 0 && fileIndex < modifiedFilesState.files.length);
 const effectiveFileIndex = $derived(
-	isValidIndex ? fileIndex : Math.min(fileIndex, Math.max(0, modifiedFilesState.files.length - 1))
+	isValidIndex ? fileIndex : Math.max(0, Math.min(fileIndex, modifiedFilesState.files.length - 1))
 );
 
 function handleFileIndexChange(index: number): void {

--- a/packages/desktop/src/lib/services/acp-types.ts
+++ b/packages/desktop/src/lib/services/acp-types.ts
@@ -166,7 +166,7 @@ export type SessionDomainEvent = { event_id: string; seq: number; session_id: st
 
 export type SessionTurnState = "Idle" | "Running" | "Completed" | "Failed"
 
-export type SessionSnapshot = { session_id: string; agent_id: CanonicalAgentId | null; last_event_seq: number; turn_state: SessionTurnState; message_count: number; last_agent_message_id: string | null; active_tool_call_ids: string[]; completed_tool_call_ids: string[] }
+export type SessionSnapshot = { session_id: string; agent_id: CanonicalAgentId | null; last_event_seq: number; turn_state: SessionTurnState; message_count: number; last_agent_message_id: string | null; active_tool_call_ids: string[]; completed_tool_call_ids: string[]; active_turn_failure?: TurnFailureSnapshot | null; last_terminal_turn_id?: string | null }
 
 export type OperationSnapshot = { id: string; session_id: string; tool_call_id: string; name: string; kind: ToolKind | null; status: ToolCallStatus; title: string | null; arguments: ToolArguments; progressive_arguments: ToolArguments | null; result: JsonValue | null; command: string | null; parent_tool_call_id: string | null; parent_operation_id: string | null; child_tool_call_ids: string[]; child_operation_ids: string[] }
 
@@ -181,6 +181,18 @@ export type InteractionPayload = { Permission: PermissionData } | { Question: Qu
 export type InteractionResponse = { kind: "permission"; accepted: boolean; option_id?: string | null; reply?: string | null } | { kind: "question"; answers: JsonValue } | { kind: "plan_approval"; approved: boolean }
 
 export type InteractionSnapshot = { id: string; session_id: string; kind: InteractionKind; state: InteractionState; json_rpc_request_id: number | null; reply_handler: InteractionReplyHandler | null; tool_reference: ToolReference | null; responded_at_event_seq: number | null; response: InteractionResponse | null; payload: InteractionPayload }
+
+/**
+ * Turn error severity.
+ */
+export type TurnErrorKind = "recoverable" | "fatal"
+
+/**
+ * Turn error source.
+ */
+export type TurnErrorSource = "json_rpc" | "transport" | "process" | "unknown"
+
+export type TurnFailureSnapshot = { turn_id: string | null; message: string; code?: string | null; kind: TurnErrorKind; source: TurnErrorSource }
 
 export type SessionProjectionSnapshot = { session: SessionSnapshot | null; operations: OperationSnapshot[]; interactions: InteractionSnapshot[] }
 

--- a/packages/desktop/src/lib/services/converted-session-types.ts
+++ b/packages/desktop/src/lib/services/converted-session-types.ts
@@ -37,12 +37,12 @@ export type SessionUpdate = { type: "userMessageChunk"; chunk: ContentChunk; ses
  * Indicates that the current turn/prompt has completed.
  * This is emitted when the JSON-RPC response for a prompt request is received.
  */
-{ type: "turnComplete"; session_id?: string | null } | 
+{ type: "turnComplete"; session_id?: string | null; turn_id?: string | null } | 
 /**
  * Indicates that the current turn/prompt failed with an error.
  * This is emitted when the JSON-RPC response contains an error.
  */
-{ type: "turnError"; error: TurnErrorData; session_id?: string | null } | 
+{ type: "turnError"; error: TurnErrorData; session_id?: string | null; turn_id?: string | null } | 
 /**
  * Usage/cost and token telemetry from the agent (adapter-agnostic).
  * Emitted by adapters (e.g. OpenCode step-finish) for spend and context UI.
@@ -477,7 +477,7 @@ displayModel?: string | null; receivedAt?: string | null }
 /**
  * Error entry stored in replayed session history.
  */
-export type StoredErrorMessage = { content: string; code?: string | null; kind: TurnErrorKind }
+export type StoredErrorMessage = { content: string; code?: string | null; kind: TurnErrorKind; source?: TurnErrorSource | null }
 
 /**
  * Skill metadata for skill tool calls.
@@ -629,10 +629,14 @@ export type UserSettingKey =
  * Persisted per-agent environment overrides (JSON object)
  */
 "agent_env_overrides" | 
-	/**
-	 * Use worktrees by default for new sessions (boolean)
-	 */
-	"worktree_global_default_enabled" | 
+/**
+ * Whether opening review should use full-screen overlay (boolean string "true"/"false")
+ */
+"review_prefer_fullscreen" | 
+/**
+ * Use worktrees by default for new sessions (boolean)
+ */
+"worktree_global_default_enabled" | 
 /**
  * Workspace trust decisions for setup commands (JSON map: path key -> { trusted, commands })
  */


### PR DESCRIPTION
## Summary
Make turn failures canonical session state keyed by turn identity instead of live transcript rows. This removes duplicate \"Error\" messages from the conversation, makes the composer-level failure UI authoritative, and restores failed-turn state consistently when sessions are replayed.

## What changed
1. Thread `turn_id` through backend terminal updates, provider adapters, journaling, generated types, and frontend hot state so one failed turn has one canonical identity.
2. Move live failed-turn ownership into session runtime/projection state (`activeTurnFailure`, `lastTerminalTurnId`) and stop appending live transcript error entries for turn failures.
3. Restore canonical failed-turn state during replay/hydration while keeping legacy stored error entries readable as a compatibility path.
4. Cut queue, thread-board, urgency, and panel state over to canonical failed-turn state, with a narrow compatibility filter that hides only trailing legacy duplicate error rows that match the active failed turn.
5. Fix provider and replay edge cases, including null turn-id dedupe, Codex transport/process failure identity, stored error source preservation, and clearing stale historical errors when later replayed entries show the session continued.

## Review guide
The most important seams are:
- `packages/desktop/src-tauri/src/acp/projections/mod.rs`
- `packages/desktop/src/lib/acp/store/services/session-messaging-service.ts`
- `packages/desktop/src/lib/acp/store/session-store.svelte.ts`
- `packages/desktop/src-tauri/src/acp/client/codex_native_client.rs`

---

[![Compound Engineering](https://img.shields.io/badge/Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
🤖 Generated with GPT-5.4 (unknown context, standard reasoning) via [GitHub Copilot CLI](https://github.com/features/copilot)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make failed turns a canonical session state keyed by `turn_id` across backend and UI to eliminate duplicate errors and ensure reliable replay. Also adds a full-screen review overlay with saved preferences and safer index handling.

- **Refactors**
  - Added `turn_id` to `turnComplete`/`turnError` and threaded through adapters (Codex/Forge/OpenCode), batcher, client loop, normalization, journaling, and enrichment.
  - Introduced `active_turn_failure` and `last_terminal_turn_id` in session projections and hot state; hydrate on replay while keeping legacy stored error entries readable.
  - Stopped appending live transcript error rows; UI now uses `activeTurnFailure` for agent panel, queue, thread board, urgency, and tabs.
  - Normalized stored error `source` to `"unknown"` when missing; exported new error types for JSONL and `acp-types`.
  - Updated tests and projections to cover canonical failure identity, `turn_id` propagation, and replay.

- **Bug Fixes**
  - Deduplicated terminal updates (ignore late `turnComplete` when the same turn already failed), handled null `turn_id`, and finalized streaming entries before early return to stop shimmering.
  - Preserved failure identity/source; cleared `active_tool_call_ids` when replaying stored error entries; dropped duplicate tool-call events during idle replay.
  - Fixed Codex native `cancel()` locking to prevent stale `turn_id` after interrupt; guarded `clearSessionProjection` to no-op for unknown/removed sessions.
  - Added full-screen review overlay and preference store; enabled open-from modified files header; persisted overlay state; clamped review indexes (including full-screen) to valid bounds and to non-negative; fell back to inline review when a full-screen handler is unavailable.

<sup>Written for commit 10146aa7cc468e4e3ff05d80119be098302ca582. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

