### PR TITLE
feat(website): revamp landing with cinematic shader + split hero

### DIFF
--- a/packages/website/src/app.html
+++ b/packages/website/src/app.html
@@ -39,11 +39,12 @@
 		<link rel="manifest" href="/site.webmanifest" />
 		<meta name="theme-color" content="#F77E2C" />
 		<script>
-			const themeStorageKey = 'acepe-theme';
-			const storedTheme = window.localStorage.getItem(themeStorageKey);
-			const theme = storedTheme === 'light' || storedTheme === 'dark' ? storedTheme : 'dark';
-			document.documentElement.dataset.theme = theme;
-			document.documentElement.style.colorScheme = theme;
+			// Dark theme only — light theme disabled across the site.
+			document.documentElement.dataset.theme = 'dark';
+			document.documentElement.style.colorScheme = 'dark';
+			try {
+				window.localStorage.setItem('acepe-theme', 'dark');
+			} catch {}
 		</script>
 
 		%sveltekit.head%

--- a/packages/website/src/lib/components/feature-showcase.svelte
+++ b/packages/website/src/lib/components/feature-showcase.svelte
@@ -1,5 +1,4 @@
 <script lang="ts">
-import { BrandShaderBackground } from "@acepe/ui";
 import { Kanban, Columns, Square, SquaresFour } from "phosphor-svelte";
 import AgentPanelDemo from "./agent-panel-demo.svelte";
 import LandingByProjectDemo from "./landing-by-project-demo.svelte";
@@ -42,18 +41,19 @@ let activeFeature = $state("agent");
 	</div>
 
 	<!-- Feature content -->
-	<div class="relative overflow-hidden rounded-md bg-card/10">
-		<BrandShaderBackground class="rounded-xl" fallback="gradient" />
-		<div class="relative p-3 md:p-4">
-			{#if activeFeature === "agent"}
-				<AgentPanelDemo />
-			{:else if activeFeature === "by-project"}
-				<LandingByProjectDemo />
-			{:else if activeFeature === "single"}
-				<LandingSingleDemo />
-			{:else if activeFeature === "kanban"}
-				<LandingKanbanDemo />
-			{/if}
-		</div>
+	<div class="relative">
+		{#if activeFeature === "agent"}
+			<AgentPanelDemo />
+		{:else if activeFeature === "by-project"}
+			<LandingByProjectDemo />
+		{:else if activeFeature === "single"}
+			<LandingSingleDemo />
+		{:else if activeFeature === "kanban"}
+			<LandingKanbanDemo />
+		{/if}
 	</div>
 </div>
+
+<style>
+	/* container intentionally empty — demo stands alone on the page */
+</style>

--- a/packages/website/src/lib/components/header.svelte
+++ b/packages/website/src/lib/components/header.svelte
@@ -1,17 +1,9 @@
 <script lang="ts">
 import { BrandLockup } from "@acepe/ui";
-import { browser } from "$app/environment";
 import { page } from "$app/stores";
-import { Download, Menu, Moon, Sun } from "@lucide/svelte";
+import { Download, Menu } from "@lucide/svelte";
 import { Drawer, DrawerContent, DrawerOverlay, DrawerPortal, DrawerTrigger } from "@acepe/ui";
 import { DiscordLogo, GithubLogo, Star } from "phosphor-svelte";
-import {
-	THEME_STORAGE_KEY,
-	applyThemeToDocument,
-	getToggledTheme,
-	websiteThemeStore,
-	type WebsiteTheme,
-} from "$lib/theme/theme";
 
 interface Props {
 	showLogin?: boolean;
@@ -30,21 +22,6 @@ function formatStars(count: number): string {
 	}
 	return count.toString();
 }
-const theme = $derived($websiteThemeStore);
-
-const toggleThemeLabel = $derived(
-	theme === "dark" ? "Switch to light theme" : "Switch to dark theme"
-);
-
-function handleThemeToggle() {
-	const nextTheme = getToggledTheme(theme);
-
-	if (browser) {
-		websiteThemeStore.set(nextTheme);
-		applyThemeToDocument(nextTheme, document.documentElement);
-		window.localStorage.setItem(THEME_STORAGE_KEY, nextTheme);
-	}
-}
 
 const desktopNavLinkClass =
 	"rounded-full px-2.5 py-1.5 text-sm text-muted-foreground transition-colors hover:bg-card/70 hover:text-foreground";
@@ -54,7 +31,7 @@ const mobileNavLinkClass =
 
 <header class="fixed top-4 left-1/2 z-50 w-[calc(100%-3rem)] max-w-4xl -translate-x-1/2">
 	<div
-		class="flex items-center justify-between rounded-full bg-card/45 px-4 py-2.5 backdrop-blur-[30px]"
+		class="flex items-center justify-between rounded-2xl bg-card/45 px-4 py-2.5 backdrop-blur-[30px]"
 	>
 		<div class="flex shrink-0 items-center">
 			<a
@@ -126,19 +103,6 @@ const mobileNavLinkClass =
 					/>
 				</svg>
 			</a>
-			<button
-				type="button"
-				class="inline-flex h-8 w-8 cursor-pointer items-center justify-center rounded-full bg-card/70 text-foreground transition-colors hover:bg-card"
-				aria-label={toggleThemeLabel}
-				title={toggleThemeLabel}
-				onclick={handleThemeToggle}
-			>
-				{#if theme === 'dark'}
-					<Sun class="h-4 w-4" />
-				{:else}
-					<Moon class="h-4 w-4" />
-				{/if}
-			</button>
 			{#if showDownload}
 				<a
 					href="/download"
@@ -227,19 +191,6 @@ const mobileNavLinkClass =
 									/>
 								</svg>
 							</a>
-								<button
-									type="button"
-									class="inline-flex h-11 min-h-11 w-11 min-w-11 cursor-pointer items-center justify-center rounded-full bg-card/70 text-foreground transition-colors hover:bg-card"
-									aria-label={toggleThemeLabel}
-									title={toggleThemeLabel}
-									onclick={handleThemeToggle}
-								>
-									{#if theme === 'dark'}
-										<Sun class="h-4 w-4" />
-									{:else}
-										<Moon class="h-4 w-4" />
-									{/if}
-								</button>
 							</div>
 						</div>
 						<nav class="flex flex-col gap-1">

--- a/packages/website/src/lib/components/hero-shader-stage.svelte
+++ b/packages/website/src/lib/components/hero-shader-stage.svelte
@@ -1,0 +1,254 @@
+<script lang="ts">
+import { onDestroy, onMount } from "svelte";
+import {
+	GrainGradientShapes,
+	ShaderFitOptions,
+	ShaderMount,
+	getShaderColorFromString,
+	getShaderNoiseTexture,
+	grainGradientFragmentShader,
+	pulsingBorderFragmentShader,
+	type GrainGradientUniforms,
+	type PulsingBorderUniforms,
+} from "@paper-design/shaders";
+import { websiteThemeStore } from "$lib/theme/theme.js";
+
+interface Props {
+	class?: string;
+	/** Height of the shader stage. Height-based so the hero composition stays stable. */
+	heightClass?: string;
+	/** When true, renders a second shader (pulsing border) for a luminous accent ring. */
+	accentRing?: boolean;
+}
+
+let {
+	class: className = "",
+	heightClass = "h-[min(900px,100vh)]",
+	accentRing = false,
+}: Props = $props();
+
+const theme = $derived($websiteThemeStore);
+
+let primaryContainer: HTMLDivElement | null = $state(null);
+let accentContainer: HTMLDivElement | null = $state(null);
+let shaderReady = $state(false);
+let primaryMount: ShaderMount | null = null;
+let accentMount: ShaderMount | null = null;
+let initVersion = 0;
+
+type PaletteKind = "dark" | "light";
+
+function paletteFor(kind: PaletteKind) {
+	if (kind === "light") {
+		return {
+			background: "#F0EEE6",
+			colors: ["#F77E2C", "#F9A15E", "#FFD7A8", "#FFE7CA"] as const,
+			softness: 0.36,
+			intensity: 0.92,
+			noise: 0.14,
+		};
+	}
+
+	return {
+		background: "#0F0F10",
+		colors: ["#F77E2C", "#C85A12", "#5B2404", "#18120E"] as const,
+		softness: 0.55,
+		intensity: 0.85,
+		noise: 0.18,
+	};
+}
+
+onMount(() => {
+	initVersion += 1;
+	void init(initVersion);
+});
+
+onDestroy(() => {
+	initVersion += 1;
+	primaryMount?.dispose();
+	accentMount?.dispose();
+	primaryMount = null;
+	accentMount = null;
+});
+
+async function init(version: number) {
+	if (!primaryContainer) return;
+
+	const noiseTexture = getShaderNoiseTexture();
+	if (noiseTexture && !noiseTexture.complete) {
+		await new Promise<void>((resolve, reject) => {
+			noiseTexture.onload = () => resolve();
+			noiseTexture.onerror = () => reject(new Error("Failed to load noise texture"));
+		});
+	}
+
+	if (version !== initVersion) return;
+
+	const activeTheme: PaletteKind = theme === "light" ? "light" : "dark";
+	const palette = paletteFor(activeTheme);
+
+	primaryMount = new ShaderMount(
+		primaryContainer,
+		grainGradientFragmentShader,
+		{
+			u_colorBack: getShaderColorFromString(palette.background),
+			u_colors: [
+				getShaderColorFromString(palette.colors[0]),
+				getShaderColorFromString(palette.colors[1]),
+				getShaderColorFromString(palette.colors[2]),
+				getShaderColorFromString(palette.colors[3]),
+			],
+			u_colorsCount: 4,
+			u_softness: palette.softness,
+			u_intensity: palette.intensity,
+			u_noise: palette.noise,
+			u_shape: GrainGradientShapes.corners,
+			u_noiseTexture: noiseTexture,
+			u_fit: ShaderFitOptions.cover,
+			u_scale: 1.4,
+			u_rotation: 0,
+			u_originX: 0.5,
+			u_originY: 0.95,
+			u_offsetX: 0,
+			u_offsetY: 0.25,
+			u_worldWidth: primaryContainer.offsetWidth,
+			u_worldHeight: primaryContainer.offsetHeight,
+		} satisfies Partial<GrainGradientUniforms>,
+		{ alpha: false, premultipliedAlpha: false },
+		0.35
+	);
+
+	if (accentRing && accentContainer) {
+		accentMount = new ShaderMount(
+			accentContainer,
+			pulsingBorderFragmentShader,
+			{
+				u_colorBack: getShaderColorFromString("#00000000"),
+				u_colors: [
+					getShaderColorFromString("#F77E2C"),
+					getShaderColorFromString("#FFB27A"),
+					getShaderColorFromString("#FF6A1A"),
+				],
+				u_colorsCount: 3,
+				u_roundness: 1,
+				u_thickness: 0.18,
+				u_softness: 0.85,
+				u_marginLeft: 0.08,
+				u_marginRight: 0.08,
+				u_marginTop: 0.2,
+				u_marginBottom: 0.2,
+				u_aspectRatio: 0,
+				u_intensity: 0.55,
+				u_bloom: 0.85,
+				u_spots: 4,
+				u_spotSize: 0.35,
+				u_pulse: 0.35,
+				u_smoke: 0.25,
+				u_smokeSize: 0.6,
+				u_noiseTexture: noiseTexture,
+				u_fit: ShaderFitOptions.cover,
+				u_scale: 1,
+				u_rotation: 0,
+				u_originX: 0.5,
+				u_originY: 0.5,
+				u_offsetX: 0,
+				u_offsetY: 0,
+				u_worldWidth: accentContainer.offsetWidth,
+				u_worldHeight: accentContainer.offsetHeight,
+			} satisfies Partial<PulsingBorderUniforms>,
+			{ alpha: true, premultipliedAlpha: false },
+			0.2
+		);
+	}
+
+	if (version !== initVersion) {
+		primaryMount?.dispose();
+		accentMount?.dispose();
+		primaryMount = null;
+		accentMount = null;
+		return;
+	}
+
+	shaderReady = true;
+}
+</script>
+
+<div
+	class="hero-shader-stage pointer-events-none absolute inset-x-0 top-0 overflow-hidden {heightClass} {className}"
+	aria-hidden="true"
+>
+	<div
+		bind:this={primaryContainer}
+		class="absolute inset-0 block h-full w-full transition-opacity duration-[1400ms] ease-out {shaderReady
+			? 'opacity-100'
+			: 'opacity-0'}"
+	></div>
+
+	{#if accentRing}
+		<div
+			bind:this={accentContainer}
+			class="absolute inset-0 block h-full w-full mix-blend-screen transition-opacity duration-[1800ms] ease-out {shaderReady
+				? 'opacity-60'
+				: 'opacity-0'}"
+		></div>
+	{/if}
+
+	<!-- Subtle grain film -->
+	<div class="absolute inset-0 grain-film opacity-[0.14]"></div>
+
+	<!-- Vignette: darkens the edges so the hero content floats -->
+	<div class="absolute inset-0 vignette"></div>
+
+	<!-- Top gradient: keeps the floating header readable over warm tones -->
+	<div class="absolute inset-x-0 top-0 h-40 top-fade"></div>
+
+	<!-- Bottom fade to page bg: stitches shader into the page content seamlessly -->
+	<div class="absolute inset-x-0 bottom-0 h-48 bottom-fade"></div>
+</div>
+
+<style>
+	.hero-shader-stage :global(canvas) {
+		display: block;
+		width: 100%;
+		height: 100%;
+	}
+
+	.vignette {
+		background:
+			radial-gradient(
+				90% 60% at 50% 42%,
+				color-mix(in srgb, var(--background) 70%, transparent) 0%,
+				color-mix(in srgb, var(--background) 35%, transparent) 35%,
+				transparent 70%
+			),
+			radial-gradient(
+				140% 100% at 50% 50%,
+				transparent 0%,
+				transparent 55%,
+				color-mix(in srgb, var(--background) 55%, transparent) 82%,
+				var(--background) 100%
+			);
+	}
+
+	.top-fade {
+		background: linear-gradient(
+			to bottom,
+			color-mix(in srgb, var(--background) 38%, transparent) 0%,
+			transparent 100%
+		);
+	}
+
+	.bottom-fade {
+		background: linear-gradient(
+			to bottom,
+			transparent 0%,
+			color-mix(in srgb, var(--background) 65%, transparent) 45%,
+			var(--background) 100%
+		);
+	}
+
+	.grain-film {
+		background-image: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' width='160' height='160'><filter id='n'><feTurbulence type='fractalNoise' baseFrequency='0.9' numOctaves='2' stitchTiles='stitch'/><feColorMatrix values='0 0 0 0 0  0 0 0 0 0  0 0 0 0 0  0 0 0 0.6 0'/></filter><rect width='100%' height='100%' filter='url(%23n)'/></svg>");
+		mix-blend-mode: overlay;
+	}
+</style>

--- a/packages/website/src/routes/+page.svelte
+++ b/packages/website/src/routes/+page.svelte
@@ -408,7 +408,7 @@ const features = [
 					</h1>
 
 					<p class="mb-10 max-w-[560px] text-pretty text-base leading-[1.55] text-muted-foreground md:text-[19px]">
-						{"Run Claude Code, Codex, Cursor Agent, and OpenCode side by side. Orchestrate parallel sessions, track every change, and ship from plan to PR — in one window."}
+						{"One native workspace for every coding agent. Run them in parallel, review every change, and ship from plan to PR without leaving the window."}
 					</p>
 
 					<div class="flex flex-col items-start gap-3 sm:flex-row sm:items-center">
@@ -841,6 +841,13 @@ const features = [
 <style>
 	.hero-demo {
 		/* Let the product UI render at its natural width, then scale to fit */
+	}
+	.hero-demo-stage {
+		filter: grayscale(1);
+		transition: filter 0.4s ease;
+	}
+	.hero-demo-stage:hover {
+		filter: grayscale(0);
 	}
 	@media (min-width: 1024px) {
 		.hero-demo-stage {

--- a/packages/website/src/routes/+page.svelte
+++ b/packages/website/src/routes/+page.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-import { ArrowRightIcon, BrandLockup, BrandShaderBackground, PillButton } from "@acepe/ui";
+import { ArrowRightIcon, BrandLockup, PillButton } from "@acepe/ui";
 import { CheckpointTimeline } from "@acepe/ui/checkpoint";
 import { PlanCard } from "@acepe/ui/plan-card";
 import { AgentSelectionGrid } from "@acepe/ui/agent-panel";
@@ -20,7 +20,7 @@ import type {
 import AgentIconsRow from "$lib/components/agent-icons-row.svelte";
 import Header from "$lib/components/header.svelte";
 import FeatureShowcase from "$lib/components/feature-showcase.svelte";
-import { websiteThemeStore } from "$lib/theme/theme.js";
+import HeroShaderStage from "$lib/components/hero-shader-stage.svelte";
 import {
 	Stack,
 	ArrowsOutSimple,
@@ -39,7 +39,7 @@ let { data } = $props();
 
 // === Mock data for real component showcases ===
 
-const theme = $derived($websiteThemeStore);
+const theme = "dark" as const;
 
 const mockGridAgents: AgentGridItem[] = $derived([
 	{
@@ -393,38 +393,62 @@ const features = [
 		showDownload={data.featureFlags.downloadEnabled}
 	/>
 
-	<main class="pt-20">
-		<!-- Hero Section -->
-		<section class="flex justify-center px-4 pt-16 pb-12 md:px-6 md:pt-24 md:pb-16">
-			<div class="text-center">
-				<AgentIconsRow size={24} class="mb-6" />
+	<main>
+		<!-- Hero Section — split left/right -->
+		<section class="relative isolate overflow-hidden px-4 pt-36 pb-24 md:px-6 md:pt-44 md:pb-28">
+			<HeroShaderStage heightClass="h-full" />
 
-				<h1 class="mb-6 text-3xl leading-[1.1] font-semibold tracking-[-0.03em] md:text-[56px]">
-					{"The Agentic Developer Environment"}
-				</h1>
-				<p class="mx-auto mb-10 max-w-[760px] text-lg leading-[1.5] font-normal tracking-[-0.01em] text-muted-foreground md:text-[22px]">
-					{"Run Claude Code, Codex, Cursor Agent, and OpenCode side by side. Orchestrate parallel sessions, track every change, and ship from plan to PR. All in one window."}
-				</p>
+			<div class="relative z-10 mx-auto grid w-full max-w-[86rem] items-center gap-12 lg:grid-cols-[minmax(0,1fr)_minmax(0,1.05fr)] lg:gap-14">
+				<!-- Left: headline + CTA -->
+				<div class="flex flex-col items-start text-left">
+					<h1 class="mb-6 text-balance text-5xl leading-[1.02] font-semibold tracking-[-0.035em] text-foreground md:text-[72px] [text-shadow:0_1px_30px_rgba(0,0,0,0.45)]">
+						{"The Agentic Developer"}
+						<br class="hidden md:block" />
+						<span class="italic font-normal text-foreground/90">{"Environment"}</span>
+					</h1>
 
-				<div class="flex flex-col items-center gap-4 sm:flex-row sm:justify-center">
-					<PillButton
-						href="/download"
-						variant="invert"
-						size="default"
-						class="h-11 py-1.5 pr-1.5 pl-5"
-					>
-						{"Get started"}
-						{#snippet trailingIcon()}
-							<ArrowRightIcon size="lg" />
-						{/snippet}
-					</PillButton>
+					<p class="mb-10 max-w-[560px] text-pretty text-base leading-[1.55] text-muted-foreground md:text-[19px]">
+						{"Run Claude Code, Codex, Cursor Agent, and OpenCode side by side. Orchestrate parallel sessions, track every change, and ship from plan to PR — in one window."}
+					</p>
+
+					<div class="flex flex-col items-start gap-3 sm:flex-row sm:items-center">
+						<PillButton
+							href="/download"
+							variant="invert"
+							size="default"
+							class="h-12 py-1.5 pr-1.5 pl-6 shadow-[0_12px_40px_-12px_rgba(247,126,44,0.55)]"
+						>
+							{"Download for macOS"}
+							{#snippet trailingIcon()}
+								<ArrowRightIcon size="lg" />
+							{/snippet}
+						</PillButton>
+					</div>
+				</div>
+
+				<!-- Right: demo — natural width, compact scale so UI stays crisp.
+				     Hidden below lg: at phone widths the multi-panel UI is unreadable
+				     and the hero works better as a focused headline + CTA. -->
+				<div class="hero-demo relative hidden w-full lg:block">
+					<div class="hero-demo-stage">
+						<FeatureShowcase />
+					</div>
 				</div>
 			</div>
 		</section>
 
-		<!-- Feature Showcase Section -->
-		<section class="mx-auto max-w-[86rem] px-4 pb-24 md:px-6 md:pb-32">
-			<FeatureShowcase />
+		<!-- Supported agents band -->
+		<section class="relative px-4 pb-24 md:px-6 md:pb-28">
+			<div class="mx-auto flex max-w-4xl flex-col items-center">
+				<div class="mb-5 flex items-center gap-3">
+					<span class="h-px w-10 bg-border/60"></span>
+					<span class="font-mono text-[10px] uppercase tracking-[0.22em] text-muted-foreground/80">
+						{"Works with"}
+					</span>
+					<span class="h-px w-10 bg-border/60"></span>
+				</div>
+				<AgentIconsRow size={30} />
+			</div>
 		</section>
 
 		<!-- What is an ADE? -->
@@ -676,31 +700,40 @@ const features = [
 		</section>
 
 		<!-- Bottom CTA -->
-		<section class="border-t border-border/50 px-4 py-24 md:px-6">
-			<div class="mx-auto flex max-w-2xl flex-col items-center text-center">
-				<h2 class="mb-4 text-2xl leading-[1.2] font-semibold tracking-[-0.03em] md:text-[36px]">
+		<section class="relative overflow-hidden border-t border-border/50 px-4 py-32 md:px-6 md:py-40">
+			<div class="absolute inset-0 -z-10">
+				<HeroShaderStage heightClass="h-full" accentRing={false} />
+			</div>
+			<div class="relative mx-auto flex max-w-2xl flex-col items-center text-center">
+				<span class="mb-5 font-mono text-[10px] uppercase tracking-[0.2em] text-muted-foreground">
+					{"// ship from plan to PR"}
+				</span>
+				<h2 class="mb-4 text-balance text-3xl leading-[1.1] font-semibold tracking-[-0.03em] md:text-[52px]">
 					{"Your ADE is ready"}
 				</h2>
-				<p class="mb-8 max-w-[500px] whitespace-pre-line text-[15px] leading-[1.7] text-muted-foreground md:text-[17px]">
-					{"Acepe is free while in beta.\nOne download, every agent, full control."}
+				<p class="mb-10 max-w-[540px] text-pretty text-[15px] leading-[1.65] text-muted-foreground md:text-[18px]">
+					{"Acepe is free while in beta. One download, every agent, full control."}
 				</p>
-				<PillButton
-					href="/download"
-					variant="invert"
-					size="default"
-					class="h-11 py-1.5 pr-1.5 pl-5"
-				>
-					{"Get started"}
-					{#snippet trailingIcon()}
-						<ArrowRightIcon size="lg" />
-					{/snippet}
-				</PillButton>
-				<a
-					href="/compare/cursor"
-					class="mt-4 inline-flex items-center gap-1.5 text-sm text-muted-foreground transition-colors hover:text-foreground"
-				>
-					{"See how Acepe compares →"}
-				</a>
+				<div class="flex flex-col items-center gap-3 sm:flex-row">
+					<PillButton
+						href="/download"
+						variant="invert"
+						size="default"
+						class="h-12 py-1.5 pr-1.5 pl-6 shadow-[0_12px_40px_-12px_rgba(247,126,44,0.55)]"
+					>
+						{"Download for macOS"}
+						{#snippet trailingIcon()}
+							<ArrowRightIcon size="lg" />
+						{/snippet}
+					</PillButton>
+					<a
+						href="/compare/cursor"
+						class="inline-flex h-12 items-center gap-2 rounded-full border border-white/10 bg-background/40 px-5 text-sm text-muted-foreground backdrop-blur-xl transition-colors hover:border-white/20 hover:text-foreground"
+					>
+						{"See how Acepe compares"}
+						<ArrowRightIcon size="sm" />
+					</a>
+				</div>
 			</div>
 		</section>
 	</main>
@@ -806,6 +839,29 @@ const features = [
 </div>
 
 <style>
+	.hero-demo {
+		/* Let the product UI render at its natural width, then scale to fit */
+	}
+	@media (min-width: 1024px) {
+		.hero-demo-stage {
+			width: 900px;
+			transform-origin: left top;
+			transform: scale(0.7);
+			/* reclaim the empty space left behind by the scale so layout stays tight */
+			margin-bottom: calc(-1 * (900px * 0.3) * (500 / 900));
+		}
+	}
+	@media (min-width: 1280px) {
+		.hero-demo-stage {
+			transform: scale(0.78);
+		}
+	}
+	@media (min-width: 1440px) {
+		.hero-demo-stage {
+			transform: scale(0.88);
+		}
+	}
+
 	.feature-card {
 		backdrop-filter: blur(12px);
 	}


### PR DESCRIPTION
Revamps the landing page to make the paper shader more visible and the overall design more professional.

## Changes

- Extend `HeroShaderStage` behind the floating nav with a softened top fade so the glow reads under the header without fighting it.
- Lock landing to dark theme only; drop the toggle and `pt-20` reservation.
- Split hero: left-aligned headline + Download CTA, right-side `FeatureShowcase` preview (natural 900px width, scaled per breakpoint, bleeds off-screen intentionally).
- Hide the demo below `lg` so mobile + tablet get a clean headline → CTA → 'Works with' band.
- Greyscale the hero demo by default; restore color on hover.
- Add a 'Works with' eyebrow above the agent icons (no more bare logo cluster).
- Strip the shader panel / container from `FeatureShowcase` — demo sits flat.
- Reduce header rounding: `rounded-full` → `rounded-2xl`.
- Remove eyebrow pills ('Public beta', 'macOS · Apple Silicon', 'Open source · MIT') and the 'Star on GitHub' CTA.
- Rework hero subtitle to lead with the core promise instead of enumerating agent names (the 'Works with' band carries that job).

## Verified

- Desktop 1440, tablet 768, mobile 390 — all clean.
- `bun run check` passes (0 errors, 1 pre-existing a11y warning).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Revamps the landing page with a cinematic shader backdrop and a split hero that spotlights the headline and Download CTA. Locks the site to dark theme and simplifies the header for a cleaner, more focused first impression.

- **New Features**
  - Added `HeroShaderStage` (WebGL via `@paper-design/shaders`) with grain gradient, vignette, top/bottom fades; extends under the floating header.
  - Split hero: left headline + “Download for macOS”; right `FeatureShowcase` preview at natural 900px, scaled per breakpoint; grayscale by default, color on hover.
  - New “Works with” eyebrow above agent icons; refreshed bottom CTA section with shader backdrop.

- **Refactors**
  - Forced dark theme site-wide; removed theme toggle and top spacing; persist `'dark'` in `localStorage`.
  - Simplified `FeatureShowcase` by removing the shader container so the demo sits flat.
  - Hid the hero demo below `lg` for a focused mobile/tablet experience.
  - Reduced header rounding to `rounded-2xl`; removed old eyebrow pills and the “Star on GitHub” CTA; reworked hero subtitle to lead with the core promise.

<sup>Written for commit 3ff7985f630f409a75bf4f28c8b6580e8aeb61aa. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

