### PR TITLE
chore: add agent skill symlinks to .github/skills

### DIFF
--- a/.agents/skills
+++ b/.agents/skills
@@ -1,0 +1,1 @@
+../.github/skills

--- a/.claude/skills
+++ b/.claude/skills
@@ -1,0 +1,1 @@
+../.github/skills

--- a/.codex/skills
+++ b/.codex/skills
@@ -1,0 +1,1 @@
+../.github/skills


### PR DESCRIPTION
## Summary

- Add symlinks so `.agents/skills`, `.claude/skills`, and `.codex/skills` all resolve to the shared `.github/skills` directory.

## Changes

- New symlinks: `.agents/skills`, `.claude/skills`, `.codex/skills` → `../.github/skills`.

## Test plan

- `ls -la .agents/skills .claude/skills .codex/skills` resolves to the same `.github/skills` contents.

## Screenshots

N/A

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add symlinks so `.agents/skills`, `.claude/skills`, and `.codex/skills` all point to the shared `.github/skills` directory. This keeps a single source of truth so all tools read the same skills set.

<sup>Written for commit 9f9eddada9051a37ccdf0b5b473c31fcae88c471. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

