### PR TITLE
fix(markdown): restore streaming word fade

### DIFF
--- a/packages/desktop/src/lib/acp/components/messages/markdown-text.svelte
+++ b/packages/desktop/src/lib/acp/components/messages/markdown-text.svelte
@@ -73,6 +73,17 @@ interface Props {
 	onRevealActivityChange?: (active: boolean) => void;
 }
 
+type StreamingWordFadeParams = {
+	active: boolean;
+	marker: string;
+	resetKey: string;
+};
+
+type TextSegment = {
+	text: string;
+	isWordLike: boolean;
+};
+
 let {
 	text,
 	isStreaming = false,
@@ -100,7 +111,7 @@ const reveal: StreamingRevealController = createStreamingRevealController(
 let hasStreamingSession = $state(false);
 let wasStreaming = false;
 let seedRevealFromSource = $state(false);
-let lastRevealKey = "";
+let lastRevealKey = $state("");
 
 // Fetch and cache repo context for enhancing commit badges
 let repoContext = $state<RepoContext | null>(null);
@@ -387,6 +398,140 @@ function openExternalLink(url: string) {
 	openUrl(url);
 }
 
+function shouldSkipWordFade(textNode: Text): boolean {
+	const parent = textNode.parentElement;
+	if (!parent) {
+		return true;
+	}
+
+	return (
+		parent.closest(
+			"[data-reveal-skip], pre, code, button, .file-path-badge, .file-path-badge-placeholder, .github-badge-placeholder"
+		) !== null
+	);
+}
+
+function segmentTextForFade(textValue: string): TextSegment[] {
+	const segments: TextSegment[] = [];
+	const parts = textValue.split(/(\s+)/);
+
+	for (const part of parts) {
+		if (part.length === 0) {
+			continue;
+		}
+
+		segments.push({
+			text: part,
+			isWordLike: /^\s+$/.test(part) === false,
+		});
+	}
+
+	return segments;
+}
+
+function replaceTextNodeWithFadedSuffix(textNode: Text, animateFromOffset: number): void {
+	const textValue = textNode.nodeValue ?? "";
+	const parent = textNode.parentNode;
+	if (!parent || textValue.length === 0 || animateFromOffset >= textValue.length) {
+		return;
+	}
+
+	const fragment = document.createDocumentFragment();
+	const stablePrefix = textValue.slice(0, animateFromOffset);
+	if (stablePrefix.length > 0) {
+		fragment.append(document.createTextNode(stablePrefix));
+	}
+
+	for (const segment of segmentTextForFade(textValue.slice(animateFromOffset))) {
+		if (!segment.isWordLike) {
+			fragment.append(document.createTextNode(segment.text));
+			continue;
+		}
+
+		const span = document.createElement("span");
+		span.className = "sd-word-fade";
+		span.textContent = segment.text;
+		fragment.append(span);
+	}
+
+	parent.replaceChild(fragment, textNode);
+}
+
+function applyStreamingWordFade(node: HTMLElement, animateFromTextOffset: number): void {
+	const textNodes: Text[] = [];
+	const walker = document.createTreeWalker(node, NodeFilter.SHOW_TEXT, {
+		acceptNode(textNode) {
+			return textNode instanceof Text && !shouldSkipWordFade(textNode)
+				? NodeFilter.FILTER_ACCEPT
+				: NodeFilter.FILTER_REJECT;
+		},
+	});
+
+	let currentNode = walker.nextNode();
+	while (currentNode !== null) {
+		if (currentNode instanceof Text) {
+			textNodes.push(currentNode);
+		}
+		currentNode = walker.nextNode();
+	}
+
+	let textOffset = 0;
+	for (const textNode of textNodes) {
+		const textValue = textNode.nodeValue ?? "";
+		const nextOffset = textOffset + textValue.length;
+		if (nextOffset > animateFromTextOffset) {
+			replaceTextNodeWithFadedSuffix(textNode, Math.max(0, animateFromTextOffset - textOffset));
+		}
+		textOffset = nextOffset;
+	}
+}
+
+function canonicalStreamingWordFade(node: HTMLElement, initialParams: StreamingWordFadeParams) {
+	let params = initialParams;
+	let lastTextContent = "";
+	let lastResetKey = initialParams.resetKey;
+	let scheduledVersion = 0;
+
+	function schedule(): void {
+		scheduledVersion += 1;
+		const version = scheduledVersion;
+		queueMicrotask(() => {
+			if (version !== scheduledVersion) {
+				return;
+			}
+
+			if (params.resetKey !== lastResetKey) {
+				lastTextContent = "";
+				lastResetKey = params.resetKey;
+			}
+
+			if (!params.active || params.marker.length === 0) {
+				lastTextContent = "";
+				return;
+			}
+
+			const currentTextContent = node.textContent ?? "";
+			const animateFromTextOffset = currentTextContent.startsWith(lastTextContent)
+				? lastTextContent.length
+				: 0;
+			applyStreamingWordFade(node, animateFromTextOffset);
+			lastTextContent = currentTextContent;
+		});
+	}
+
+	schedule();
+
+	return {
+		update(nextParams: StreamingWordFadeParams) {
+			params = nextParams;
+			schedule();
+		},
+		destroy() {
+			scheduledVersion += 1;
+		},
+	};
+}
+
 /**
  * Handle click events on interactive elements within rendered markdown.
  * - External links: opens in system browser
@@ -505,6 +650,11 @@ function handleKeydown(event: KeyboardEvent) {
 		tabindex="0"
 		onclick={handleClick}
 		onkeydown={handleKeydown}
+		use:canonicalStreamingWordFade={{
+			active: isRenderingReveal && streamingHtml !== null && !streamingHasSpecialBlocks,
+			marker: streamingHtml ?? "",
+			resetKey: lastRevealKey,
+		}}
 	>
 		{#if streamingHtml}
 			{#if streamingHasSpecialBlocks}

--- a/packages/desktop/src/lib/acp/components/messages/markdown-text.svelte.vitest.ts
+++ b/packages/desktop/src/lib/acp/components/messages/markdown-text.svelte.vitest.ts
@@ -803,7 +803,7 @@ describe("MarkdownText", () => {
 	});
 
 	describe("streaming reveal behavior", () => {
-		it("updates streamed text without reintroducing live-word animation spans", async () => {
+		it("does not re-animate existing words when streaming text grows", async () => {
 			const view = render(MarkdownText, {
 				text: "hello world",
 				isStreaming: true,
@@ -811,7 +811,8 @@ describe("MarkdownText", () => {
 			});
 
 			await waitFor(() => {
-				expect(view.container.textContent).toContain("hello world");
+				const fades = view.container.querySelectorAll(".sd-word-fade");
+				expect(fades.length).toBeGreaterThan(0);
 			});
 
 			await view.rerender({
@@ -821,12 +822,20 @@ describe("MarkdownText", () => {
 			});
 
 			await waitFor(() => {
-				expect(view.container.textContent).toContain("hello");
-				expect(view.container.textContent).toContain("world");
-				expect(view.container.textContent).toContain("foo");
-			});
+				const section = view.container.querySelector(".markdown-content");
+				expect(section).not.toBeNull();
+				if (!section) {
+					throw new Error("Expected markdown content");
+				}
 
-			expect(view.container.querySelector(".markdown-content")).not.toBeNull();
+				const html = section.innerHTML;
+				expect(html).not.toContain('<span class="sd-word-fade">hello</span>');
+				expect(html).not.toContain('<span class="sd-word-fade">world</span>');
+				expect(html).toContain('<span class="sd-word-fade">foo</span>');
+				expect(section.textContent).toContain("hello");
+				expect(section.textContent).toContain("world");
+				expect(section.textContent).toContain("foo");
+			});
 		});
 
 		it("renders canonical inline markdown while streaming is active", async () => {
@@ -846,6 +855,7 @@ describe("MarkdownText", () => {
 
 			await waitFor(() => {
 				expect(view.container.querySelector(".markdown-content strong")?.textContent).toBe("bold");
+				expect(view.container.querySelector(".sd-word-fade")?.textContent).toBe("bold");
 			});
 		});
 
@@ -915,7 +925,7 @@ describe("MarkdownText", () => {
 				expect(rendered?.textContent).toBe("bold");
 			});
 
-			expect(view.container.querySelector(".markdown-content")).not.toBeNull();
+			expect(view.container.querySelector(".sd-word-fade")).toBeNull();
 		});
 
 		it("does not restart reveal from the beginning after a remount with the same reveal key", async () => {


### PR DESCRIPTION
## Summary
Streaming markdown keeps the canonical renderer and gets the word-fade feel back.

The reveal path now post-processes raw canonical streaming HTML and wraps only newly revealed text in `.sd-word-fade`. Existing words stay stable on subsequent streaming updates, so the animation feels like the old live renderer without bringing back the partial markdown parser that broke tables.

## What changed
- add a streaming-only DOM action that fades newly revealed canonical HTML text
- skip code, badges, and other reveal-skip placeholders so mounted components and code blocks stay stable
- keep the action off fallback plaintext and special-block component rendering, where Svelte owns the child DOM
- restore tests for word-fade spans and no re-animation of previously revealed words

## Testing
- `cd packages/desktop && bunx vitest run src/lib/acp/components/messages/markdown-text.svelte.vitest.ts --reporter=dot`
- `cd packages/desktop && bun run check`

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Codex](https://img.shields.io/badge/GPT--5.4-000000)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restores the streaming word fade effect for canonical markdown rendering by animating only newly revealed words. Keeps the canonical renderer to avoid table regressions and skips code and special blocks.

- **Bug Fixes**
  - Added a streaming-only DOM action that wraps only new text in `.sd-word-fade`.
  - Skips `pre/code`, badges, and `[data-reveal-skip]` regions; leaves Svelte-owned blocks untouched.
  - Prevents re-animation of existing words; updated tests to cover fade spans and stability.

<sup>Written for commit c1f559511e9a13c8fef9d3e5cb8f3e6d0be28037. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

