### PR TITLE
fix: terminal/browser panels open behind agent panel in single mode

### DIFF
--- a/packages/desktop/src/lib/acp/components/session-list/session-list-ui.svelte
+++ b/packages/desktop/src/lib/acp/components/session-list/session-list-ui.svelte
@@ -607,7 +607,7 @@ function handleOpenGitPanel(event: MouseEvent, projectPath: string) {
 }
 
 const projectHeaderHoverActionButtonClass =
-	"flex items-center justify-center size-5 rounded text-muted-foreground transition-all hover:bg-accent hover:text-foreground opacity-50 group-hover:opacity-100 group-focus-within:opacity-100 focus-visible:opacity-100";
+	"flex items-center justify-center size-5 rounded text-muted-foreground transition-colors hover:bg-accent hover:text-foreground";
 
 function handleOpenFileExplorer(event: MouseEvent, group: SessionGroup): void {
 	event.stopPropagation();

--- a/packages/desktop/src/lib/acp/store/panel-store.svelte.ts
+++ b/packages/desktop/src/lib/acp/store/panel-store.svelte.ts
@@ -100,7 +100,12 @@ export class PanelStore {
 
 	private isTopLevelFullscreenTarget(panelId: string | null): boolean {
 		if (panelId === null) return false;
-		return this.findTopLevelWorkspacePanel(panelId) !== undefined;
+		if (this.findTopLevelWorkspacePanel(panelId) !== undefined) return true;
+		// Terminal and browser panels are stored outside workspacePanels but are
+		// valid top-level fullscreen targets.
+		if (this.terminalPanelGroups.some((g) => g.id === panelId)) return true;
+		if (this.browserPanels.some((p) => p.id === panelId)) return true;
+		return false;
 	}
 
 	private setFullscreenPanelTarget(panelId: string | null): void {
@@ -201,12 +206,25 @@ export class PanelStore {
 			this.switchFullscreen(panelId);
 		}
 		if (this.viewMode !== "multi") {
-			const panel = this.findTopLevelWorkspacePanel(panelId);
-			if (panel?.projectPath) {
-				this.focusedViewProjectPath = panel.projectPath;
+			const projectPath = this.resolveTopLevelPanelProjectPath(panelId);
+			if (projectPath) {
+				this.focusedViewProjectPath = projectPath;
 				this.scrollX = 0;
 			}
 		}
+	}
+
+	/**
+	 * Resolve the project path for any top-level panel (workspace, terminal, or browser).
+	 */
+	private resolveTopLevelPanelProjectPath(panelId: string): string | null {
+		const workspacePanel = this.findTopLevelWorkspacePanel(panelId);
+		if (workspacePanel) return workspacePanel.projectPath;
+		const terminalGroup = this.terminalPanelGroups.find((g) => g.id === panelId);
+		if (terminalGroup) return terminalGroup.projectPath;
+		const browserPanel = this.browserPanels.find((p) => p.id === panelId);
+		if (browserPanel) return browserPanel.projectPath;
+		return null;
 	}
 
 	private ensureOwnerPanelWidth(ownerPanelId: string, attachedWidth: number): void {

--- a/packages/desktop/src/lib/components/main-app-view/components/content/panels-container.svelte
+++ b/packages/desktop/src/lib/components/main-app-view/components/content/panels-container.svelte
@@ -152,6 +152,14 @@ const topLevelPanelsWithProject = $derived.by(() => {
 		}
 		topLevelPanels.push({ id: panel.id, projectPath: panel.projectPath });
 	}
+	// Terminal and browser panels are stored outside workspacePanels but are
+	// top-level panels that must be reachable as fullscreen targets in single mode.
+	for (const group of panelStore.terminalPanelGroups) {
+		topLevelPanels.push({ id: group.id, projectPath: group.projectPath });
+	}
+	for (const panel of panelStore.browserPanels) {
+		topLevelPanels.push({ id: panel.id, projectPath: panel.projectPath });
+	}
 	return topLevelPanels;
 });
 


### PR DESCRIPTION
## Summary

Terminal and browser panels now open correctly in single-panel view mode instead of being hidden behind the agent panel. A secondary fix removes the group-hover fade effect on project header action icons so each icon highlights independently.

## What changed

**Panel store: terminal/browser as first-class top-level panels** (`panel-store.svelte.ts`)

Terminal and browser panels are stored outside `workspacePanels`, but 3 key mechanisms only checked `workspacePanels` when resolving targets:

1. `isTopLevelFullscreenTarget` — didn't recognize terminal/browser panel IDs, routing them through the wrong fullscreen path.
2. `focusOpenedTopLevelPanel` — couldn't resolve project paths for terminal/browser panels, leaving `focusedViewProjectPath` unset and the panel invisible.
3. `topLevelPanelsWithProject` in `panels-container.svelte` — missed terminal/browser panels entirely, so single-mode view state fell back to the agent panel as fullscreen target.

All 3 sites now include terminal and browser panels. A new `resolveTopLevelPanelProjectPath` helper unifies the project-path lookup across workspace, terminal, and browser panels.

**Project header icon hover** (`session-list-ui.svelte`)

`projectHeaderHoverActionButtonClass` previously used `opacity-50 group-hover:opacity-100`, causing all 3 folder/terminal/browser icons to fade in together on row hover. Now each icon uses only per-icon `hover:bg-accent hover:text-foreground`, matching the rest of the app's icon hover behavior. `transition-all` narrowed to `transition-colors`.

## CI note

The `Frontend` CI job fails on `main` (pre-existing `runed`/`bun-test` ESM resolution issue). Unrelated to this PR.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Opus 4.6](https://img.shields.io/badge/Opus_4.6-D97757?logo=claude&logoColor=white)