### PR TITLE
fix(website): restore landing showcase demos

### DIFF
--- a/packages/ui/src/components/app-layout/app-sidebar-footer.svelte
+++ b/packages/ui/src/components/app-layout/app-sidebar-footer.svelte
@@ -1,0 +1,94 @@
+<script lang="ts">
+	import { DiscordLogo, GithubLogo } from "phosphor-svelte";
+
+	interface Props {
+		githubUrl: string;
+		xUrl: string;
+		discordUrl: string;
+		/** App version string, or `null` to omit the release-notes link. */
+		version: string | null;
+		/** Optional click handler; when provided, anchors become buttons invoking it. */
+		onLinkClick?: (url: string) => void;
+	}
+
+	let { githubUrl, xUrl, discordUrl, version, onLinkClick }: Props = $props();
+
+	const releaseUrl = $derived(
+		version ? `https://github.com/flazouh/acepe/releases/tag/v${version}` : null
+	);
+
+	const iconButtonClass =
+		"flex items-center justify-center size-5 rounded text-muted-foreground/60 hover:text-foreground hover:bg-accent transition-colors";
+</script>
+
+<div class="shrink-0 px-2 py-1.5 flex items-center gap-0.5">
+	<div class="flex items-center gap-0.5">
+		{#if onLinkClick}
+			<button
+				type="button"
+				class={iconButtonClass}
+				title="GitHub"
+				aria-label="GitHub"
+				onclick={() => onLinkClick(githubUrl)}
+			>
+				<GithubLogo class="size-3.5" weight="fill" />
+			</button>
+			<button
+				type="button"
+				class={iconButtonClass}
+				title="X"
+				aria-label="X"
+				onclick={() => onLinkClick(xUrl)}
+			>
+				<svg viewBox="0 0 24 24" aria-hidden="true" class="size-3 fill-current">
+					<path
+						d="M18.244 2H21.5l-7.1 8.117L22 22h-5.956l-4.663-6.104L6.04 22H2.78l7.594-8.68L2 2h6.108l4.215 5.56L18.244 2Zm-1.143 18h1.804L5.128 3.895H3.193L17.1 20Z"
+					/>
+				</svg>
+			</button>
+			<button
+				type="button"
+				class={iconButtonClass}
+				title="Discord"
+				aria-label="Discord"
+				onclick={() => onLinkClick(discordUrl)}
+			>
+				<DiscordLogo class="size-3.5" style="color: #6C75E8" weight="fill" />
+			</button>
+		{:else}
+			<a href={githubUrl} class={iconButtonClass} title="GitHub" aria-label="GitHub">
+				<GithubLogo class="size-3.5" weight="fill" />
+			</a>
+			<a href={xUrl} class={iconButtonClass} title="X" aria-label="X">
+				<svg viewBox="0 0 24 24" aria-hidden="true" class="size-3 fill-current">
+					<path
+						d="M18.244 2H21.5l-7.1 8.117L22 22h-5.956l-4.663-6.104L6.04 22H2.78l7.594-8.68L2 2h6.108l4.215 5.56L18.244 2Zm-1.143 18h1.804L5.128 3.895H3.193L17.1 20Z"
+					/>
+				</svg>
+			</a>
+			<a href={discordUrl} class={iconButtonClass} title="Discord" aria-label="Discord">
+				<DiscordLogo class="size-3.5" style="color: #6C75E8" weight="fill" />
+			</a>
+		{/if}
+	</div>
+	{#if version !== null}
+		{#if onLinkClick && releaseUrl}
+			<button
+				type="button"
+				onclick={() => onLinkClick(releaseUrl)}
+				class="ml-auto text-[9px] text-muted-foreground/50 hover:text-muted-foreground transition-colors"
+				title={`Open release notes for v${version}`}
+			>
+				v{version}
+			</button>
+		{:else if releaseUrl}
+			<a
+				href={releaseUrl}
+				class="ml-auto text-[9px] text-muted-foreground/50 hover:text-muted-foreground transition-colors"
+				title={`Open release notes for v${version}`}
+			>
+				v{version}
+			</a>
+		{/if}
+	{/if}
+</div>

--- a/packages/ui/src/components/app-layout/index.ts
+++ b/packages/ui/src/components/app-layout/index.ts
@@ -8,6 +8,7 @@ export { default as AppSearchButton } from "./app-search-button.svelte";
 export { default as AppSessionItem } from "./app-session-item.svelte";
 export { default as AppSidebarProjectGroup } from "./app-sidebar-project-group.svelte";
 export { default as AppSidebarLayout } from "./app-sidebar-layout.svelte";
+export { default as AppSidebarFooter } from "./app-sidebar-footer.svelte";
 export type {
   AppTab,
   AppTabGroup,

--- a/packages/website/src/lib/components/feature-showcase.svelte
+++ b/packages/website/src/lib/components/feature-showcase.svelte
@@ -1,21 +1,23 @@
 <script lang="ts">
 import { BrandShaderBackground } from "@acepe/ui";
-import { Kanban, GitBranch, ShieldCheck, ListChecks, Terminal } from "phosphor-svelte";
+import { Kanban, Columns, Square, SquaresFour } from "phosphor-svelte";
 import AgentPanelDemo from "./agent-panel-demo.svelte";
+import LandingByProjectDemo from "./landing-by-project-demo.svelte";
+import LandingSingleDemo from "./landing-single-demo.svelte";
 import LandingKanbanDemo from "./landing-kanban-demo.svelte";
 
 interface Feature {
 	id: string;
 	label: string;
 	icon: typeof Kanban;
+	color: string;
 }
 
 const features: Feature[] = [
-	{ id: "agent", label: "Agent Panel", icon: Terminal },
-	{ id: "kanban", label: "Kanban Board", icon: Kanban },
-	{ id: "checkpoints", label: "Checkpoints", icon: GitBranch },
-	{ id: "permissions", label: "Permissions", icon: ShieldCheck },
-	{ id: "plans", label: "Plans & Tasks", icon: ListChecks },
+	{ id: "agent", label: "Side by Side", icon: SquaresFour, color: "#99FFE4" },
+	{ id: "by-project", label: "By Project", icon: Columns, color: "#FF8D20" },
+	{ id: "single", label: "Single Agent", icon: Square, color: "#9858FF" },
+	{ id: "kanban", label: "Kanban", icon: Kanban, color: "#FF78F7" },
 ];
 
 let activeFeature = $state("agent");
@@ -28,12 +30,12 @@ let activeFeature = $state("agent");
 			{@const isActive = activeFeature === feature.id}
 			<button
 				type="button"
-				class="inline-flex items-center gap-1.5 rounded-full px-3.5 py-1.5 text-xs font-medium transition-colors {isActive
+				class="inline-flex items-center gap-1.5 rounded-full px-4 py-2 text-sm font-medium transition-colors {isActive
 					? 'bg-foreground text-background'
 					: 'text-muted-foreground hover:text-foreground hover:bg-muted/50'}"
 				onclick={() => (activeFeature = feature.id)}
 			>
-				<feature.icon class="size-3.5" weight={isActive ? "fill" : "regular"} />
+				<feature.icon class="size-4" weight={isActive ? "fill" : "regular"} style="color: {isActive ? 'currentColor' : feature.color}" />
 				{feature.label}
 			</button>
 		{/each}
@@ -42,15 +44,15 @@ let activeFeature = $state("agent");
 	<!-- Feature content -->
 	<div class="relative overflow-hidden rounded-md bg-card/10">
 		<BrandShaderBackground class="rounded-xl" fallback="gradient" />
-		<div class="relative p-2 md:p-3">
+		<div class="relative p-3 md:p-4">
 			{#if activeFeature === "agent"}
 				<AgentPanelDemo />
+			{:else if activeFeature === "by-project"}
+				<LandingByProjectDemo />
+			{:else if activeFeature === "single"}
+				<LandingSingleDemo />
 			{:else if activeFeature === "kanban"}
 				<LandingKanbanDemo />
-			{:else}
-				<div class="flex aspect-[16/10] items-center justify-center rounded-xl border border-border/10 bg-background/50">
-					<span class="text-sm text-muted-foreground/50">Coming soon</span>
-				</div>
 			{/if}
 		</div>
 	</div>

--- a/packages/website/src/lib/components/landing-by-project-demo.svelte
+++ b/packages/website/src/lib/components/landing-by-project-demo.svelte
@@ -1,0 +1,395 @@
+<script lang="ts">
+	import {
+		AgentPanelScene,
+		AgentPanelComposer,
+		AgentPanelComposerFrame,
+		AgentPanelFooter,
+		AgentInputEditor,
+		AgentInputToolbar,
+		AgentInputModeSelector,
+		AgentInputDivider,
+		AgentInputAutonomousToggle,
+		AgentInputModelSelector,
+		AgentInputMetricsChip,
+		AgentInputMicButton,
+		ProjectLetterBadge,
+		TextShimmer,
+		SegmentedProgress,
+	} from "@acepe/ui";
+	import { AgentPanelStatusIcon } from "@acepe/ui/agent-panel";
+	import {
+		AppMainLayout,
+		AppSidebarLayout,
+		AppSidebarProjectGroup,
+		AppSidebarFooter,
+	} from "@acepe/ui/app-layout";
+	import { CloseAction, FullscreenAction, OverflowMenuTriggerAction } from "@acepe/ui/panel-header";
+	import type {
+		AppProjectGroup,
+	} from "@acepe/ui/app-layout";
+	import { ProjectCard } from "@acepe/ui/project-card";
+	import type {
+		AgentPanelSceneModel,
+	} from "@acepe/ui";
+
+	import LandingDemoFrame from "./landing-demo-frame.svelte";
+	import { websiteThemeStore } from "$lib/theme/theme.js";
+
+	const theme = $derived($websiteThemeStore);
+
+	function agentIcon(agent: "claude" | "codex" | "cursor" | "opencode", t: string): string {
+		if (agent === "codex") return `/svgs/agents/codex/codex-icon-${t}.svg`;
+		if (agent === "cursor") return `/svgs/agents/cursor/cursor-icon-${t}.svg`;
+		if (agent === "opencode") return `/svgs/agents/opencode/opencode-logo-${t}.svg`;
+		return `/svgs/agents/claude/claude-icon-${t}.svg`;
+	}
+
+	// Queue items for the attention queue
+	interface DemoQueueItem {
+		id: string;
+		title: string;
+		agentIconSrc: string;
+		projectName: string;
+		projectColor: string;
+		statusText: string;
+		isStreaming: boolean;
+		todoProgress: { current: number; total: number } | null;
+	}
+
+	const queueItems = $derived<DemoQueueItem[]>([
+		{
+			id: "q1",
+			title: "Unblock review queue",
+			agentIconSrc: agentIcon("claude", theme),
+			projectName: "acepe.dev",
+			projectColor: "#9858FF",
+			statusText: "Editing agent-panel-shell.svelte",
+			isStreaming: true,
+			todoProgress: { current: 2, total: 4 },
+		},
+		{
+			id: "q2",
+			title: "Audit panel regressions",
+			agentIconSrc: agentIcon("codex", theme),
+			projectName: "desktop",
+			projectColor: "#4AD0FF",
+			statusText: "Searching panel parity surfaces",
+			isStreaming: true,
+			todoProgress: { current: 1, total: 3 },
+		},
+	]);
+
+	const sidebarGroups = $derived<AppProjectGroup[]>([
+		{
+			name: "acepe.dev",
+			color: "#9858FF",
+			sessions: [
+				{
+					id: "s1",
+					title: "Unblock review queue",
+					agentIconSrc: agentIcon("claude", theme),
+					status: "running",
+					isActive: true,
+				},
+				{
+					id: "s2",
+					title: "Polish release notes",
+					agentIconSrc: agentIcon("cursor", theme),
+					status: "done",
+					isActive: false,
+				},
+				{
+					id: "s3",
+					title: "Fix hero spacing",
+					agentIconSrc: agentIcon("claude", theme),
+					status: "done",
+					isActive: false,
+				},
+			],
+		},
+		{
+			name: "desktop",
+			color: "#4AD0FF",
+			sessions: [
+				{
+					id: "s4",
+					title: "Audit panel regressions",
+					agentIconSrc: agentIcon("codex", theme),
+					status: "running",
+					isActive: false,
+				},
+				{
+					id: "s5",
+					title: "Worktree isolation bug",
+					agentIconSrc: agentIcon("claude", theme),
+					status: "error",
+					isActive: false,
+				},
+			],
+		},
+		{
+			name: "api",
+			color: "#FF8D20",
+			sessions: [
+				{
+					id: "s6",
+					title: "Fix auth middleware",
+					agentIconSrc: agentIcon("opencode", theme),
+					status: "idle",
+					isActive: false,
+				},
+				{
+					id: "s7",
+					title: "Rate limiter config",
+					agentIconSrc: agentIcon("codex", theme),
+					status: "done",
+					isActive: false,
+				},
+			],
+		},
+	]);
+
+	const focusedScene = $derived<AgentPanelSceneModel>({
+		panelId: "by-project-panel",
+		status: "connected",
+		header: {
+			title: "Unblock review queue",
+			subtitle: null,
+			status: "connected",
+			agentLabel: "Claude Code",
+			agentIconSrc: agentIcon("claude", theme),
+			projectLabel: "acepe.dev",
+			projectColor: "#9858FF",
+			sequenceId: 12,
+			actions: [],
+		},
+		conversation: {
+			entries: [
+				{ id: "bp-u1", type: "user", text: "Tighten the review queue so the shared agent panel stops drifting between desktop and website." },
+				{
+					id: "bp-tool-1",
+					type: "tool_call",
+					kind: "search",
+					title: "Search",
+					subtitle: "shared panel surfaces",
+					query: "AgentPanelDeck AgentPanelFooter",
+					searchPath: "packages",
+					searchFiles: [
+						"packages/ui/src/components/agent-panel/agent-panel-deck.svelte",
+						"packages/ui/src/components/agent-panel/agent-panel-footer.svelte",
+					],
+					searchResultCount: 2,
+					status: "done",
+				},
+				{
+					id: "bp-tool-2",
+					type: "tool_call",
+					kind: "edit",
+					title: "Edit",
+					filePath: "packages/ui/src/components/agent-panel/agent-panel-shell.svelte",
+					status: "done",
+				},
+				{
+					id: "bp-a1",
+					type: "assistant",
+					markdown: "Pulled the shared panel rail and composer frame into `@acepe/ui`, then removed the website-only footer drift.\n\nChecking the remaining spacing deltas now.",
+					isStreaming: true,
+				},
+			],
+			isStreaming: true,
+		},
+	});
+
+	const availableModes = [{ id: "plan" }, { id: "build" }] as const;
+
+	const modelGroups = $derived([
+		{
+			label: "Anthropic",
+			items: [
+				{
+					id: "claude-sonnet-4",
+					name: "Claude Sonnet 4",
+					providerSource: "Anthropic",
+					isFavorite: true,
+					isBuildDefault: true,
+					isPlanDefault: false,
+				},
+				{
+					id: "claude-opus-4-6",
+					name: "Claude Opus 4.6",
+					providerSource: "Anthropic",
+					isFavorite: false,
+					isBuildDefault: false,
+					isPlanDefault: true,
+				},
+			],
+		},
+	]);
+
+	const favoriteModels = $derived(
+		modelGroups.flatMap((g) => g.items.filter((i) => i.isFavorite))
+	);
+</script>
+
+<LandingDemoFrame>
+	{#snippet children()}
+		<AppMainLayout>
+			{#snippet sidebar()}
+				<AppSidebarLayout>
+					{#snippet queueSection()}
+						<div class="mb-0.5 mt-1.5 flex shrink-0 flex-col overflow-hidden rounded-lg bg-card/50 mx-1.5">
+							<div class="flex w-full items-center gap-1.5 px-2 py-1.5">
+								<span class="text-[11px] font-medium text-muted-foreground">Attention Queue</span>
+								<span class="text-[10px] text-muted-foreground/60 tabular-nums">{queueItems.length}</span>
+							</div>
+							<div class="flex flex-col gap-0.5 p-1 pt-0">
+								{#each queueItems as qItem (qItem.id)}
+									<div class="flex flex-col gap-1 px-2 py-1.5 rounded hover:bg-accent/50 transition-colors">
+										<div class="flex items-center gap-1.5">
+											<ProjectLetterBadge
+												name={qItem.projectName}
+												color={qItem.projectColor}
+												iconSrc={null}
+												size={14}
+											/>
+											<img src={qItem.agentIconSrc} alt="" class="size-3.5 rounded-sm" />
+											<div class="flex-1 min-w-0">
+												<div class="text-xs font-medium truncate">{qItem.title}</div>
+											</div>
+										</div>
+										<div class="flex items-center gap-1.5">
+											<div class="flex-1 min-w-0 text-[10px] text-muted-foreground truncate">
+												{#if qItem.isStreaming}
+													<TextShimmer class="truncate">{qItem.statusText}</TextShimmer>
+												{:else}
+													<span class="truncate">{qItem.statusText}</span>
+												{/if}
+											</div>
+											{#if qItem.todoProgress}
+												<div class="flex items-center gap-1 shrink-0">
+													<SegmentedProgress current={qItem.todoProgress.current} total={qItem.todoProgress.total} />
+												</div>
+											{/if}
+										</div>
+									</div>
+								{/each}
+							</div>
+						</div>
+					{/snippet}
+					{#snippet sessionList()}
+						<div class="relative flex flex-col flex-1 min-h-0 gap-0.5 overflow-y-auto outline-none">
+							{#each sidebarGroups as group (group.name)}
+								<AppSidebarProjectGroup {group} />
+							{/each}
+						</div>
+					{/snippet}
+					{#snippet footer()}
+						<AppSidebarFooter
+							githubUrl="https://github.com/flazouh/acepe"
+							xUrl="https://x.com/AcepeDev"
+							discordUrl="https://discord.gg/acepe"
+							version="1.4.2"
+						/>
+					{/snippet}
+				</AppSidebarLayout>
+			{/snippet}
+			{#snippet panels()}
+				<div class="flex-1 min-w-0 min-h-0 overflow-hidden p-0.5">
+					<ProjectCard
+						projectName="acepe.dev"
+						projectColor="#9858FF"
+						variant="corner"
+						allProjects={[
+							{ name: "acepe.dev", color: "#9858FF", path: "/Users/dev/acepe" },
+							{ name: "desktop", color: "#4AD0FF", path: "/Users/dev/desktop" },
+							{ name: "api", color: "#FF8D20", path: "/Users/dev/api" },
+						]}
+						activeProjectPath="/Users/dev/acepe"
+						class="h-full"
+					>
+					<div class="flex-1 min-w-0 min-h-0 overflow-hidden">
+					<AgentPanelScene
+						scene={focusedScene}
+						iconBasePath="/svgs/icons"
+						widthStyle="min-width: 0; width: 100%; max-width: 100%;"
+					>
+						{#snippet headerControls()}
+							<AgentPanelStatusIcon status={focusedScene.header.status} />
+							<OverflowMenuTriggerAction title="More actions" />
+							<FullscreenAction isFullscreen={false} onToggle={() => {}} />
+							<CloseAction onClose={() => {}} />
+						{/snippet}
+						{#snippet composerOverride()}
+							<div class="shrink-0">
+								<AgentPanelComposerFrame>
+									<AgentPanelComposer
+										class="border-t-0 p-0"
+										inputClass="flex-shrink-0 border border-border bg-input/30"
+										contentClass="p-3"
+									>
+										{#snippet content()}
+											<AgentInputEditor
+												placeholder="Plan, @ for context, / for commands"
+												isEmpty={true}
+												submitIntent="send"
+												submitDisabled={true}
+												submitAriaLabel="Send message"
+											/>
+										{/snippet}
+										{#snippet footer()}
+											<AgentInputToolbar>
+												{#snippet items()}
+													<AgentInputModeSelector
+														{availableModes}
+														currentModeId="build"
+														onModeChange={() => {}}
+													/>
+													<AgentInputDivider />
+													<AgentInputAutonomousToggle
+														active={false}
+														title="Autonomous mode"
+														onToggle={() => {}}
+													/>
+													<AgentInputDivider />
+													<AgentInputModelSelector
+														triggerLabel="Claude Sonnet 4"
+														triggerProviderSource="Anthropic"
+														currentModelId="claude-sonnet-4"
+														{modelGroups}
+														{favoriteModels}
+														onModelChange={() => {}}
+														onSetBuildDefault={() => {}}
+														onSetPlanDefault={() => {}}
+														onToggleFavorite={() => {}}
+													/>
+													<AgentInputDivider />
+												{/snippet}
+												{#snippet trailing()}
+													<AgentInputMetricsChip
+														label="12/200k"
+														percent={6}
+														hideLabel={true}
+													/>
+													<AgentInputMicButton visualState="mic" title="Record with Claude" />
+												{/snippet}
+											</AgentInputToolbar>
+										{/snippet}
+									</AgentPanelComposer>
+								</AgentPanelComposerFrame>
+							</div>
+						{/snippet}
+						{#snippet footerOverride()}
+							<AgentPanelFooter
+								browserActive={false}
+								terminalActive={false}
+								terminalDisabled={false}
+							/>
+						{/snippet}
+					</AgentPanelScene>
+					</div>
+					</ProjectCard>
+				</div>
+			{/snippet}
+		</AppMainLayout>
+	{/snippet}
+</LandingDemoFrame>

--- a/packages/website/src/lib/components/landing-single-demo.svelte
+++ b/packages/website/src/lib/components/landing-single-demo.svelte
@@ -1,0 +1,276 @@
+<script lang="ts">
+	import {
+		AgentPanelScene,
+		AgentPanelComposer,
+		AgentPanelComposerFrame,
+		AgentPanelFooter,
+		AgentInputEditor,
+		AgentInputToolbar,
+		AgentInputModeSelector,
+		AgentInputDivider,
+		AgentInputAutonomousToggle,
+		AgentInputModelSelector,
+		AgentInputMetricsChip,
+		AgentInputMicButton,
+		type AgentPanelSceneModel,
+	} from "@acepe/ui";
+	import { AgentPanelStatusIcon } from "@acepe/ui/agent-panel";
+	import {
+		AppMainLayout,
+		AppSidebarLayout,
+		AppSidebarProjectGroup,
+		AppSidebarFooter,
+		AppTabBarTab,
+		type AppProjectGroup,
+		type AppTab,
+	} from "@acepe/ui/app-layout";
+	import { CloseAction, FullscreenAction, OverflowMenuTriggerAction } from "@acepe/ui/panel-header";
+
+	import LandingDemoFrame from "./landing-demo-frame.svelte";
+	import { websiteThemeStore } from "$lib/theme/theme.js";
+
+	const theme = $derived($websiteThemeStore);
+
+	function agentIcon(agent: "claude" | "codex" | "cursor" | "opencode", t: string): string {
+		if (agent === "codex") return `/svgs/agents/codex/codex-icon-${t}.svg`;
+		if (agent === "cursor") return `/svgs/agents/cursor/cursor-icon-${t}.svg`;
+		if (agent === "opencode") return `/svgs/agents/opencode/opencode-logo-${t}.svg`;
+		return `/svgs/agents/claude/claude-icon-${t}.svg`;
+	}
+
+	const sidebarGroups = $derived<AppProjectGroup[]>([
+		{ name: "acepe", color: "#9858FF", sessions: [] },
+		{ name: "VC", color: "#E879F9", sessions: [] },
+		{ name: "luminar", color: "#FACC15", sessions: [] },
+		{ name: "fluentai", color: "#8B5CF6", sessions: [] },
+	]);
+
+	const tabs = $derived<AppTab[]>([
+		{
+			id: "single-tab-1",
+			title: "how to run a w",
+			projectName: "acepe",
+			projectColor: "#9858FF",
+			agentIconSrc: agentIcon("claude", theme),
+			mode: "build",
+			status: "idle",
+			isFocused: false,
+		},
+		{
+			id: "single-tab-2",
+			title: "for our websit",
+			projectName: "acepe",
+			projectColor: "#9858FF",
+			agentIconSrc: agentIcon("claude", theme),
+			mode: "build",
+			status: "idle",
+			isFocused: false,
+		},
+		{
+			id: "single-tab-3",
+			title: "i would like yo",
+			projectName: "VC",
+			projectColor: "#E879F9",
+			agentIconSrc: agentIcon("claude", theme),
+			mode: "build",
+			status: "done",
+			isFocused: true,
+		},
+	]);
+
+	const scene = $derived<AgentPanelSceneModel>({
+		panelId: "single-panel-demo",
+		status: "connected",
+		header: {
+			title: "For our website second section where we showcase each view we have, can you take the exact pixel by ...",
+			subtitle: null,
+			status: "connected",
+			agentLabel: null,
+			agentIconSrc: agentIcon("claude", theme),
+			projectLabel: "VC",
+			projectColor: "#E879F9",
+			sequenceId: 3,
+			actions: [],
+		},
+		conversation: {
+			entries: [
+				{
+					id: "single-user-1",
+					type: "user",
+					text: "For our website second section where we showcase each view we have, can you take the exact pixel by pixel design from our actual app and implement it instead of having almost similar as it is now",
+				},
+				{
+					id: "single-tool-1",
+					type: "tool_call",
+					kind: "execute",
+					title: "Run",
+					command: "cd /Users/liya/Documents/acepe/packages/website && bun run check 2>&1 | tail -20",
+					status: "done",
+				},
+				{
+					id: "single-read-1",
+					type: "tool_call",
+					kind: "read",
+					title: "Read",
+					filePath: "landing-single-demo.svelte",
+					status: "done",
+				},
+				{
+					id: "single-assistant-1",
+					type: "assistant",
+					markdown:
+						"Done. The **Single** demo now uses the real desktop composition instead of the simplified version:\n\n- selectors are **injected into the composer toolbar**\n- full composer chrome is back: **mode, autonomous, model, agent, project, metrics, mic**\n- branch picker is rendered in the same separate minimal row as the app",
+					isStreaming: false,
+				},
+			],
+			isStreaming: false,
+		},
+	});
+
+	const availableModes = [{ id: "plan" }, { id: "build" }] as const;
+
+	const modelGroups = $derived([
+		{
+			label: "Anthropic",
+			items: [
+				{
+					id: "claude-sonnet-4",
+					name: "Claude Sonnet 4",
+					providerSource: "Anthropic",
+					isFavorite: true,
+					isBuildDefault: true,
+					isPlanDefault: false,
+				},
+				{
+					id: "claude-opus-4-6",
+					name: "Claude Opus 4.6",
+					providerSource: "Anthropic",
+					isFavorite: false,
+					isBuildDefault: false,
+					isPlanDefault: true,
+				},
+			],
+		},
+	]);
+
+	const favoriteModels = $derived(
+		modelGroups.flatMap((group) => group.items.filter((item) => item.isFavorite))
+	);
+</script>
+
+<LandingDemoFrame>
+	{#snippet children()}
+		<AppMainLayout>
+			{#snippet sidebar()}
+				<AppSidebarLayout>
+					{#snippet sessionList()}
+						<div class="relative flex flex-col flex-1 min-h-0 gap-0.5 overflow-y-auto outline-none">
+							{#each sidebarGroups as group (group.name)}
+								<AppSidebarProjectGroup {group} />
+							{/each}
+						</div>
+					{/snippet}
+					{#snippet footer()}
+						<AppSidebarFooter
+							githubUrl="https://github.com/flazouh/acepe"
+							xUrl="https://x.com/AcepeDev"
+							discordUrl="https://discord.gg/acepe"
+							version="1.4.2"
+						/>
+					{/snippet}
+				</AppSidebarLayout>
+			{/snippet}
+			{#snippet panels()}
+				<div class="flex flex-1 min-w-0 min-h-0 flex-col gap-0.5 overflow-hidden">
+					<div class="shrink-0 overflow-hidden rounded-lg border border-border bg-card/50">
+						<div class="flex items-center gap-1 overflow-x-auto px-1 py-0.5" role="tablist">
+							{#each tabs as tab (tab.id)}
+								<AppTabBarTab {tab} onclose={() => {}} />
+							{/each}
+						</div>
+					</div>
+					<div class="flex-1 min-w-0 min-h-0 overflow-hidden">
+						<AgentPanelScene
+							{scene}
+							iconBasePath="/svgs/icons"
+							widthStyle="min-width: 0; width: 100%; max-width: 100%;"
+						>
+							{#snippet headerControls()}
+								<AgentPanelStatusIcon status={scene.header.status} />
+								<OverflowMenuTriggerAction title="More actions" />
+								<FullscreenAction isFullscreen={false} onToggle={() => {}} />
+								<CloseAction onClose={() => {}} />
+							{/snippet}
+							{#snippet composerOverride()}
+								<div class="shrink-0">
+									<AgentPanelComposerFrame>
+										<AgentPanelComposer
+											class="border-t-0 p-0"
+											inputClass="flex-shrink-0 border border-border bg-input/30"
+											contentClass="p-3 py-4"
+										>
+											{#snippet content()}
+												<AgentInputEditor
+													placeholder="Plan, @ for context, / for commands"
+													isEmpty={true}
+													submitIntent="send"
+													submitDisabled={true}
+													submitAriaLabel="Send message"
+												/>
+											{/snippet}
+											{#snippet footer()}
+												<AgentInputToolbar>
+													{#snippet items()}
+														<AgentInputModeSelector
+															{availableModes}
+															currentModeId="build"
+															onModeChange={() => {}}
+														/>
+														<AgentInputDivider />
+														<AgentInputAutonomousToggle
+															active={false}
+															title="Autonomous mode"
+															onToggle={() => {}}
+														/>
+														<AgentInputDivider />
+														<AgentInputModelSelector
+															triggerLabel="Claude Sonnet 4"
+															triggerProviderSource="Anthropic"
+															currentModelId="claude-sonnet-4"
+															{modelGroups}
+															{favoriteModels}
+															onModelChange={() => {}}
+															onSetBuildDefault={() => {}}
+															onSetPlanDefault={() => {}}
+															onToggleFavorite={() => {}}
+														/>
+														<AgentInputDivider />
+													{/snippet}
+													{#snippet trailing()}
+														<AgentInputMetricsChip
+															label="18/200k"
+															percent={9}
+															hideLabel={true}
+														/>
+														<AgentInputMicButton visualState="mic" title="Record with Claude" />
+													{/snippet}
+												</AgentInputToolbar>
+											{/snippet}
+										</AgentPanelComposer>
+									</AgentPanelComposerFrame>
+								</div>
+							{/snippet}
+							{#snippet footerOverride()}
+								<AgentPanelFooter
+									browserActive={false}
+									terminalActive={false}
+									terminalDisabled={false}
+								/>
+							{/snippet}
+						</AgentPanelScene>
+					</div>
+				</div>
+			{/snippet}
+		</AppMainLayout>
+	{/snippet}
+</LandingDemoFrame>


### PR DESCRIPTION
## Summary
- restore the 4-view landing showcase tabs from PR #149
- bring back the missing single-agent and by-project landing demos
- restore the shared sidebar footer shell those demos depend on

## Why
PR #149 (`ba48c486797c8121167234f46cdcb34cd5a6e3d2`) was merged, but the website showcase changes were later overwritten by PR #154 (`28a3f53bee3fdf0b3e4724b8fa7a6f25189460a9`). This restores the lost landing-demo surfaces on top of current `main` without reverting the rest of #154.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restores the landing showcase on the website with four tabs and brings back the missing "By Project" and "Single Agent" demos. Also reintroduces the shared sidebar footer used by these demos.

- **New Features**
  - Re-added 4-tab showcase: Side by Side, By Project, Single Agent, Kanban.
  - Restored `landing-by-project-demo.svelte` and `landing-single-demo.svelte` using real `AgentPanel*` composition.
  - Added `AppSidebarFooter` in `@acepe/ui` (GitHub/X/Discord links and optional version link) and exported via `app-layout/index.ts`.
  - Updated `feature-showcase.svelte` to wire tabs, icons, and layouts.

<sup>Written for commit afe7edf1e070b5e08403ec3767cab1bdd6a4916b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

