### PR TITLE
fix(markdown): align word fade around skipped content

### DIFF
--- a/packages/desktop/src/lib/acp/components/messages/markdown-text.svelte
+++ b/packages/desktop/src/lib/acp/components/messages/markdown-text.svelte
@@ -457,7 +457,7 @@ function replaceTextNodeWithFadedSuffix(textNode: Text, animateFromOffset: numbe
 	parent.replaceChild(fragment, textNode);
 }
 
-function applyStreamingWordFade(node: HTMLElement, animateFromTextOffset: number): void {
+function collectWordFadeTextNodes(node: HTMLElement): Text[] {
 	const textNodes: Text[] = [];
 	const walker = document.createTreeWalker(node, NodeFilter.SHOW_TEXT, {
 		acceptNode(textNode) {
@@ -475,6 +475,18 @@ function applyStreamingWordFade(node: HTMLElement, animateFromTextOffset: number
 		currentNode = walker.nextNode();
 	}
 
+	return textNodes;
+}
+
+function getWordFadeTextContent(node: HTMLElement): string {
+	return collectWordFadeTextNodes(node)
+		.map((textNode) => textNode.nodeValue ?? "")
+		.join("");
+}
+
+function applyStreamingWordFade(node: HTMLElement, animateFromTextOffset: number): void {
+	const textNodes = collectWordFadeTextNodes(node);
+
 	let textOffset = 0;
 	for (const textNode of textNodes) {
 		const textValue = textNode.nodeValue ?? "";
@@ -488,7 +500,7 @@ function applyStreamingWordFade(node: HTMLElement, animateFromTextOffset: number
 
 function canonicalStreamingWordFade(node: HTMLElement, initialParams: StreamingWordFadeParams) {
 	let params = initialParams;
-	let lastTextContent = "";
+	let lastWordFadeTextContent = "";
 	let lastResetKey = initialParams.resetKey;
 	let scheduledVersion = 0;
 
@@ -501,21 +513,23 @@ function canonicalStreamingWordFade(node: HTMLElement, initialParams: StreamingW
 			}
 
 			if (params.resetKey !== lastResetKey) {
-				lastTextContent = "";
+				lastWordFadeTextContent = "";
 				lastResetKey = params.resetKey;
 			}
 
 			if (!params.active || params.marker.length === 0) {
-				lastTextContent = "";
+				lastWordFadeTextContent = "";
 				return;
 			}
 
-			const currentTextContent = node.textContent ?? "";
-			const animateFromTextOffset = currentTextContent.startsWith(lastTextContent)
-				? lastTextContent.length
+			const currentWordFadeTextContent = getWordFadeTextContent(node);
+			const animateFromTextOffset = currentWordFadeTextContent.startsWith(
+				lastWordFadeTextContent
+			)
+				? lastWordFadeTextContent.length
 				: 0;
 			applyStreamingWordFade(node, animateFromTextOffset);
-			lastTextContent = currentTextContent;
+			lastWordFadeTextContent = currentWordFadeTextContent;
 		});
 	}
 

--- a/packages/desktop/src/lib/acp/components/messages/markdown-text.svelte.vitest.ts
+++ b/packages/desktop/src/lib/acp/components/messages/markdown-text.svelte.vitest.ts
@@ -155,6 +155,11 @@ function renderCanonicalTestMarkdown(text: string): string {
 		return `<pre class="streaming-code"><code>${code}</code></pre>`;
 	}
 
+	if (text.startsWith("before skip after")) {
+		const suffix = text.includes(" after new") ? " new" : "";
+		return `<p>before <span data-reveal-skip>skip</span> after${suffix}</p>`;
+	}
+
 	return `<p>${text
 		.replace("**bold**", "<strong>bold</strong>")
 		.replace("[Acepe](https://acepe.dev)", '<a href="https://acepe.dev">Acepe</a>')}</p>`;
@@ -835,6 +840,38 @@ describe("MarkdownText", () => {
 				expect(section.textContent).toContain("hello");
 				expect(section.textContent).toContain("world");
 				expect(section.textContent).toContain("foo");
+			});
+		});
+
+		it("keeps word-fade offsets aligned when skipped reveal content precedes new text", async () => {
+			const view = render(MarkdownText, {
+				text: "before skip after",
+				isStreaming: true,
+				streamingAnimationMode: "smooth",
+			});
+
+			await waitFor(() => {
+				expect(view.container.querySelector('[data-reveal-skip]')?.textContent).toBe("skip");
+				expect(view.container.textContent).toContain("before skip after");
+			});
+
+			await view.rerender({
+				text: "before skip after new",
+				isStreaming: true,
+				streamingAnimationMode: "smooth",
+			});
+
+			await waitFor(() => {
+				const section = view.container.querySelector(".markdown-content");
+				expect(section).not.toBeNull();
+				if (!section) {
+					throw new Error("Expected markdown content");
+				}
+
+				const html = section.innerHTML;
+				expect(html).not.toContain('<span class="sd-word-fade">before</span>');
+				expect(html).not.toContain('<span class="sd-word-fade">after</span>');
+				expect(html).toContain('<span class="sd-word-fade">new</span>');
 			});
 		});
 


### PR DESCRIPTION
## Summary
Word-fade animation now stays aligned when canonical streaming markdown contains skipped regions such as badges or other `data-reveal-skip` content.

The previous offset compared full container text, including skipped content, but applied the fade boundary only to fade-eligible text nodes. When skipped text appeared before new streamed words, the offset could overshoot and leave the newly streamed words unanimated. This patch tracks the previous baseline using the same fade-eligible text nodes that the animation pass mutates.

## Testing
- `cd packages/desktop && bunx vitest run src/lib/acp/components/messages/markdown-text.svelte.vitest.ts --reporter=dot`
- `cd packages/desktop && bun run check`

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Codex](https://img.shields.io/badge/GPT--5.4-000000)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes misaligned streaming word-fade when markdown includes skipped reveal regions (like badges). Offsets now track only fade-eligible text, so new streamed words animate correctly even after `data-reveal-skip` content.

- **Bug Fixes**
  - Compute baseline from fade-eligible text nodes via new helpers, avoiding offset mismatch with skipped `data-reveal-skip` content.
  - Added a test ensuring words after skipped content fade as expected.

<sup>Written for commit 043bd27912f24e004b2d1c8cc5f4e485168cf38a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

