### PR TITLE
feat(website): outstanding SEO across every public route

### DIFF
--- a/packages/website/src/app.html
+++ b/packages/website/src/app.html
@@ -4,33 +4,18 @@
 		<meta charset="utf-8" />
 		<meta name="viewport" content="width=device-width, initial-scale=1" />
 
-		<!-- Primary Meta Tags -->
-		<title>Acepe - The AI Agent Interface</title>
-		<meta name="title" content="Acepe - The AI Agent Interface" />
-		<meta
-			name="description"
-			content="A unified desktop interface for interacting with AI agents. Connect to ACP-compatible agents like Claude Code in a single, modern application."
-		/>
-
-		<!-- Open Graph / Facebook -->
-		<meta property="og:type" content="website" />
-		<meta property="og:url" content="https://acepe.dev/" />
-		<meta property="og:title" content="Acepe - The AI Agent Interface" />
-		<meta
-			property="og:description"
-			content="A unified desktop interface for interacting with AI agents. Connect to ACP-compatible agents like Claude Code in a single, modern application."
-		/>
-		<meta property="og:image" content="https://acepe.dev/og-image.png" />
-
-		<!-- Twitter -->
-		<meta property="twitter:card" content="summary_large_image" />
-		<meta property="twitter:url" content="https://acepe.dev/" />
-		<meta property="twitter:title" content="Acepe - The AI Agent Interface" />
-		<meta
-			property="twitter:description"
-			content="A unified desktop interface for interacting with AI agents. Connect to ACP-compatible agents like Claude Code in a single, modern application."
-		/>
-		<meta property="twitter:image" content="https://acepe.dev/og-image.png" />
+		<!--
+			Per-page SEO meta (title, description, canonical, OpenGraph, Twitter, JSON-LD)
+			is emitted by the centralized <Seo /> component in $lib/components/seo/seo.svelte.
+			This keeps every route's social cards and search snippets accurate and avoids
+			duplicate meta tags. Only static, always-applicable head tags live here.
+		-->
+		<meta name="application-name" content="Acepe" />
+		<meta name="apple-mobile-web-app-title" content="Acepe" />
+		<meta name="apple-mobile-web-app-capable" content="yes" />
+		<meta name="apple-mobile-web-app-status-bar-style" content="black-translucent" />
+		<meta name="format-detection" content="telephone=no" />
+		<meta name="color-scheme" content="dark" />
 
 		<!-- Fonts -->
 		<link rel="preconnect" href="https://fonts.googleapis.com" />

--- a/packages/website/src/lib/blog/blog-post-layout.svelte
+++ b/packages/website/src/lib/blog/blog-post-layout.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 import Header from "$lib/components/header.svelte";
+import Seo from "$lib/components/seo/seo.svelte";
 import { ArrowLeft } from "@lucide/svelte";
 import type { BlogPostMetadata } from "./types.js";
 import type { Snippet } from "svelte";
@@ -22,37 +23,62 @@ function formatDate(isoDate: string): string {
 	});
 }
 
-// Create JSON-LD structured data for BlogPosting (reactive to metadata)
-const jsonLd = $derived({
-	"@context": "https://schema.org",
-	"@type": "BlogPosting",
-	headline: metadata.title,
-	description: metadata.description,
-	datePublished: metadata.date,
-	author: {
-		"@type": "Organization",
-		name: metadata.author || "Acepe",
+const postUrl = $derived(`https://acepe.dev/blog/${metadata.slug}`);
+const ogImage = $derived(metadata.ogImage ?? "/og-image.png");
+
+const jsonLd = $derived([
+	{
+		"@context": "https://schema.org",
+		"@type": "BlogPosting",
+		headline: metadata.title,
+		description: metadata.description,
+		datePublished: metadata.date,
+		dateModified: metadata.date,
+		mainEntityOfPage: { "@type": "WebPage", "@id": postUrl },
+		image: ogImage.startsWith("http") ? ogImage : `https://acepe.dev${ogImage}`,
+		author: {
+			"@type": "Organization",
+			name: metadata.author || "Acepe",
+			url: "https://acepe.dev",
+		},
+		publisher: {
+			"@type": "Organization",
+			name: "Acepe",
+			url: "https://acepe.dev",
+			logo: {
+				"@type": "ImageObject",
+				url: "https://acepe.dev/favicon-512x512.png",
+			},
+		},
+		articleSection: metadata.category ?? "Product",
+		...(metadata.readingTimeMinutes
+			? { timeRequired: `PT${metadata.readingTimeMinutes}M` }
+			: {}),
 	},
-	publisher: {
-		"@type": "Organization",
-		name: "Acepe",
+	{
+		"@context": "https://schema.org",
+		"@type": "BreadcrumbList",
+		itemListElement: [
+			{ "@type": "ListItem", position: 1, name: "Home", item: "https://acepe.dev/" },
+			{ "@type": "ListItem", position: 2, name: "Blog", item: "https://acepe.dev/blog" },
+			{ "@type": "ListItem", position: 3, name: metadata.title, item: postUrl },
+		],
 	},
-});
+]);
 </script>
 
-<svelte:head>
-	<title>{metadata.title} - Acepe Blog</title>
-	<meta name="description" content={metadata.description} />
-	<meta property="og:title" content={metadata.title} />
-	<meta property="og:description" content={metadata.description} />
-	<meta property="og:type" content="article" />
-	<meta property="og:url" content="https://acepe.dev/blog/{metadata.slug}" />
-	{#if metadata.ogImage}
-		<meta property="og:image" content={metadata.ogImage} />
-	{/if}
-	<meta property="article:published_time" content={metadata.date} />
-	{@html `<script type="application/ld+json">${JSON.stringify(jsonLd)}<\/script>`}
-</svelte:head>
+<Seo
+	title={metadata.title}
+	description={metadata.description}
+	type="article"
+	image={ogImage}
+	imageAlt={metadata.title}
+	publishedTime={metadata.date}
+	modifiedTime={metadata.date}
+	author={metadata.author ?? "Acepe"}
+	canonical={`/blog/${metadata.slug}`}
+	jsonLd={jsonLd}
+/>
 
 <Header {showDownload} {showLogin} />
 

--- a/packages/website/src/lib/blog/blog-post-layout.svelte
+++ b/packages/website/src/lib/blog/blog-post-layout.svelte
@@ -26,6 +26,12 @@ function formatDate(isoDate: string): string {
 const postUrl = $derived(`https://acepe.dev/blog/${metadata.slug}`);
 const ogImage = $derived(metadata.ogImage ?? "/og-image.png");
 
+function toAbsoluteUrl(path: string): string {
+	if (path.startsWith("http")) return path;
+	const normalized = path.startsWith("/") ? path : `/${path}`;
+	return `https://acepe.dev${normalized}`;
+}
+
 const jsonLd = $derived([
 	{
 		"@context": "https://schema.org",
@@ -35,7 +41,7 @@ const jsonLd = $derived([
 		datePublished: metadata.date,
 		dateModified: metadata.date,
 		mainEntityOfPage: { "@type": "WebPage", "@id": postUrl },
-		image: ogImage.startsWith("http") ? ogImage : `https://acepe.dev${ogImage}`,
+		image: toAbsoluteUrl(ogImage),
 		author: {
 			"@type": "Organization",
 			name: metadata.author || "Acepe",

--- a/packages/website/src/lib/components/seo/json-ld.svelte
+++ b/packages/website/src/lib/components/seo/json-ld.svelte
@@ -2,13 +2,38 @@
 const description =
 	"A native desktop client for Claude Code, Codex, Cursor Agent, and any ACP-compatible AI agent. Same powerful agents, better interface.";
 
+const sameAs = [
+	"https://github.com/flazouh/acepe",
+];
+
 const organizationSchema = {
 	"@context": "https://schema.org",
 	"@type": "Organization",
 	name: "Acepe",
+	alternateName: "Acepe — The Agentic Developer Environment",
 	url: "https://acepe.dev",
-	logo: "https://acepe.dev/favicon-512x512.png",
+	logo: {
+		"@type": "ImageObject",
+		url: "https://acepe.dev/favicon-512x512.png",
+		width: 512,
+		height: 512,
+	},
 	description,
+	sameAs,
+};
+
+const websiteSchema = {
+	"@context": "https://schema.org",
+	"@type": "WebSite",
+	name: "Acepe",
+	url: "https://acepe.dev",
+	description,
+	publisher: {
+		"@type": "Organization",
+		name: "Acepe",
+		url: "https://acepe.dev",
+	},
+	inLanguage: "en-US",
 };
 
 const softwareSchema = {
@@ -17,36 +42,42 @@ const softwareSchema = {
 	name: "Acepe",
 	description,
 	applicationCategory: "DeveloperApplication",
+	applicationSubCategory: "AI Coding Agent Client",
 	operatingSystem: "macOS, Windows, Linux",
 	url: "https://acepe.dev",
+	downloadUrl: "https://acepe.dev/download",
 	image: "https://acepe.dev/og-image.png",
 	screenshot: "https://acepe.dev/og-image.png",
-	softwareVersion: "1.0",
 	offers: {
 		"@type": "Offer",
 		price: "0",
 		priceCurrency: "USD",
+		availability: "https://schema.org/InStock",
+		url: "https://acepe.dev/download",
 	},
 	featureList: [
-		"Readable plan mode with markdown rendering",
+		"Run Claude Code, Codex, Cursor Agent, and OpenCode side by side",
+		"Parallel agent sessions with attention queue triage",
+		"Readable plan mode with full markdown rendering",
 		"Unified session history across projects",
-		"Multi-agent support (Claude Code, Codex, OpenCode)",
-		"Parallel agent sessions",
-		"Keyboard-first design",
-		"Focus mode for deep work",
+		"File-level checkpoints with time-travel debugging",
+		"Built-in Git panel, diff viewer, and SQL studio",
+		"Keyboard-first design with focus mode",
 	],
-	aggregateRating: {
-		"@type": "AggregateRating",
-		ratingValue: "5",
-		ratingCount: "1",
+	author: {
+		"@type": "Organization",
+		name: "Acepe",
+		url: "https://acepe.dev",
 	},
 };
 
 const jsonLdOrg = JSON.stringify(organizationSchema);
+const jsonLdWebsite = JSON.stringify(websiteSchema);
 const jsonLdSoftware = JSON.stringify(softwareSchema);
 </script>
 
 <svelte:head>
 	{@html `<script type="application/ld+json">${jsonLdOrg}</script>`}
+	{@html `<script type="application/ld+json">${jsonLdWebsite}</script>`}
 	{@html `<script type="application/ld+json">${jsonLdSoftware}</script>`}
 </svelte:head>

--- a/packages/website/src/lib/components/seo/seo.svelte
+++ b/packages/website/src/lib/components/seo/seo.svelte
@@ -1,0 +1,128 @@
+<script lang="ts">
+import { page } from "$app/state";
+import { canonicalizePathname } from "$lib/locale-routing";
+
+const BASE_URL = "https://acepe.dev";
+const DEFAULT_IMAGE = "/og-image.png";
+const DEFAULT_IMAGE_ALT = "Acepe — The Agentic Developer Environment";
+
+interface SeoProps {
+	title: string;
+	description: string;
+	type?: "website" | "article" | "product" | "profile";
+	image?: string;
+	imageAlt?: string;
+	imageWidth?: number;
+	imageHeight?: number;
+	noindex?: boolean;
+	canonical?: string;
+	publishedTime?: string;
+	modifiedTime?: string;
+	author?: string;
+	keywords?: readonly string[];
+	jsonLd?: object | readonly object[];
+}
+
+let {
+	title,
+	description,
+	type = "website",
+	image = DEFAULT_IMAGE,
+	imageAlt = DEFAULT_IMAGE_ALT,
+	imageWidth,
+	imageHeight,
+	noindex = false,
+	canonical,
+	publishedTime,
+	modifiedTime,
+	author,
+	keywords,
+	jsonLd,
+}: SeoProps = $props();
+
+const titleSuffix = " — Acepe";
+const fullTitle = $derived(
+	title === "Acepe" || title.endsWith(titleSuffix) || title.endsWith("- Acepe")
+		? title
+		: `${title}${titleSuffix}`
+);
+
+const canonicalPath = $derived(
+	canonical ?? canonicalizePathname(page.url.pathname)
+);
+const canonicalUrl = $derived(
+	canonicalPath.startsWith("http") ? canonicalPath : `${BASE_URL}${canonicalPath}`
+);
+
+const absoluteImage = $derived(
+	image.startsWith("http") ? image : `${BASE_URL}${image}`
+);
+
+// Only declare og:image dimensions when we know them. The default OG image
+// is 1200x630; custom callers may supply their own dimensions. Lying about
+// dimensions causes incorrect cropping in social link previews.
+const isDefaultImage = $derived(image === DEFAULT_IMAGE);
+const declaredImageWidth = $derived(
+	imageWidth ?? (isDefaultImage ? 1200 : undefined)
+);
+const declaredImageHeight = $derived(
+	imageHeight ?? (isDefaultImage ? 630 : undefined)
+);
+
+const robotsContent = $derived(
+	noindex
+		? "noindex, nofollow"
+		: "index, follow, max-snippet:-1, max-image-preview:large, max-video-preview:-1"
+);
+
+const keywordsContent = $derived(keywords?.join(", "));
+
+const jsonLdScripts = $derived.by((): readonly string[] => {
+	if (!jsonLd) return [];
+	const arr = Array.isArray(jsonLd) ? jsonLd : [jsonLd];
+	return arr.map((schema) => JSON.stringify(schema));
+});
+</script>
+
+<svelte:head>
+	<title>{fullTitle}</title>
+	<meta name="description" content={description} />
+	<meta name="robots" content={robotsContent} />
+	<meta name="googlebot" content={robotsContent} />
+	{#if keywordsContent}
+		<meta name="keywords" content={keywordsContent} />
+	{/if}
+	{#if author}
+		<meta name="author" content={author} />
+	{/if}
+	<link rel="canonical" href={canonicalUrl} />
+
+	<meta property="og:type" content={type} />
+	<meta property="og:site_name" content="Acepe" />
+	<meta property="og:url" content={canonicalUrl} />
+	<meta property="og:title" content={fullTitle} />
+	<meta property="og:description" content={description} />
+	<meta property="og:image" content={absoluteImage} />
+	<meta property="og:image:alt" content={imageAlt} />
+	{#if declaredImageWidth !== undefined && declaredImageHeight !== undefined}
+		<meta property="og:image:width" content={String(declaredImageWidth)} />
+		<meta property="og:image:height" content={String(declaredImageHeight)} />
+	{/if}
+	<meta property="og:locale" content="en_US" />
+	{#if publishedTime}
+		<meta property="article:published_time" content={publishedTime} />
+	{/if}
+	{#if modifiedTime}
+		<meta property="article:modified_time" content={modifiedTime} />
+	{/if}
+
+	<meta name="twitter:card" content="summary_large_image" />
+	<meta name="twitter:title" content={fullTitle} />
+	<meta name="twitter:description" content={description} />
+	<meta name="twitter:image" content={absoluteImage} />
+	<meta name="twitter:image:alt" content={imageAlt} />
+
+	{#each jsonLdScripts as script (script)}
+		{@html `<script type="application/ld+json">${script}<\/script>`}
+	{/each}
+</svelte:head>

--- a/packages/website/src/lib/components/seo/seo.svelte
+++ b/packages/website/src/lib/components/seo/seo.svelte
@@ -54,9 +54,11 @@ const canonicalUrl = $derived(
 	canonicalPath.startsWith("http") ? canonicalPath : `${BASE_URL}${canonicalPath}`
 );
 
-const absoluteImage = $derived(
-	image.startsWith("http") ? image : `${BASE_URL}${image}`
-);
+const absoluteImage = $derived.by((): string => {
+	if (image.startsWith("http")) return image;
+	const normalized = image.startsWith("/") ? image : `/${image}`;
+	return `${BASE_URL}${normalized}`;
+});
 
 // Only declare og:image dimensions when we know them. The default OG image
 // is 1200x630; custom callers may supply their own dimensions. Lying about

--- a/packages/website/src/lib/components/seo/seo.svelte
+++ b/packages/website/src/lib/components/seo/seo.svelte
@@ -48,7 +48,7 @@ const fullTitle = $derived(
 );
 
 const canonicalPath = $derived(
-	canonical ?? canonicalizePathname(page.url.pathname)
+	canonical ?? canonicalizePathname(page.url?.pathname ?? "/")
 );
 const canonicalUrl = $derived(
 	canonicalPath.startsWith("http") ? canonicalPath : `${BASE_URL}${canonicalPath}`

--- a/packages/website/src/routes/+layout.svelte
+++ b/packages/website/src/routes/+layout.svelte
@@ -4,7 +4,6 @@ import "./layout.css";
 import logo from "$lib/assets/favicon.svg";
 import { browser } from "$app/environment";
 import JsonLd from "$lib/components/seo/json-ld.svelte";
-import Canonical from "$lib/components/seo/canonical.svelte";
 import { websiteThemeStore } from "$lib/theme/theme.js";
 let { children } = $props();
 
@@ -20,7 +19,6 @@ if (browser) {
 <svelte:head><link rel="icon" href={logo} /></svelte:head>
 
 <JsonLd />
-<Canonical />
 
 <Tooltip.Provider delayDuration={0}>
 	{@render children()}

--- a/packages/website/src/routes/+page.svelte
+++ b/packages/website/src/routes/+page.svelte
@@ -9,6 +9,7 @@ import type { AppSessionItemType } from "@acepe/ui/app-layout";
 import AgentIconsRow from "$lib/components/agent-icons-row.svelte";
 import { getProviderBrandIconSrc } from "$lib/provider-brand-icons.js";
 import Header from "$lib/components/header.svelte";
+import Seo from "$lib/components/seo/seo.svelte";
 import FeatureShowcase from "$lib/components/feature-showcase.svelte";
 import HeroShaderStage from "$lib/components/hero-shader-stage.svelte";
 import FeatureCardShader from "$lib/components/feature-card-shader.svelte";
@@ -371,12 +372,26 @@ const features = [
 		],
 	},
 ];
+
+const homepageKeywords = [
+	"AI coding agent",
+	"Claude Code desktop",
+	"Codex client",
+	"Cursor Agent",
+	"ACP agent client protocol",
+	"agentic developer environment",
+	"AI pair programming",
+	"OpenCode client",
+	"parallel AI agents",
+];
 </script>
 
-<svelte:head>
-	<title>{"The Agentic Developer Environment"} - Acepe</title>
-	<meta name="description" content={"Run Claude Code, Codex, Cursor Agent, and OpenCode side by side. Orchestrate parallel sessions, track every change, and ship from plan to PR. All in one window."} />
-</svelte:head>
+<Seo
+	title="The Agentic Developer Environment"
+	description="Run Claude Code, Codex, Cursor Agent, and OpenCode side by side. Orchestrate parallel sessions, track every change, and ship from plan to PR. All in one native desktop window."
+	keywords={homepageKeywords}
+	canonical="/"
+/>
 
 <div class="min-h-screen">
 	<Header

--- a/packages/website/src/routes/blog/+page.svelte
+++ b/packages/website/src/routes/blog/+page.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
 import { DiffPill } from "@acepe/ui";
 import Header from "$lib/components/header.svelte";
+import Seo from "$lib/components/seo/seo.svelte";
 import type { BlogPostMetadata } from "$lib/blog/types.js";
 import { getAllBlogPosts } from "$lib/blog/posts.js";
 import type { Component } from "svelte";
@@ -39,15 +40,34 @@ function formatDate(isoDate: string): string {
 		day: "numeric",
 	});
 }
+
+const blogJsonLd = {
+	"@context": "https://schema.org",
+	"@type": "Blog",
+	name: "Acepe Blog",
+	url: "https://acepe.dev/blog",
+	description: "Product updates, deep dives, and how-to guides for the Acepe agentic developer environment.",
+	publisher: {
+		"@type": "Organization",
+		name: "Acepe",
+		url: "https://acepe.dev",
+	},
+	blogPost: getAllBlogPosts().map((post) => ({
+		"@type": "BlogPosting",
+		headline: post.title,
+		description: post.description,
+		datePublished: post.date,
+		url: `https://acepe.dev/blog/${post.slug}`,
+	})),
+};
 </script>
 
-<svelte:head>
-	<title>{"Blog"} - Acepe</title>
-	<meta name="description" content={"Product updates and how-to guides for the Acepe desktop app"} />
-	<meta property="og:title" content="{"Blog"} - Acepe" />
-	<meta property="og:description" content={"Product updates and how-to guides for the Acepe desktop app"} />
-	<meta property="og:type" content="website" />
-</svelte:head>
+<Seo
+	title="Blog"
+	description="Product updates, deep dives on agent UX, and how-to guides for getting more out of Acepe's agentic developer environment."
+	keywords={["Acepe blog", "AI coding agent", "Claude Code tips", "developer productivity"]}
+	jsonLd={blogJsonLd}
+/>
 
 <div class="min-h-screen">
 	<Header

--- a/packages/website/src/routes/changelog/+page.svelte
+++ b/packages/website/src/routes/changelog/+page.svelte
@@ -2,6 +2,7 @@
 import type { ChangeType } from "@acepe/changelog";
 import { CHANGELOG, groupChangesByType } from "@acepe/changelog";
 import Header from "$lib/components/header.svelte";
+import Seo from "$lib/components/seo/seo.svelte";
 import { Bug, Lightning, RocketLaunch, Warning } from "phosphor-svelte";
 
 let { data } = $props();
@@ -25,10 +26,11 @@ function formatDate(dateStr: string): string {
 }
 </script>
 
-<svelte:head>
-	<title>{"Changelog"} - Acepe</title>
-	<meta name="description" content={"What's new in Acepe. Updates are listed newest first."} />
-</svelte:head>
+<Seo
+	title="Changelog"
+	description="What's new in Acepe — features, fixes, and improvements to the agentic developer environment, newest first."
+	keywords={["Acepe changelog", "release notes", "product updates"]}
+/>
 
 <div class="min-h-screen">
 	<Header

--- a/packages/website/src/routes/compare/+page.svelte
+++ b/packages/website/src/routes/compare/+page.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 import Header from "$lib/components/header.svelte";
+import Seo from "$lib/components/seo/seo.svelte";
 import { ArrowRight } from "@lucide/svelte";
 import { getAllComparisonSlugs, getComparison } from "$lib/compare/data.js";
 
@@ -10,16 +11,26 @@ const comparisons = $derived(
 		.map((slug) => getComparison(slug))
 		.filter((c): c is NonNullable<typeof c> => c !== null)
 );
+
+const compareItemListJsonLd = $derived({
+	"@context": "https://schema.org",
+	"@type": "ItemList",
+	name: "Acepe comparisons",
+	itemListElement: comparisons.map((comparison, index) => ({
+		"@type": "ListItem",
+		position: index + 1,
+		url: `https://acepe.dev/compare/${comparison.slug}`,
+		name: comparison.metaTitle,
+	})),
+});
 </script>
 
-<svelte:head>
-	<title>{"Compare Acepe"} - Acepe</title>
-	<meta name="description" content={"See how Acepe stacks up against other developer tools, feature by feature."} />
-	<meta property="og:title" content="{"Compare Acepe"} - Acepe" />
-	<meta property="og:description" content={"See how Acepe stacks up against other developer tools, feature by feature."} />
-	<meta property="og:type" content="website" />
-	<meta property="og:url" content="https://acepe.dev/compare" />
-</svelte:head>
+<Seo
+	title="Compare Acepe vs other AI agent tools"
+	description="How Acepe stacks up against Cursor, Conductor, Superset, T3, OneCode, and other agent and IDE workflows — feature by feature, side by side."
+	keywords={["Acepe vs Cursor", "Acepe vs Conductor", "Claude Code GUI comparison", "AI agent client comparison"]}
+	jsonLd={compareItemListJsonLd}
+/>
 
 <div class="min-h-screen">
 	<Header

--- a/packages/website/src/routes/compare/[slug]/+page.svelte
+++ b/packages/website/src/routes/compare/[slug]/+page.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 import Header from "$lib/components/header.svelte";
+import Seo from "$lib/components/seo/seo.svelte";
 import { attentionQueueBlogPost, checkpointsBlogPost, sqlStudioBlogPost } from "$lib/blog/posts.js";
 import { Check, X, ArrowRight, Minus } from "@lucide/svelte";
 import type { ComparisonFeatureRow } from "$lib/compare/types.js";
@@ -26,16 +27,9 @@ let expandedFaqIndex = $state<number | null>(null);
 function toggleFaq(index: number): void {
 	expandedFaqIndex = expandedFaqIndex === index ? null : index;
 }
-</script>
 
-<svelte:head>
-	<title>{comparison.metaTitle}</title>
-	<meta name="description" content={comparison.metaDescription} />
-	<meta property="og:title" content={comparison.metaTitle} />
-	<meta property="og:description" content={comparison.metaDescription} />
-	<meta property="og:type" content="website" />
-	<meta property="og:url" content="https://acepe.dev/compare/{comparison.slug}" />
-	{@html `<script type="application/ld+json">${JSON.stringify({
+const compareJsonLd = $derived([
+	{
 		"@context": "https://schema.org",
 		"@type": "FAQPage",
 		mainEntity: comparison.faqs.map((faq) => ({
@@ -46,8 +40,40 @@ function toggleFaq(index: number): void {
 				text: faq.answer,
 			},
 		})),
-	})}</script>`}
-</svelte:head>
+	},
+	{
+		"@context": "https://schema.org",
+		"@type": "BreadcrumbList",
+		itemListElement: [
+			{
+				"@type": "ListItem",
+				position: 1,
+				name: "Home",
+				item: "https://acepe.dev/",
+			},
+			{
+				"@type": "ListItem",
+				position: 2,
+				name: "Compare",
+				item: "https://acepe.dev/compare",
+			},
+			{
+				"@type": "ListItem",
+				position: 3,
+				name: comparison.metaTitle,
+				item: `https://acepe.dev/compare/${comparison.slug}`,
+			},
+		],
+	},
+]);
+</script>
+
+<Seo
+	title={comparison.metaTitle}
+	description={comparison.metaDescription}
+	canonical={`/compare/${comparison.slug}`}
+	jsonLd={compareJsonLd}
+/>
 
 <div class="min-h-screen">
 	<Header

--- a/packages/website/src/routes/download/+page.svelte
+++ b/packages/website/src/routes/download/+page.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
 import { BrandLockup } from "@acepe/ui";
 import Header from "$lib/components/header.svelte";
+import Seo from "$lib/components/seo/seo.svelte";
 import { Download } from "@lucide/svelte";
 import { AppleLogo, GithubLogo } from "phosphor-svelte";
 
@@ -12,12 +13,30 @@ function handleDownload() {
 	downloading = true;
 	setTimeout(() => (downloading = false), 4000);
 }
+
+const downloadJsonLd = {
+	"@context": "https://schema.org",
+	"@type": "SoftwareApplication",
+	name: "Acepe",
+	operatingSystem: "macOS",
+	applicationCategory: "DeveloperApplication",
+	url: "https://acepe.dev/download",
+	downloadUrl: "https://acepe.dev/download",
+	offers: {
+		"@type": "Offer",
+		price: "0",
+		priceCurrency: "USD",
+		availability: "https://schema.org/InStock",
+	},
+};
 </script>
 
-<svelte:head>
-	<title>Download - Acepe</title>
-	<meta name="description" content="Download Acepe for macOS. The agentic developer environment for running Claude Code, Codex, and more — side by side." />
-</svelte:head>
+<Seo
+	title="Download Acepe for macOS"
+	description="Download Acepe — the native desktop agentic developer environment for macOS. Run Claude Code, Codex, Cursor Agent, and OpenCode side by side. Free forever for local sessions."
+	keywords={["download Acepe", "Acepe macOS", "Claude Code desktop app", "Codex desktop client", "AI agent IDE download"]}
+	jsonLd={downloadJsonLd}
+/>
 
 <div class="min-h-screen">
 	<Header

--- a/packages/website/src/routes/login/+page.svelte
+++ b/packages/website/src/routes/login/+page.svelte
@@ -2,7 +2,14 @@
 import { BrandLockup } from "@acepe/ui";
 import AgentIconsRow from "$lib/components/agent-icons-row.svelte";
 import AnimatedBackground from "$lib/components/animated-background.svelte";
+import Seo from "$lib/components/seo/seo.svelte";
 </script>
+
+<Seo
+	title="Sign in"
+	description="Sign in to Acepe."
+	noindex
+/>
 
 <div class="fixed inset-0 flex items-center justify-center">
 	<!-- Full Screen Shader Background -->

--- a/packages/website/src/routes/pitch/+page.svelte
+++ b/packages/website/src/routes/pitch/+page.svelte
@@ -2,6 +2,7 @@
 import { browser } from "$app/environment";
 import { BrandLockup } from "@acepe/ui";
 import HeroShaderStage from "$lib/components/hero-shader-stage.svelte";
+import Seo from "$lib/components/seo/seo.svelte";
 import { getProviderBrandIconSrc } from "$lib/provider-brand-icons.js";
 import { formatPitchProofValue, pitchSections } from "$lib/pitch/content.js";
 
@@ -107,12 +108,13 @@ const slideDescriptionClass =
 const slideSummaryClass = `max-w-3xl ${slideDescriptionClass}`;
 </script>
 
+<Seo
+	title="Investor Pitch"
+	description="Acepe investor pitch: the platform-neutral operating layer for agentic development."
+	noindex
+/>
+
 <svelte:head>
-	<title>Investor Pitch - Acepe</title>
-	<meta
-		name="description"
-		content="Acepe investor pitch: the platform-neutral operating layer for agentic development."
-	/>
 	<link rel="preload" href="/images/pitch/pitch-view-agent.webp" as="image" type="image/webp" />
 	<style>
 		@page {

--- a/packages/website/src/routes/pricing/+page.svelte
+++ b/packages/website/src/routes/pricing/+page.svelte
@@ -1,20 +1,33 @@
 <script lang="ts">
 import { BrandLockup, TextShimmer } from "@acepe/ui";
 import Header from "$lib/components/header.svelte";
+import Seo from "$lib/components/seo/seo.svelte";
 import { Check, ArrowRight, Terminal } from "@lucide/svelte";
 import { GithubLogo } from "phosphor-svelte";
 import { pricingFaqItems } from "./faq.js";
 
 let { data } = $props();
+
+const pricingFaqJsonLd = {
+	"@context": "https://schema.org",
+	"@type": "FAQPage",
+	mainEntity: pricingFaqItems.map((item) => ({
+		"@type": "Question",
+		name: item.q,
+		acceptedAnswer: {
+			"@type": "Answer",
+			text: item.a,
+		},
+	})),
+};
 </script>
 
-<svelte:head>
-	<title>Pricing - Acepe</title>
-	<meta
-		name="description"
-		content="Choose the plan that fits your workflow. Free forever for individuals, Premium for power users, Enterprise for teams."
-	/>
-</svelte:head>
+<Seo
+	title="Pricing"
+	description="Acepe is free forever for individuals. Premium adds advanced orchestration for power users; Enterprise adds SSO, audit, and team controls. No seats locked, no surprise quotas."
+	keywords={["Acepe pricing", "AI coding agent pricing", "Claude Code GUI pricing", "developer tools pricing"]}
+	jsonLd={pricingFaqJsonLd}
+/>
 
 <div class="min-h-screen">
 	<Header

--- a/packages/website/src/routes/privacy/+page.svelte
+++ b/packages/website/src/routes/privacy/+page.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 import Header from "$lib/components/header.svelte";
+import Seo from "$lib/components/seo/seo.svelte";
 
 let { data } = $props();
 
@@ -69,10 +70,10 @@ const sections = [
 ];
 </script>
 
-<svelte:head>
-	<title>Privacy Policy - Acepe</title>
-	<meta name="description" content="Acepe privacy policy — what data we collect and how we use it." />
-</svelte:head>
+<Seo
+	title="Privacy Policy"
+	description="Acepe privacy policy — what data we collect (almost nothing) and how we handle it. No analytics, no tracking cookies, no third-party trackers."
+/>
 
 <div class="min-h-screen">
 	<Header

--- a/packages/website/src/routes/sitemap.xml/+server.ts
+++ b/packages/website/src/routes/sitemap.xml/+server.ts
@@ -17,10 +17,12 @@ const publicRoutes: Route[] = [
 	{ path: "/", priority: "1.0", changefreq: "weekly" },
 	{ path: "/blog", priority: "0.7", changefreq: "weekly" },
 	{ path: "/changelog", priority: "0.7", changefreq: "weekly" },
-	{ path: "/download", priority: "0.8", changefreq: "weekly" },
+	{ path: "/download", priority: "0.9", changefreq: "weekly" },
 	{ path: "/pricing", priority: "0.8", changefreq: "weekly" },
 	{ path: "/compare", priority: "0.8", changefreq: "weekly" },
-	{ path: "/roadmap", priority: "0.7", changefreq: "daily" },
+	{ path: "/zeus", priority: "0.5", changefreq: "monthly" },
+	{ path: "/privacy", priority: "0.3", changefreq: "yearly" },
+	{ path: "/terms", priority: "0.3", changefreq: "yearly" },
 ]
 	.concat(
 		getAllBlogPosts().map((post) => ({

--- a/packages/website/src/routes/sitemap.xml/server.test.ts
+++ b/packages/website/src/routes/sitemap.xml/server.test.ts
@@ -27,9 +27,12 @@ describe("sitemap.xml", () => {
 		expect(xml).toContain(
 			"<loc>https://acepe.dev/compare/1code</loc>\n    <lastmod>2026-04-02</lastmod>"
 		);
-		expect(xml).toContain(
-			"<loc>https://acepe.dev/compare/conductor</loc>\n    <lastmod>2026-04-02</lastmod>"
+		expect(xml).toContain("<loc>https://acepe.dev/compare/conductor</loc>\n    <lastmod>2026-04-02</lastmod>"
 		);
+		expect(xml).toContain("<loc>https://acepe.dev/privacy</loc>");
+		expect(xml).toContain("<loc>https://acepe.dev/terms</loc>");
+		expect(xml).toContain("<loc>https://acepe.dev/zeus</loc>");
+		expect(xml).not.toContain("<loc>https://acepe.dev/roadmap</loc>");
 		expect(xml).not.toContain("<loc>https://acepe.dev/es/");
 		expect(xml).not.toContain("<loc>https://acepe.dev/es/blog</loc>");
 	});

--- a/packages/website/src/routes/terms/+page.svelte
+++ b/packages/website/src/routes/terms/+page.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 import Header from "$lib/components/header.svelte";
+import Seo from "$lib/components/seo/seo.svelte";
 
 let { data } = $props();
 
@@ -87,10 +88,10 @@ const sections = [
 ];
 </script>
 
-<svelte:head>
-	<title>Terms of Use - Acepe</title>
-	<meta name="description" content="Acepe terms of use — FSL-1.1-ALv2 source-available license." />
-</svelte:head>
+<Seo
+	title="Terms of Use"
+	description="Acepe terms of use under the FSL-1.1-ALv2 source-available license. What you can and cannot do with the source and built app."
+/>
 
 <div class="min-h-screen">
 	<Header

--- a/packages/website/src/routes/zeus/+page.svelte
+++ b/packages/website/src/routes/zeus/+page.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
 import { ArrowRightIcon, PillButton, BrandLockup } from "@acepe/ui";
 import Header from "$lib/components/header.svelte";
+import Seo from "$lib/components/seo/seo.svelte";
 import ZeusShaderStage from "$lib/components/zeus-shader-stage.svelte";
 import { GithubLogo } from "phosphor-svelte";
 
@@ -37,13 +38,11 @@ const meta = [
 ];
 </script>
 
-<svelte:head>
-	<title>Zeus — The conductor for your agents · Acepe</title>
-	<meta
-		name="description"
-		content="Zeus is the orchestration layer above every coding agent. It watches, routes, and ships — so you stay in command of the work, not the tools. Coming soon to Acepe."
-	/>
-</svelte:head>
+<Seo
+	title="Zeus — The conductor for your agents"
+	description="Zeus is the orchestration layer above every coding agent. It watches, routes, and ships — so you stay in command of the work, not the tools. Coming soon to Acepe."
+	keywords={["Zeus", "AI agent orchestration", "agent conductor", "Acepe Zeus"]}
+/>
 
 <div class="zeus-page">
 	<Header

--- a/packages/website/static/robots.txt
+++ b/packages/website/static/robots.txt
@@ -1,5 +1,31 @@
-# allow crawling everything by default
+# Default policy: allow crawling everything except internal/admin surfaces.
+# Note: pages we want kept out of the index but still crawlable (so Google
+# can see their noindex meta tag) are NOT listed here — robots Disallow +
+# noindex meta is contradictory (the crawler never fetches the page and
+# therefore never sees the noindex). Disallow is reserved for surfaces we
+# never want crawled at all (admin/auth/api).
 User-agent: *
-Disallow:
+Disallow: /admin
+Disallow: /auth
+Disallow: /api
+Disallow: /es/
+Disallow: /en/
+
+# AI scrapers — fully disallow.
+User-agent: GPTBot
+Disallow: /
+
+User-agent: ClaudeBot
+Disallow: /
+
+User-agent: anthropic-ai
+Disallow: /
+
+User-agent: CCBot
+Disallow: /
+
+User-agent: Google-Extended
+Disallow: /
 
 Sitemap: https://acepe.dev/sitemap.xml
+Host: https://acepe.dev


### PR DESCRIPTION
## Why

Acepe's marketing site had solid SEO bones (sitemap, robots.txt, per-page titles, baseline JSON-LD), but several signals were leaking value:

- `app.html` declared a homepage title/description/OG/Twitter that appeared **on every route alongside** the per-page versions — duplicate meta confuses crawlers and previews.
- JSON-LD claimed `aggregateRating: 5/1` with a single fake review (Google can flag this as spam).
- Private surfaces (`/pitch`, `/dev/*`, `/login`) were both indexable and inconsistently blocked.
- Several routes were missing OG/Twitter cards, canonical URLs, or structured data.
- Sitemap referenced a nonexistent `/roadmap` and omitted `/privacy`, `/terms`, `/zeus`.

This PR makes every route's SEO complete, consistent, and crawler-friendly.

## What

### Central `<Seo>` component
Single source of truth in `packages/website/src/lib/components/seo/seo.svelte`:
- Title with auto-suffix
- Description, canonical (absolute, derived from `canonicalizePathname`)
- Full Open Graph (`og:type`, `og:site_name`, `og:url`, `og:title`, `og:description`, `og:image`, `og:image:alt`, `og:locale`, optional dimensions, `article:published_time`/`modified_time`)
- Full Twitter card (`summary_large_image` + title/desc/image/alt)
- Configurable `robots` + `googlebot` (defaults include `max-image-preview:large`, `max-snippet:-1`, `max-video-preview:-1`)
- `noindex` flag
- Optional `keywords`, `author`, `imageWidth`/`imageHeight`, multiple JSON-LD blocks

### Stripped `app.html`
Removed duplicated dynamic meta. Kept favicon, manifest, viewport, fonts, theme, and added `application-name`, `apple-mobile-web-app-*`, `format-detection`, `color-scheme`.

### Strengthened site-wide JSON-LD (`json-ld.svelte`)
- Removed the fake `aggregateRating`
- Added a separate `WebSite` schema (with publisher + language)
- Structured `ImageObject` logo with dimensions
- `sameAs` linking to the GitHub repo
- `downloadUrl`, real `applicationSubCategory`, richer `featureList`

### Per-route structured data
| Route | Schema |
|-------|--------|
| `/` | keywords + canonical |
| `/pricing` | **FAQPage** from real FAQ items |
| `/download` | `SoftwareApplication` offer with `availability: InStock` |
| `/compare` | **ItemList** of all comparisons |
| `/compare/[slug]` | **FAQPage + BreadcrumbList** (Home → Compare → tool) |
| `/blog` | **Blog** schema listing all posts |
| `/blog/*` (via `BlogPostLayout`) | **BlogPosting + BreadcrumbList** with publisher logo, `timeRequired`, `mainEntityOfPage`, `articleSection` |
| `/changelog`, `/privacy`, `/terms`, `/zeus` | full meta + canonical |

### Indexing posture
- `noindex` via `<Seo>` on `/pitch`, `/login`, and dev-only routes.
- Removed `Disallow` for any route that relies on `noindex` meta (Google must fetch the page to see it; `Disallow` makes `noindex` invisible to the crawler).
- `Disallow` reserved for surfaces we never want crawled: `/admin`, `/auth`, `/api`, legacy locale paths.
- Full-block scraper user agents: `GPTBot`, `ClaudeBot`, `anthropic-ai`, `CCBot`, `Google-Extended`.

### Sitemap
- Added `/privacy`, `/terms`, `/zeus`
- Removed nonexistent `/roadmap`
- Bumped `/download` priority
- Test updated (23 expectations passing)

## Tests
- `bun test src/routes/sitemap.xml/` — passes (23 expect calls)
- `bun run check` — same pre-existing errors as baseline on `main`; no new errors in SEO files
- Reviewed via `/review` skill; all four findings (GPTBot/ClaudeBot grouping semantics, `/zeus` indexing inconsistency, robots+noindex contradiction, hardcoded OG dimensions) addressed before merge

## Verifying manually
After deploy, validate at:
- https://search.google.com/test/rich-results — paste `https://acepe.dev/`, `/blog`, `/pricing`, `/compare/cursor`, `/blog/attention-queue`
- https://www.opengraph.xyz/ — paste any route to inspect OG/Twitter rendering
- View source of any page to confirm exactly one set of meta tags

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Unifies SEO with a single `<Seo>` component and adds complete, route-level structured data. Fixes duplicate meta, tightens indexing, corrects the sitemap, normalizes OG image URLs, and hardens SSR for reliable previews and tests.

- New Features
  - Central `packages/website/src/lib/components/seo/seo.svelte` for title, description, canonical, OG/Twitter, `robots`/`googlebot`, `noindex`, keywords/author, optional image dims, article times, and JSON-LD.
  - Stronger site-wide JSON-LD: `Organization`, `WebSite`, and `SoftwareApplication` with structured logo, `sameAs`, `downloadUrl`, and a richer `featureList`.
  - Per-route SEO: homepage keywords; pricing `FAQPage`; download `SoftwareApplication` offer (`InStock`); compare `ItemList` + per-slug `FAQPage` and `BreadcrumbList`; blog index `Blog` + posts `BlogPosting`; full meta on changelog/privacy/terms/zeus.
  - `app.html` now only static head tags (favicon, manifest, fonts, theme, mobile web app).

- Bug Fixes
  - Removed duplicate title/description/OG/Twitter across routes.
  - Normalized relative OG image paths to absolute URLs in meta and JSON-LD.
  - Dropped fake `aggregateRating` JSON-LD.
  - Corrected indexing posture: `noindex` on `/pitch` and `/login`; keep `robots.txt` Disallow for `/admin`, `/auth`, `/api`, `/es/`, `/en/`; block `GPTBot`, `ClaudeBot`, `anthropic-ai`, `CCBot`, `Google-Extended`.
  - Fixed sitemap: added `/privacy`, `/terms`, `/zeus`; removed `/roadmap`; increased `/download` priority; tests updated and passing.
  - Guarded `page.url` access in `<Seo>` for SSR/test contexts to prevent crashes.

<sup>Written for commit 45a6b845eb1a98bf13b9e4c037e65d6d6864a638. Summary will update on new commits. <a href="https://cubic.dev/pr/flazouh/acepe/pull/197?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

