### PR TITLE
style(website): restore fully-rounded nav bar

### DIFF
--- a/packages/website/src/lib/components/header.svelte
+++ b/packages/website/src/lib/components/header.svelte
@@ -31,7 +31,7 @@ const mobileNavLinkClass =
 
 <header class="fixed top-4 left-1/2 z-50 w-[calc(100%-3rem)] max-w-4xl -translate-x-1/2">
 	<div
-		class="flex items-center justify-between rounded-2xl bg-card/45 px-4 py-2.5 backdrop-blur-[30px]"
+		class="flex items-center justify-between rounded-full bg-card/45 px-4 py-2.5 backdrop-blur-[30px]"
 	>
 		<div class="flex shrink-0 items-center">
 			<a


### PR DESCRIPTION
Revert header container from `rounded-2xl` back to `rounded-full` so the floating nav reads as a pill again.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restore the floating nav’s pill shape by changing the header container from `rounded-2xl` to `rounded-full` in `packages/website/src/lib/components/header.svelte`. This brings the navbar back to the intended fully rounded design.

<sup>Written for commit 7dc029cd4412595c98a1a8e21dac9c093cf1ccba. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

