### PR TITLE
feat(website): extend hero shader behind agents band

### DIFF
--- a/packages/website/src/lib/components/hero-shader-stage.svelte
+++ b/packages/website/src/lib/components/hero-shader-stage.svelte
@@ -52,8 +52,8 @@ function paletteFor(kind: PaletteKind) {
 	return {
 		background: "#0F0F10",
 		colors: ["#F77E2C", "#C85A12", "#5B2404", "#18120E"] as const,
-		softness: 0.55,
-		intensity: 0.85,
+		softness: 0.6,
+		intensity: 0.92,
 		noise: 0.18,
 	};
 }
@@ -105,12 +105,12 @@ async function init(version: number) {
 			u_shape: GrainGradientShapes.corners,
 			u_noiseTexture: noiseTexture,
 			u_fit: ShaderFitOptions.cover,
-			u_scale: 1.4,
+			u_scale: 1.25,
 			u_rotation: 0,
 			u_originX: 0.5,
-			u_originY: 0.95,
+			u_originY: 0.5,
 			u_offsetX: 0,
-			u_offsetY: 0.25,
+			u_offsetY: 0,
 			u_worldWidth: primaryContainer.offsetWidth,
 			u_worldHeight: primaryContainer.offsetHeight,
 		} satisfies Partial<GrainGradientUniforms>,
@@ -216,17 +216,11 @@ async function init(version: number) {
 	.vignette {
 		background:
 			radial-gradient(
-				90% 60% at 50% 42%,
-				color-mix(in srgb, var(--background) 70%, transparent) 0%,
-				color-mix(in srgb, var(--background) 35%, transparent) 35%,
-				transparent 70%
-			),
-			radial-gradient(
-				140% 100% at 50% 50%,
+				120% 80% at 50% 50%,
 				transparent 0%,
 				transparent 55%,
-				color-mix(in srgb, var(--background) 55%, transparent) 82%,
-				var(--background) 100%
+				color-mix(in srgb, var(--background) 35%, transparent) 82%,
+				color-mix(in srgb, var(--background) 75%, transparent) 100%
 			);
 	}
 
@@ -242,7 +236,8 @@ async function init(version: number) {
 		background: linear-gradient(
 			to bottom,
 			transparent 0%,
-			color-mix(in srgb, var(--background) 65%, transparent) 45%,
+			color-mix(in srgb, var(--background) 35%, transparent) 55%,
+			color-mix(in srgb, var(--background) 85%, transparent) 85%,
 			var(--background) 100%
 		);
 	}

--- a/packages/website/src/routes/+page.svelte
+++ b/packages/website/src/routes/+page.svelte
@@ -394,62 +394,66 @@ const features = [
 	/>
 
 	<main>
-		<!-- Hero Section — split left/right -->
-		<section class="relative isolate overflow-hidden px-4 pt-36 pb-24 md:px-6 md:pt-44 md:pb-28">
+		<!-- Hero + supported agents band share one shader stage so the warm glow
+		     runs continuously from the floating header through the 'Works with' band. -->
+		<div class="relative isolate overflow-hidden">
 			<HeroShaderStage heightClass="h-full" />
 
-			<div class="relative z-10 mx-auto grid w-full max-w-[86rem] items-center gap-12 lg:grid-cols-[minmax(0,1fr)_minmax(0,1.05fr)] lg:gap-14">
-				<!-- Left: headline + CTA -->
-				<div class="flex flex-col items-start text-left">
-					<h1 class="mb-6 text-balance text-5xl leading-[1.02] font-semibold tracking-[-0.035em] text-foreground md:text-[72px] [text-shadow:0_1px_30px_rgba(0,0,0,0.45)]">
-						{"The Agentic Developer"}
-						<br class="hidden md:block" />
-						<span class="italic font-normal text-foreground/90">{"Environment"}</span>
-					</h1>
+			<!-- Hero Section — split left/right -->
+			<section class="relative z-10 px-4 pt-36 pb-24 md:px-6 md:pt-44 md:pb-28">
+				<div class="mx-auto grid w-full max-w-[86rem] items-center gap-12 lg:grid-cols-[minmax(0,1fr)_minmax(0,1.05fr)] lg:gap-14">
+					<!-- Left: headline + CTA -->
+					<div class="flex flex-col items-start text-left">
+						<h1 class="mb-6 text-balance text-5xl leading-[1.02] font-semibold tracking-[-0.035em] text-foreground md:text-[72px] [text-shadow:0_1px_30px_rgba(0,0,0,0.45)]">
+							{"The Agentic Developer"}
+							<br class="hidden md:block" />
+							<span class="italic font-normal text-foreground/90">{"Environment"}</span>
+						</h1>
 
-					<p class="mb-10 max-w-[560px] text-pretty text-base leading-[1.55] text-muted-foreground md:text-[19px]">
-						{"One native workspace for every coding agent. Run them in parallel, review every change, and ship from plan to PR without leaving the window."}
-					</p>
+						<p class="mb-10 max-w-[560px] text-pretty text-base leading-[1.55] text-muted-foreground md:text-[19px]">
+							{"One native workspace for every coding agent. Run them in parallel, review every change, and ship from plan to PR without leaving the window."}
+						</p>
 
-					<div class="flex flex-col items-start gap-3 sm:flex-row sm:items-center">
-						<PillButton
-							href="/download"
-							variant="invert"
-							size="default"
-							class="h-12 py-1.5 pr-1.5 pl-6 shadow-[0_12px_40px_-12px_rgba(247,126,44,0.55)]"
-						>
-							{"Download for macOS"}
-							{#snippet trailingIcon()}
-								<ArrowRightIcon size="lg" />
-							{/snippet}
-						</PillButton>
+						<div class="flex flex-col items-start gap-3 sm:flex-row sm:items-center">
+							<PillButton
+								href="/download"
+								variant="invert"
+								size="default"
+								class="h-12 py-1.5 pr-1.5 pl-6 shadow-[0_12px_40px_-12px_rgba(247,126,44,0.55)]"
+							>
+								{"Download for macOS"}
+								{#snippet trailingIcon()}
+									<ArrowRightIcon size="lg" />
+								{/snippet}
+							</PillButton>
+						</div>
+					</div>
+
+					<!-- Right: demo — natural width, compact scale so UI stays crisp.
+					     Hidden below lg: at phone widths the multi-panel UI is unreadable
+					     and the hero works better as a focused headline + CTA. -->
+					<div class="hero-demo relative hidden w-full lg:block">
+						<div class="hero-demo-stage">
+							<FeatureShowcase />
+						</div>
 					</div>
 				</div>
+			</section>
 
-				<!-- Right: demo — natural width, compact scale so UI stays crisp.
-				     Hidden below lg: at phone widths the multi-panel UI is unreadable
-				     and the hero works better as a focused headline + CTA. -->
-				<div class="hero-demo relative hidden w-full lg:block">
-					<div class="hero-demo-stage">
-						<FeatureShowcase />
+			<!-- Supported agents band -->
+			<section class="relative z-10 px-4 pb-24 md:px-6 md:pb-28">
+				<div class="mx-auto flex max-w-4xl flex-col items-center">
+					<div class="mb-5 flex items-center gap-3">
+						<span class="h-px w-10 bg-border/60"></span>
+						<span class="font-mono text-[10px] uppercase tracking-[0.22em] text-muted-foreground/80">
+							{"Works with"}
+						</span>
+						<span class="h-px w-10 bg-border/60"></span>
 					</div>
+					<AgentIconsRow size={30} />
 				</div>
-			</div>
-		</section>
-
-		<!-- Supported agents band -->
-		<section class="relative px-4 pb-24 md:px-6 md:pb-28">
-			<div class="mx-auto flex max-w-4xl flex-col items-center">
-				<div class="mb-5 flex items-center gap-3">
-					<span class="h-px w-10 bg-border/60"></span>
-					<span class="font-mono text-[10px] uppercase tracking-[0.22em] text-muted-foreground/80">
-						{"Works with"}
-					</span>
-					<span class="h-px w-10 bg-border/60"></span>
-				</div>
-				<AgentIconsRow size={30} />
-			</div>
-		</section>
+			</section>
+		</div>
 
 		<!-- What is an ADE? -->
 		<section class="border-t border-border/50 px-4 py-24 md:px-6 md:py-32">


### PR DESCRIPTION
Shader now spans the full hero + "Works with" region instead of clipping at the agents band. Rebalanced uniforms and vignette so the warm glow distributes evenly across the viewport.

- Merged hero and agents sections under one shader container
- originY 0.95→0.5, offsetY 0.25→0, scale 1.4→1.25 for even distribution
- Softened palette (softness 0.55→0.6, intensity 0.85→0.92)
- Dropped center-darkening vignette, pushed bottom fade from 45%→55%

Fixes the visible seam where the shader stopped mid-page.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Extends the hero shader behind the “Works with” band to create one continuous glow and remove the mid-page seam. Tweaks uniforms and vignette so the gradient spreads evenly across the viewport.

- **Refactors**
  - Wrapped hero and agents band in a single shader container.
  - Rebalanced uniforms: originY 0.95→0.5, offsetY 0.25→0, scale 1.4→1.25.
  - Palette/vignette tweaks: softness 0.55→0.6, intensity 0.85→0.92; removed center-dark vignette and pushed bottom fade to 55% with a smoother ramp.

<sup>Written for commit 14594a6d1f1dcec55a9f114e5bf32addde582991. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

