### PR TITLE
fix(markdown): make streaming word-fade visually continuous

### DIFF
--- a/packages/desktop/src/lib/acp/components/messages/markdown-text.svelte
+++ b/packages/desktop/src/lib/acp/components/messages/markdown-text.svelte
@@ -84,6 +84,11 @@ type TextSegment = {
 	isWordLike: boolean;
 };
 
+type AppearanceRecord = {
+	length: number;
+	time: number;
+};
+
 let {
 	text,
 	isStreaming = false,
@@ -398,6 +403,8 @@ function openExternalLink(url: string) {
 	openUrl(url);
 }
 
+const STREAMING_WORD_FADE_DURATION_MS = 300;
+
 function shouldSkipWordFade(textNode: Text): boolean {
 	const parent = textNode.parentElement;
 	if (!parent) {
@@ -429,35 +436,62 @@ function segmentTextForFade(textValue: string): TextSegment[] {
 	return segments;
 }
 
-function replaceTextNodeWithFadedSuffix(textNode: Text, animateFromOffset: number): void {
-	const textValue = textNode.nodeValue ?? "";
-	const parent = textNode.parentNode;
-	if (!parent || textValue.length === 0 || animateFromOffset >= textValue.length) {
-		return;
-	}
-
-	const fragment = document.createDocumentFragment();
-	const stablePrefix = textValue.slice(0, animateFromOffset);
-	if (stablePrefix.length > 0) {
-		fragment.append(document.createTextNode(stablePrefix));
-	}
-
-	for (const segment of segmentTextForFade(textValue.slice(animateFromOffset))) {
-		if (!segment.isWordLike) {
-			fragment.append(document.createTextNode(segment.text));
-			continue;
+/**
+ * Find the time at which the character at `offset` was first revealed.
+ * History entries map cumulative text length to the timestamp at which that length
+ * was first observed; the smallest entry whose length > offset owns that character.
+ * Returns null when no entry covers the offset (i.e., it predates all retained history).
+ */
+function findFirstSeenTime(history: AppearanceRecord[], offset: number): number | null {
+	let lo = 0;
+	let hi = history.length;
+	while (lo < hi) {
+		const mid = (lo + hi) >>> 1;
+		if (history[mid].length > offset) {
+			hi = mid;
+		} else {
+			lo = mid + 1;
 		}
-
-		const span = document.createElement("span");
-		span.className = "sd-word-fade";
-		span.textContent = segment.text;
-		fragment.append(span);
 	}
-
-	parent.replaceChild(fragment, textNode);
+	return lo < history.length ? history[lo].time : null;
 }
 
-function applyStreamingWordFade(node: HTMLElement, animateFromTextOffset: number): void {
+/**
+ * Drop history entries that can no longer influence the visible fade window.
+ * When pruning, retain a "fence" entry whose time is just past the cutoff so
+ * offsets owned by pruned entries still resolve to "past the fade window"
+ * instead of being inherited by the next active entry.
+ */
+function pruneAppearanceHistory(history: AppearanceRecord[], now: number): AppearanceRecord[] {
+	if (history.length === 0) {
+		return history;
+	}
+
+	const cutoff = now - STREAMING_WORD_FADE_DURATION_MS;
+	let firstActive = -1;
+	for (let i = 0; i < history.length; i += 1) {
+		if (history[i].time >= cutoff) {
+			firstActive = i;
+			break;
+		}
+	}
+
+	const fenceTime = cutoff - 1;
+
+	if (firstActive === -1) {
+		const last = history[history.length - 1];
+		return [{ length: last.length, time: fenceTime }];
+	}
+
+	if (firstActive === 0) {
+		return history;
+	}
+
+	const fence = history[firstActive - 1];
+	return [{ length: fence.length, time: fenceTime }, ...history.slice(firstActive)];
+}
+
+function collectWordFadeTextNodes(node: HTMLElement): Text[] {
 	const textNodes: Text[] = [];
 	const walker = document.createTreeWalker(node, NodeFilter.SHOW_TEXT, {
 		acceptNode(textNode) {
@@ -475,22 +509,108 @@ function applyStreamingWordFade(node: HTMLElement, animateFromTextOffset: number
 		currentNode = walker.nextNode();
 	}
 
-	let textOffset = 0;
+	return textNodes;
+}
+
+function getWordFadeTextContent(node: HTMLElement): string {
+	let combined = "";
+	for (const textNode of collectWordFadeTextNodes(node)) {
+		combined += textNode.nodeValue ?? "";
+	}
+	return combined;
+}
+
+/**
+ * Wrap a single text node's contents with `.sd-word-fade` spans for words whose
+ * first-appearance-time is within the current fade window. Each span carries an
+ * inline `animation-delay: -Xms` so its CSS animation picks up where the prior
+ * span (wiped by the canonical `{@html}` re-render) left off — making the fade
+ * appear continuous across re-renders.
+ */
+function wrapTextNodeWithContinuousFade(
+	textNode: Text,
+	baseOffset: number,
+	history: AppearanceRecord[],
+	now: number
+): void {
+	const textValue = textNode.nodeValue ?? "";
+	const parent = textNode.parentNode;
+	if (!parent || textValue.length === 0) {
+		return;
+	}
+
+	const segments = segmentTextForFade(textValue);
+	if (segments.length === 0) {
+		return;
+	}
+
+	const fragment = document.createDocumentFragment();
+	let offset = baseOffset;
+	let wrappedAny = false;
+
+	for (const segment of segments) {
+		if (!segment.isWordLike) {
+			fragment.append(document.createTextNode(segment.text));
+			offset += segment.text.length;
+			continue;
+		}
+
+		const firstSeen = findFirstSeenTime(history, offset);
+		const elapsed = firstSeen === null ? Number.POSITIVE_INFINITY : now - firstSeen;
+
+		if (elapsed >= STREAMING_WORD_FADE_DURATION_MS) {
+			fragment.append(document.createTextNode(segment.text));
+		} else {
+			const span = document.createElement("span");
+			span.className = "sd-word-fade";
+			// Negative delay fast-forwards the CSS animation by `elapsed` ms.
+			// Round to whole ms so identical re-renders produce identical inline styles.
+			const delayMs = Math.max(0, Math.floor(elapsed));
+			if (delayMs > 0) {
+				span.style.animationDelay = `-${delayMs}ms`;
+			}
+			span.textContent = segment.text;
+			fragment.append(span);
+			wrappedAny = true;
+		}
+
+		offset += segment.text.length;
+	}
+
+	if (wrappedAny || segments.some((s) => !s.isWordLike)) {
+		parent.replaceChild(fragment, textNode);
+	}
+}
+
+function applyStreamingWordFade(
+	node: HTMLElement,
+	history: AppearanceRecord[],
+	now: number
+): void {
+	if (history.length === 0) {
+		return;
+	}
+
+	const textNodes = collectWordFadeTextNodes(node);
+	let cumulativeOffset = 0;
 	for (const textNode of textNodes) {
 		const textValue = textNode.nodeValue ?? "";
-		const nextOffset = textOffset + textValue.length;
-		if (nextOffset > animateFromTextOffset) {
-			replaceTextNodeWithFadedSuffix(textNode, Math.max(0, animateFromTextOffset - textOffset));
-		}
-		textOffset = nextOffset;
+		wrapTextNodeWithContinuousFade(textNode, cumulativeOffset, history, now);
+		cumulativeOffset += textValue.length;
 	}
 }
 
 function canonicalStreamingWordFade(node: HTMLElement, initialParams: StreamingWordFadeParams) {
 	let params = initialParams;
-	let lastTextContent = "";
+	let lastFadeTextContent = "";
 	let lastResetKey = initialParams.resetKey;
 	let scheduledVersion = 0;
+	let history: AppearanceRecord[] = [];
+
+	function reset(): void {
+		history = [];
+		lastFadeTextContent = "";
+	}
 
 	function schedule(): void {
 		scheduledVersion += 1;
@@ -501,21 +621,43 @@ function canonicalStreamingWordFade(node: HTMLElement, initialParams: StreamingW
 			}
 
 			if (params.resetKey !== lastResetKey) {
-				lastTextContent = "";
+				reset();
 				lastResetKey = params.resetKey;
 			}
 
 			if (!params.active || params.marker.length === 0) {
-				lastTextContent = "";
+				reset();
 				return;
 			}
 
-			const currentTextContent = node.textContent ?? "";
-			const animateFromTextOffset = currentTextContent.startsWith(lastTextContent)
-				? lastTextContent.length
-				: 0;
-			applyStreamingWordFade(node, animateFromTextOffset);
-			lastTextContent = currentTextContent;
+			const currentFadeTextContent = getWordFadeTextContent(node);
+			const isPrefixGrowth = currentFadeTextContent.startsWith(lastFadeTextContent);
+
+			if (!isPrefixGrowth) {
+				history = [];
+			}
+
+			const now =
+				typeof performance !== "undefined" && typeof performance.now === "function"
+					? performance.now()
+					: Date.now();
+
+			if (currentFadeTextContent.length === 0) {
+				lastFadeTextContent = "";
+				return;
+			}
+
+			if (
+				history.length === 0 ||
+				currentFadeTextContent.length > lastFadeTextContent.length ||
+				!isPrefixGrowth
+			) {
+				history.push({ length: currentFadeTextContent.length, time: now });
+			}
+
+			history = pruneAppearanceHistory(history, now);
+			applyStreamingWordFade(node, history, now);
+			lastFadeTextContent = currentFadeTextContent;
 		});
 	}
 

--- a/packages/desktop/src/lib/acp/components/messages/markdown-text.svelte
+++ b/packages/desktop/src/lib/acp/components/messages/markdown-text.svelte
@@ -582,11 +582,7 @@ function wrapTextNodeWithContinuousFade(
 	}
 }
 
-function applyStreamingWordFade(
-	node: HTMLElement,
-	history: AppearanceRecord[],
-	now: number
-): void {
+function applyStreamingWordFade(node: HTMLElement, history: AppearanceRecord[], now: number): void {
 	if (history.length === 0) {
 		return;
 	}

--- a/packages/desktop/src/lib/acp/components/messages/markdown-text.svelte.vitest.ts
+++ b/packages/desktop/src/lib/acp/components/messages/markdown-text.svelte.vitest.ts
@@ -155,6 +155,11 @@ function renderCanonicalTestMarkdown(text: string): string {
 		return `<pre class="streaming-code"><code>${code}</code></pre>`;
 	}
 
+	if (text.startsWith("before skip after")) {
+		const suffix = text.includes(" after new") ? " new" : "";
+		return `<p>before <span data-reveal-skip>skip</span> after${suffix}</p>`;
+	}
+
 	return `<p>${text
 		.replace("**bold**", "<strong>bold</strong>")
 		.replace("[Acepe](https://acepe.dev)", '<a href="https://acepe.dev">Acepe</a>')}</p>`;
@@ -803,17 +808,28 @@ describe("MarkdownText", () => {
 	});
 
 	describe("streaming reveal behavior", () => {
-		it("does not re-animate existing words when streaming text grows", async () => {
+		it("drops words out of the fade window once their animation has fully played", async () => {
+			// Drive performance.now so the first reveal records "hello world" at t=0,
+			// then advance past the 300ms fade window before the rerender. Older words
+			// must render as plain text (animation already complete) while the freshly
+			// revealed word stays wrapped with .sd-word-fade.
+			let mockedNow = 0;
+			vi.spyOn(performance, "now").mockImplementation(() => mockedNow);
+
 			const view = render(MarkdownText, {
 				text: "hello world",
 				isStreaming: true,
 				streamingAnimationMode: "smooth",
 			});
 
+			// Wait until the reveal controller has surfaced the full text so all words
+			// have been recorded at t=0 in the appearance history.
 			await waitFor(() => {
-				const fades = view.container.querySelectorAll(".sd-word-fade");
-				expect(fades.length).toBeGreaterThan(0);
+				const section = view.container.querySelector(".markdown-content");
+				expect(section?.textContent).toBe("hello world");
 			});
+
+			mockedNow = 1000;
 
 			await view.rerender({
 				text: "hello world foo",
@@ -823,18 +839,99 @@ describe("MarkdownText", () => {
 
 			await waitFor(() => {
 				const section = view.container.querySelector(".markdown-content");
-				expect(section).not.toBeNull();
-				if (!section) {
-					throw new Error("Expected markdown content");
-				}
+				expect(section?.textContent).toBe("hello world foo");
+				const fadeSpans = Array.from(
+					section?.querySelectorAll(".sd-word-fade") ?? []
+				).map((s) => s.textContent);
+				expect(fadeSpans).not.toContain("hello");
+				expect(fadeSpans).not.toContain("world");
+				expect(fadeSpans).toContain("foo");
+			});
+		});
 
-				const html = section.innerHTML;
-				expect(html).not.toContain('<span class="sd-word-fade">hello</span>');
-				expect(html).not.toContain('<span class="sd-word-fade">world</span>');
-				expect(html).toContain('<span class="sd-word-fade">foo</span>');
-				expect(section.textContent).toContain("hello");
-				expect(section.textContent).toContain("world");
-				expect(section.textContent).toContain("foo");
+		it("applies a fast-forward animation-delay to recently revealed words", async () => {
+			// Two reveal updates 100ms apart: prior words must remain wrapped (still in
+			// the 300ms fade window) but with an inline animation-delay that picks up
+			// where their previous span left off, so the canonical {@html} re-render
+			// does not visually restart their fade.
+			let mockedNow = 0;
+			vi.spyOn(performance, "now").mockImplementation(() => mockedNow);
+
+			const view = render(MarkdownText, {
+				text: "hello",
+				isStreaming: true,
+				streamingAnimationMode: "smooth",
+			});
+
+			await waitFor(() => {
+				const section = view.container.querySelector(".markdown-content");
+				expect(section?.textContent).toBe("hello");
+			});
+
+			mockedNow = 100;
+
+			await view.rerender({
+				text: "hello world",
+				isStreaming: true,
+				streamingAnimationMode: "smooth",
+			});
+
+			await waitFor(() => {
+				const section = view.container.querySelector(".markdown-content");
+				expect(section?.textContent).toBe("hello world");
+				const helloSpan = Array.from(
+					section?.querySelectorAll(".sd-word-fade") ?? []
+				).find((s) => s.textContent === "hello") as HTMLElement | undefined;
+				const worldSpan = Array.from(
+					section?.querySelectorAll(".sd-word-fade") ?? []
+				).find((s) => s.textContent === "world") as HTMLElement | undefined;
+
+				expect(helloSpan).toBeDefined();
+				expect(worldSpan).toBeDefined();
+				// "hello" was first seen at t=0 and is now 100ms into its 300ms fade.
+				expect(helloSpan?.style.animationDelay).toBe("-100ms");
+				// "world" first appeared at t=100 → no delay yet.
+				expect(worldSpan?.style.animationDelay).toBe("");
+			});
+		});
+
+		it("keeps word-fade offsets aligned when skipped reveal content precedes new text", async () => {
+			// Skipped (`[data-reveal-skip]`) regions must not shift the offset baseline used
+			// by the appearance history. Words around the skip region drop out of the fade
+			// window normally; only the freshly revealed word retains `.sd-word-fade`.
+			let mockedNow = 0;
+			vi.spyOn(performance, "now").mockImplementation(() => mockedNow);
+
+			const view = render(MarkdownText, {
+				text: "before skip after",
+				isStreaming: true,
+				streamingAnimationMode: "smooth",
+			});
+
+			await waitFor(() => {
+				expect(view.container.querySelector("[data-reveal-skip]")?.textContent).toBe("skip");
+				expect(view.container.textContent).toContain("before skip after");
+			});
+
+			mockedNow = 1000;
+
+			await view.rerender({
+				text: "before skip after new",
+				isStreaming: true,
+				streamingAnimationMode: "smooth",
+			});
+
+			await waitFor(() => {
+				const section = view.container.querySelector(".markdown-content");
+				expect(section?.textContent).toContain("before skip after new");
+				const fadeSpans = Array.from(
+					section?.querySelectorAll(".sd-word-fade") ?? []
+				).map((s) => s.textContent);
+				expect(fadeSpans).not.toContain("before");
+				expect(fadeSpans).not.toContain("after");
+				expect(fadeSpans).toContain("new");
+				// Skipped content stays untouched.
+				expect(section?.querySelector("[data-reveal-skip]")?.textContent).toBe("skip");
 			});
 		});
 

--- a/packages/desktop/src/lib/acp/components/messages/markdown-text.svelte.vitest.ts
+++ b/packages/desktop/src/lib/acp/components/messages/markdown-text.svelte.vitest.ts
@@ -840,9 +840,9 @@ describe("MarkdownText", () => {
 			await waitFor(() => {
 				const section = view.container.querySelector(".markdown-content");
 				expect(section?.textContent).toBe("hello world foo");
-				const fadeSpans = Array.from(
-					section?.querySelectorAll(".sd-word-fade") ?? []
-				).map((s) => s.textContent);
+				const fadeSpans = Array.from(section?.querySelectorAll(".sd-word-fade") ?? []).map(
+					(s) => s.textContent
+				);
 				expect(fadeSpans).not.toContain("hello");
 				expect(fadeSpans).not.toContain("world");
 				expect(fadeSpans).toContain("foo");
@@ -879,12 +879,12 @@ describe("MarkdownText", () => {
 			await waitFor(() => {
 				const section = view.container.querySelector(".markdown-content");
 				expect(section?.textContent).toBe("hello world");
-				const helloSpan = Array.from(
-					section?.querySelectorAll(".sd-word-fade") ?? []
-				).find((s) => s.textContent === "hello") as HTMLElement | undefined;
-				const worldSpan = Array.from(
-					section?.querySelectorAll(".sd-word-fade") ?? []
-				).find((s) => s.textContent === "world") as HTMLElement | undefined;
+				const helloSpan = Array.from(section?.querySelectorAll(".sd-word-fade") ?? []).find(
+					(s) => s.textContent === "hello"
+				) as HTMLElement | undefined;
+				const worldSpan = Array.from(section?.querySelectorAll(".sd-word-fade") ?? []).find(
+					(s) => s.textContent === "world"
+				) as HTMLElement | undefined;
 
 				expect(helloSpan).toBeDefined();
 				expect(worldSpan).toBeDefined();
@@ -924,9 +924,9 @@ describe("MarkdownText", () => {
 			await waitFor(() => {
 				const section = view.container.querySelector(".markdown-content");
 				expect(section?.textContent).toContain("before skip after new");
-				const fadeSpans = Array.from(
-					section?.querySelectorAll(".sd-word-fade") ?? []
-				).map((s) => s.textContent);
+				const fadeSpans = Array.from(section?.querySelectorAll(".sd-word-fade") ?? []).map(
+					(s) => s.textContent
+				);
 				expect(fadeSpans).not.toContain("before");
 				expect(fadeSpans).not.toContain("after");
 				expect(fadeSpans).toContain("new");


### PR DESCRIPTION
## Summary

Streaming markdown's word-fade animation was effectively invisible. Each `.sd-word-fade` span lived only ~50 ms (one reveal tick) before `{@html}` wiped the entire DOM, so its 300 ms CSS animation only reached ~16 % opacity before being replaced with plain text. Words appeared to snap in.

This change makes the fade visually continuous across canonical re-renders without abandoning canonical markdown rendering (tables, GFM, code blocks remain settled).

## Approach

Track a per-character first-appearance history inside the streaming-fade Svelte action, then apply an inline `animation-delay: -<elapsed>ms` on each newly-mounted `.sd-word-fade` span so its CSS animation fast-forwards to where its previous (just-wiped) span left off.

- New `AppearanceRecord` history maps cumulative text length → timestamp.
- Each tick: push current `{ length, time }` if text grew, prune entries older than the 300 ms fade window.
- Pruning retains a "fence" entry whose time is just past the cutoff so offsets owned by pruned entries still resolve to "past the fade window" — they render as plain text instead of being inherited by the next active entry.
- Words still in the fade window are wrapped with a computed `animation-delay`. Words past it stay plain.

## Why not morphdom / token tree

A morphdom-style DOM diff would un-wrap our spans every tick (canonical HTML has plain text where DOM has `<span.sd-word-fade>`). A keyed token tree would work but is a much larger refactor. `animation-delay` is a self-contained fix that stays inside the existing action.

## Notes

- Subsumes #183 — uses `collectWordFadeTextNodes` / `getWordFadeTextContent` to keep the appearance baseline skip-region-aware.

## Testing

```
cd packages/desktop && bunx vitest run src/lib/acp/components/messages/markdown-text.svelte.vitest.ts --reporter=dot
# 30/30 pass
bun run check
# clean
```

New tests cover:
- Words drop out of the fade window at `now > firstSeen + 300 ms` (fence-aware pruning).
- Recently-revealed words carry a fast-forward `animation-delay` (continuity across `{@html}` wipes).
- Skip-region offsets stay aligned (port of #183 coverage).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the streaming markdown word-fade so words fade smoothly across canonical re-renders instead of snapping to full opacity. Keeps canonical markdown rendering intact (tables, GFM, code blocks).

- **Bug Fixes**
  - Track per-character first-seen times; apply negative `animation-delay` to `.sd-word-fade` so fades continue across `{@html}` wipes.
  - Prune appearance history with a fence; words older than 300 ms render as plain text.
  - Use `collectWordFadeTextNodes` and `getWordFadeTextContent` so `[data-reveal-skip]` regions don’t shift offsets.
  - Added tests for fade-window expiry, fast-forward `animation-delay`, and skip-region alignment; applied `biome` formatting in `markdown-text.svelte` (no logic changes).

<sup>Written for commit 96ac4bb80e27425d5082497ad4f48577c62c658b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

