### PR TITLE
fix: respect pre-filled model selector when starting new session

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -163,7 +163,9 @@
         "phosphor-svelte": "^3.1.0",
         "pino": "^10.1.0",
         "postgres": "^3.4.5",
+        "runed": "^0.35.1",
         "shiki": "^3.22.0",
+        "streamdown": "2.5.0",
         "tailwind-merge": "^3.4.0",
         "tw-animate-css": "^1.4.0",
         "vaul-svelte": "^1.0.0-next.7",
@@ -1608,7 +1610,7 @@
 
     "roughjs": ["roughjs@4.6.6", "", { "dependencies": { "hachure-fill": "^0.5.2", "path-data-parser": "^0.1.0", "points-on-curve": "^0.2.0", "points-on-path": "^0.2.1" } }, "sha512-ZUz/69+SYpFN/g/lUlo2FXcIjRkSu3nDarreVdGGndHEBJ6cXPdKguS8JGxwj5HA5xIbVKSmLgr5b3AWxtRfvQ=="],
 
-    "runed": ["runed@0.23.4", "", { "dependencies": { "esm-env": "^1.0.0" }, "peerDependencies": { "svelte": "^5.7.0" } }, "sha512-9q8oUiBYeXIDLWNK5DfCWlkL0EW3oGbk845VdKlPeia28l751VpfesaB/+7pI6rnbx1I6rqoZ2fZxptOJLxILA=="],
+    "runed": ["runed@0.35.1", "", { "dependencies": { "dequal": "^2.0.3", "esm-env": "^1.0.0", "lz-string": "^1.5.0" }, "peerDependencies": { "@sveltejs/kit": "^2.21.0", "svelte": "^5.7.0" }, "optionalPeers": ["@sveltejs/kit"] }, "sha512-2F4Q/FZzbeJTFdIS/PuOoPRSm92sA2LhzTnv6FXhCoENb3huf5+fDuNOg1LNvGOouy3u/225qxmuJvcV3IZK5Q=="],
 
     "rw": ["rw@1.3.3", "", {}, "sha512-PdhdWy89SiZogBLaw42zdeqtRJ//zFd2PgQavcICDUgJT5oW10QCRKbJ6bg4r0/UY2M6BWd5tkxuGFRvCkgfHQ=="],
 
@@ -1850,8 +1852,6 @@
 
     "@testing-library/dom/aria-query": ["aria-query@5.3.0", "", { "dependencies": { "dequal": "^2.0.3" } }, "sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A=="],
 
-    "bits-ui/runed": ["runed@0.35.1", "", { "dependencies": { "dequal": "^2.0.3", "esm-env": "^1.0.0", "lz-string": "^1.5.0" }, "peerDependencies": { "@sveltejs/kit": "^2.21.0", "svelte": "^5.7.0" }, "optionalPeers": ["@sveltejs/kit"] }, "sha512-2F4Q/FZzbeJTFdIS/PuOoPRSm92sA2LhzTnv6FXhCoENb3huf5+fDuNOg1LNvGOouy3u/225qxmuJvcV3IZK5Q=="],
-
     "bits-ui/svelte-toolbelt": ["svelte-toolbelt@0.10.6", "", { "dependencies": { "clsx": "^2.1.1", "runed": "^0.35.1", "style-to-object": "^1.0.8" }, "peerDependencies": { "svelte": "^5.30.2" } }, "sha512-YWuX+RE+CnWYx09yseAe4ZVMM7e7GRFZM6OYWpBKOb++s+SQ8RBIMMe+Bs/CznBMc0QPLjr+vDBxTAkozXsFXQ=="],
 
     "chevrotain/lodash-es": ["lodash-es@4.17.21", "", {}, "sha512-mKnC+QJ9pWVzv+C4/U3rRsHapFfHvQFoFB92e52xeyGMcX6/OlIl78je1u8vePzYZSkkogMPJ2yjxxsb89cxyw=="],
@@ -1884,7 +1884,11 @@
 
     "svelte-sonner/runed": ["runed@0.28.0", "", { "dependencies": { "esm-env": "^1.0.0" }, "peerDependencies": { "svelte": "^5.7.0" } }, "sha512-k2xx7RuO9hWcdd9f+8JoBeqWtYrm5CALfgpkg2YDB80ds/QE4w0qqu34A7fqiAwiBBSBQOid7TLxwxVC27ymWQ=="],
 
+    "svelte-toolbelt/runed": ["runed@0.23.4", "", { "dependencies": { "esm-env": "^1.0.0" }, "peerDependencies": { "svelte": "^5.7.0" } }, "sha512-9q8oUiBYeXIDLWNK5DfCWlkL0EW3oGbk845VdKlPeia28l751VpfesaB/+7pI6rnbx1I6rqoZ2fZxptOJLxILA=="],
+
     "tauri-pty/@tauri-apps/api": ["@tauri-apps/api@2.9.1", "", {}, "sha512-IGlhP6EivjXHepbBic618GOmiWe4URJiIeZFlB7x3czM0yDHHYviH1Xvoiv4FefdkQtn6v7TuwWCRfOGdnVUGw=="],
+
+    "vaul-svelte/runed": ["runed@0.23.4", "", { "dependencies": { "esm-env": "^1.0.0" }, "peerDependencies": { "svelte": "^5.7.0" } }, "sha512-9q8oUiBYeXIDLWNK5DfCWlkL0EW3oGbk845VdKlPeia28l751VpfesaB/+7pI6rnbx1I6rqoZ2fZxptOJLxILA=="],
 
     "@aws-crypto/sha1-browser/@smithy/util-utf8/@smithy/util-buffer-from": ["@smithy/util-buffer-from@2.2.0", "", { "dependencies": { "@smithy/is-array-buffer": "^2.2.0", "tslib": "^2.6.2" } }, "sha512-IJdWBbTcMQ6DA0gdNhh/BwrLkDR+ADW5Kr1aZmd4k3DIF6ezMV4R2NIAmT08wQJ3yUK82thHWmC/TnK/wpMMIA=="],
 

--- a/docs/plans/2026-05-19-mid-session-worktree-toggle-plan.md
+++ b/docs/plans/2026-05-19-mid-session-worktree-toggle-plan.md
@@ -1,0 +1,347 @@
+---
+date: 2026-05-19
+topic: mid-session-worktree-toggle
+---
+
+# Mid-session worktree toggle confirmation
+
+## Goal
+
+When a user turns on the worktree toggle under an already-working agent, Acepe should not silently change where future work lands. It should ask whether to continue future changes in a new worktree or move this session's existing changes into that new worktree first.
+
+This keeps worktree isolation explicit and prevents accidental loss, duplication, or surprise movement of user changes.
+
+## Product behavior
+
+### Entry point
+
+The existing worktree pill under the composer remains the entry point. Behavior depends on session state:
+
+- **Before first send / no session work yet:** keep current behavior. Turning Worktree on just marks the pending launch.
+- **Active session without an attached worktree:** turning Worktree on opens a confirmation dialog.
+- **Session already in a worktree:** turning Worktree off keeps current "return to project root / discard prepared launch" behavior, with existing dirty-worktree close checks preserved.
+
+### Dialog copy
+
+Title: `Start using a worktree?`
+
+Body:
+
+`Future agent changes can go into a fresh worktree. Existing changes from this session can either stay where they are, or Acepe can move the session-owned changes into the new worktree first.`
+
+Actions:
+
+1. `Continue in new worktree`
+   - Creates a new worktree.
+   - Updates the current session to use that worktree for future sends.
+   - Does not move existing changes from the current checkout.
+   - Shows helper text: `Existing changes stay in the current checkout. Future turns use the new worktree.`
+
+2. `Move session changes`
+   - Creates a new worktree.
+   - Moves only changes Acepe can prove are fully owned by this session.
+   - Updates the current session to use that worktree.
+   - Shows a file count with an expandable, reviewable file list before execution.
+   - Runs as an all-or-nothing transfer: if any session file cannot be moved safely, the move action is disabled before confirmation or the backend leaves the source checkout untouched.
+
+3. `Cancel`
+   - Leaves the session and toggle unchanged.
+
+### Availability rules
+
+`Move session changes` should only be enabled when Acepe can safely identify session-owned changed files and verify they can be transferred without clobbering user work.
+
+Disable it with an explanation when:
+
+- There are no session-attributed modified files.
+- A session-attributed file also has unrelated user edits that Acepe cannot prove belong to this session.
+- The source checkout has staged changes for one of the files.
+- A session-attributed file is deleted. Deleted-file transfer is out of scope for v1 because restoring the source state safely needs separate semantics.
+- Backend preflight finds a target conflict after creating the prepared worktree.
+- Any file path is outside the project root or resolves through unsafe path traversal.
+- Any session-attributed file is a symlink or resolves through a symlink path.
+
+The safe default is always `Continue in new worktree`.
+
+If unrelated dirty files exist outside the session-attributed file set, they do not block `Move session changes`. They remain in the current checkout, and the dialog shows: `Other local changes will stay in the current checkout.`
+
+## Technical approach
+
+### 1. Separate worktree toggle intent from immediate mutation
+
+Current code path:
+
+- `WorktreeTogglePill` calls `handlePreSessionWorktreeYes()`.
+- `handlePreSessionWorktreeYes()` immediately calls `panelStore.setPendingWorktreeEnabled(panelId, true)`.
+- First-send creation later flows through `AgentInput` and `prepareWorktreePathForPendingSend()`.
+
+Change:
+
+- Introduce a small controller-level state in `agent-panel.svelte`:
+  - `worktreeSwitchDialogOpen`
+  - `worktreeSwitchBusy`
+  - `worktreeSwitchError`
+  - `worktreeSwitchPreview`
+- Update the toggle handler:
+  - If `sessionId === null` or the session has no completed agent/tool work entries, keep current pending behavior.
+  - If `sessionId !== null` and `effectiveActiveWorktreePath === null`, open the dialog instead of setting pending directly.
+  - If the session already has a worktree, keep existing off/discard behavior.
+
+This avoids overloading `pendingWorktreeEnabled` with both "future first send" and "mid-session switch" semantics.
+
+### 2. Add a presentational dialog in `@acepe/ui`
+
+Create a reusable dumb component in `packages/ui/src/components/agent-panel/`:
+
+- `agent-panel-worktree-switch-dialog.svelte`
+- Props:
+  - `open`
+  - `sessionFileCount`
+  - `sessionFiles`
+  - `moveAvailable`
+  - `moveUnavailableReason`
+  - `otherLocalChangesMessage`
+  - `busy`
+  - `errorMessage`
+  - labels/copy
+  - callbacks: `onContinue`, `onMove`, `onCancel`
+
+Desktop owns all state and Tauri calls. Shared UI only renders copy, actions, loading, disabled state, and the optional file list.
+
+Accessibility and interaction requirements:
+
+- Use a modal dialog with focus trapped while open.
+- Move initial focus to the primary safe action, `Continue in new worktree`.
+- Disable both action buttons while `busy` is true and keep `Cancel` available only when no irreversible backend step has started.
+- Announce `errorMessage`, `moveUnavailableReason`, and transfer status with an accessible live region.
+- Render the file list as semantic list content with each path readable by screen readers.
+
+### 3. Create a mid-session worktree service
+
+Add a desktop service:
+
+- `packages/desktop/src/lib/acp/components/agent-panel/services/mid-session-worktree-switch-service.ts`
+
+Responsibilities:
+
+- Create a prepared worktree launch using the existing Tauri command:
+  - `tauriClient.git.prepareWorktreeSessionLaunch(projectPath, agentId)`
+- Run setup commands using existing worktree setup orchestration.
+- Return:
+  - `PreparedWorktreeLaunch`
+  - target worktree path
+  - optional transfer report
+
+Use `ResultAsync`/`neverthrow` style. Do not add `try/catch`.
+
+### 4. Continue-only flow
+
+Implementation steps:
+
+1. User clicks Worktree on mid-session.
+2. Dialog opens.
+3. User chooses `Continue in new worktree`.
+4. Service creates prepared worktree.
+5. Run existing worktree setup orchestration for the prepared launch.
+6. Rebind the active session/provider context to the prepared worktree so future provider tool calls, terminal launches, permission checks, and git actions execute from the worktree path rather than only updating UI-derived paths.
+7. `handlePreparedWorktreeLaunch()` stores prepared launch on the panel.
+8. `handleWorktreeCreated()` / equivalent session update sets:
+   - `activeWorktreePath`
+   - `activeWorktreeOwnerProjectPath`
+   - `sessionStore.updateSession(sessionId, { worktreeDeleted: false, worktreePath })`
+9. Future sends use `effectiveActiveWorktreePath` / `effectiveProjectPath`.
+
+Durable success boundary:
+
+- Persist `session.worktreePath` only after worktree creation, setup, and provider/session rebind all succeed.
+- If any step fails before persistence, discard the prepared launch, clear optimistic panel worktree state, leave the durable session unchanged, and show the error in the dialog.
+- If persistence fails after rebind succeeds, surface a blocking recovery error and do not claim the session has moved until the durable session record converges.
+
+Acceptance criteria:
+
+- The existing transcript remains attached to the same session.
+- Future provider tool/file/terminal/git actions resolve against the new worktree, verified by actual execution context rather than UI state alone.
+- Existing dirty files in the original checkout remain untouched.
+
+### 5. Move-session-changes flow
+
+This is the risky path and should be implemented with a dedicated backend command rather than shelling out from the frontend.
+
+Add a Tauri git command:
+
+- `prepare_and_transfer_session_changes_to_worktree`
+
+Inputs:
+
+- `projectPath`
+- `agentId`
+- `sessionId`
+
+Output:
+
+- `PreparedWorktreeLaunch`
+- `transferredFiles: string[]`
+- `blockedFiles: { path: string; reason: string }[]` on preflight failure
+
+Backend algorithm:
+
+1. Derive session-attributed candidate paths on the backend from persisted/session transcript data. Do not trust a frontend-supplied `sessionEditedFiles` list as authority.
+   - For v1, a path is transferable only when the backend can reconstruct the complete session-owned file delta from edit tool arguments, including the original baseline and final expected content.
+   - If the transcript only proves that a file path was touched, but not that the whole current file delta belongs to the session, the path blocks `Move session changes`.
+2. Validate all candidate file paths:
+   - Normalize relative paths.
+   - Reject absolute paths, `..` traversal, path separators that escape the project root, symlink files, and paths that resolve through symlink directories.
+   - Canonicalize existing source and target parent paths and verify they remain under `projectPath` and the prepared worktree root.
+3. Preflight source status for every candidate before writing:
+   - Reject staged files.
+   - Reject deleted files in v1.
+   - Reject unsupported statuses such as renames, type changes, submodules, ignored candidates, and nested untracked directories.
+   - Reject candidates whose current file delta cannot be proven to equal session-owned edits.
+4. Create a prepared worktree from the current HEAD.
+5. Run target preflight after worktree creation:
+   - Reject if any target path already has tracked, untracked, ignored, or filesystem content that would be clobbered.
+   - If target preflight fails, remove the prepared worktree and leave the source checkout untouched.
+6. For each session-attributed file:
+   - Resolve source path in `projectPath`.
+   - Resolve target path in new worktree.
+   - Copy regular modified/untracked file contents to target.
+7. Verify target git status contains the transferred paths and, for regular files, verify copied bytes match the source snapshot.
+8. Remove the moved paths from the source checkout only after successful target write and verification:
+   - Modified tracked file: restore source from HEAD.
+   - Untracked file: delete source file.
+9. Verify the source checkout no longer has the moved file changes.
+10. Rebind the active session/provider context to the prepared worktree.
+11. Persist `session.worktreePath`.
+12. Return a detailed report.
+
+Important safety rule:
+
+Do not move partial hunks. If a file has both session edits and user edits, Acepe cannot safely split them with current data. In that case the whole move is unavailable until Acepe can prove ownership or the user chooses `Continue in new worktree`.
+
+Rollback and failure behavior:
+
+- The command is all-or-nothing for v1.
+- If any preflight or target-write step fails before source cleanup, remove the prepared worktree and leave the source checkout untouched.
+- If source cleanup fails after target verification, return a blocking recovery error with the exact files and do not persist `session.worktreePath`.
+- Never return a success-shaped partial transfer. `blockedFiles` only appears in failure/preflight responses.
+- Execute git operations through argv-style command invocation, never through shell-interpolated strings.
+
+### 6. Session-owned file detection
+
+Use existing modified-files aggregation:
+
+- `aggregateFileEdits(sessionEntries)`
+- Existing `modifiedFilesState`
+
+Then cross-check against git status from source checkout.
+
+Plan:
+
+- Add a small pure helper:
+  - `deriveWorktreeSwitchMovePreview({ modifiedFilesState, gitStatus })`
+- Output:
+  - `moveAvailable`
+  - `files`
+  - `unavailableReason`
+  - `unsafeFiles`
+  - `otherDirtyFiles`
+
+Initial scope:
+
+- Treat files from edit tool calls as candidate session-owned files.
+- Only allow move when every candidate path is dirty, unstaged, not deleted, not a symlink, and ownership can be proven from a reconstructable original-to-final delta.
+- If there are extra dirty paths not attributed to the session, allow continue-only but show: `Other local changes will stay in the current checkout.`
+- Source-only preview does not claim target safety. Target conflicts are execution-time backend preflight failures because the prepared worktree does not exist until execution.
+
+V1 preview matrix:
+
+| Source status | Preview result |
+|---------------|----------------|
+| Modified tracked file, unstaged, ownership proven | Movable |
+| Untracked regular file, ownership proven | Movable |
+| Staged or partially staged file | Move unavailable |
+| Deleted tracked file | Move unavailable in v1 |
+| Renamed/typechanged/submodule path | Move unavailable in v1 |
+| Symlink file or symlink-resolving path | Move unavailable in v1 |
+| Candidate with unproven mixed user edits | Move unavailable |
+| Dirty file not attributed to session | Not moved; does not block move |
+
+### 7. Canonical state boundary
+
+This touches session worktree path and active working directory. Before implementation, run the GOD architecture check.
+
+Expected rule:
+
+- The durable session `worktreePath` remains the canonical session-level fact once a worktree is attached.
+- Panel-local `activeWorktreePath` can remain an optimistic/transient bridge during creation, but must converge to `sessionStore.updateSession(... worktreePath)` after success.
+- Do not introduce a second durable worktree authority in panel hot state.
+
+## Test plan
+
+### Unit tests
+
+1. `worktree-switch-preview.test.ts`
+   - Candidate files from `modifiedFilesState` become movable.
+   - Extra dirty user files do not block continue-only or a safe all-or-nothing move of proven session files.
+   - Staged files disable move.
+   - Path traversal candidates are rejected.
+   - Deleted-file candidates disable move in v1.
+   - Candidate files without reconstructable ownership proof disable move.
+   - No candidate files disables move.
+
+2. `mid-session-worktree-switch-service.test.ts`
+   - Continue-only creates a prepared launch and returns target path.
+   - Failure returns an explicit error and does not update session state.
+
+3. Rust git command tests
+   - Modified tracked file moves to target and restores source.
+   - Untracked file moves to target and deletes source.
+   - Staged file is rejected.
+   - Deleted tracked file disables move in v1.
+   - Unsafe path is rejected.
+   - Symlink files and symlink escape paths are rejected.
+   - Conflicting target content is rejected.
+   - Target-write failure leaves source and durable session state unchanged.
+   - Source-restore/delete failure returns a blocking recovery error and does not persist `session.worktreePath`.
+   - Nested untracked directories and unsupported statuses are rejected.
+   - Binary regular files move by byte equality, not text decoding.
+
+### Component tests
+
+1. `agent-panel-worktree-switch-dialog.svelte.vitest.ts`
+   - Renders both options when move is available.
+   - Disables move with reason.
+   - Calls `onContinue`, `onMove`, `onCancel`.
+
+2. Agent panel toggle flow test
+   - Mid-session Worktree click opens dialog instead of immediately setting pending.
+   - Continue action updates session worktree path.
+   - Cancel leaves toggle state unchanged.
+
+### Manual verification
+
+- Start a project-root session.
+- Make an agent edit.
+- Turn on Worktree from the footer pill.
+- Choose `Continue in new worktree`; verify future terminal/git context points at the worktree and source dirty files remain.
+- Repeat and choose `Move session changes`; verify session files appear dirty in target worktree, source checkout is clean for moved files, unrelated source dirty files remain, and deleted-file candidates disable move.
+
+## Implementation order
+
+1. Add pure preview helper and tests.
+2. Add continue-only mid-session worktree service and provider/session rebind tests.
+3. Add shared UI dialog and component tests for continue/cancel plus disabled move states.
+4. Wire the mid-session dialog for continue-only and cancel.
+5. Add backend transfer command with Rust tests.
+6. Wire `Move session changes` behind the preview/capability gate.
+7. Run:
+   - `cd packages/desktop && bun run check`
+   - targeted Bun/Vitest tests
+   - relevant Rust git tests
+   - `cd packages/desktop/src-tauri && cargo clippy` if Rust command changes require it.
+
+## Resolved scope decisions
+
+1. `Move session changes` is all-or-nothing in v1.
+2. Deleted files are not transferred in v1. A deleted session-attributed file disables `Move session changes` with a clear reason.
+3. The dialog shows a count plus an expandable file list.

--- a/packages/desktop/src-tauri/tauri.conf.json
+++ b/packages/desktop/src-tauri/tauri.conf.json
@@ -22,7 +22,7 @@
 				"hiddenTitle": true,
 				"titleBarStyle": "Overlay",
 				"dragDropEnabled": true,
-				"devtools": false
+				"devtools": true
 			}
 		],
 		"withGlobalTauri": true,

--- a/packages/desktop/src/lib/acp/components/agent-input/agent-input-ui.svelte
+++ b/packages/desktop/src/lib/acp/components/agent-input/agent-input-ui.svelte
@@ -705,7 +705,7 @@ const agentInputController = createAgentInputController({
 	getComposerInteraction: () => composerInteraction,
 	getAutonomousToggleActive: () => autonomousToggleActive,
 	getProvisionalModeId: () => provisionalModeId,
-	getProvisionalModelId: () => provisionalModelId,
+	getProvisionalModelId: () => provisionalModelId ?? preferredDefaultModelId,
 	getIsStreaming: () => isStreaming,
 	sessionStore,
 	panelStore,

--- a/packages/desktop/src/lib/acp/components/agent-panel/components/__tests__/fixtures/shared-terminal-drawer-stub.svelte
+++ b/packages/desktop/src/lib/acp/components/agent-panel/components/__tests__/fixtures/shared-terminal-drawer-stub.svelte
@@ -2,16 +2,19 @@
 import type { Snippet } from "svelte";
 
 interface Props {
-	height: number;
+	height?: number | null;
 	resizeHandle?: Snippet;
 	tabs: Snippet;
 	body: Snippet;
 }
 
-let { height, resizeHandle, tabs, body }: Props = $props();
+let { height = null, resizeHandle, tabs, body }: Props = $props();
 </script>
 
-<div data-testid="shared-terminal-drawer-stub" style={`height: ${height}px;`}>
+<div
+	data-testid="shared-terminal-drawer-stub"
+	style={height === null ? "height: 100%;" : `height: ${height}px;`}
+>
 	{#if resizeHandle}
 		{@render resizeHandle()}
 	{/if}

--- a/packages/desktop/src/lib/acp/components/agent-panel/components/agent-panel-layout.test.ts
+++ b/packages/desktop/src/lib/acp/components/agent-panel/components/agent-panel-layout.test.ts
@@ -18,6 +18,8 @@ describe("agent panel layout", () => {
 				planSidebarColumnWidth: 450,
 				showBrowserSidebar: false,
 				browserSidebarColumnWidth: 500,
+				showTerminalSidebar: false,
+				terminalSidebarColumnWidth: 500,
 			})
 		).toBe(1800);
 	});
@@ -32,8 +34,10 @@ describe("agent panel layout", () => {
 				planSidebarColumnWidth: 450,
 				showBrowserSidebar: true,
 				browserSidebarColumnWidth: 500,
+				showTerminalSidebar: true,
+				terminalSidebarColumnWidth: 500,
 			})
-		).toBe(2750);
+		).toBe(3250);
 	});
 
 	it("allows fullscreen panels to shrink inside split layouts", () => {

--- a/packages/desktop/src/lib/acp/components/agent-panel/components/agent-panel-layout.ts
+++ b/packages/desktop/src/lib/acp/components/agent-panel/components/agent-panel-layout.ts
@@ -11,6 +11,8 @@ interface AgentPanelEffectiveWidthInput {
 	planSidebarColumnWidth: number;
 	showBrowserSidebar: boolean;
 	browserSidebarColumnWidth: number;
+	showTerminalSidebar: boolean;
+	terminalSidebarColumnWidth: number;
 }
 
 interface AttachedPaneLayoutInput {
@@ -33,6 +35,10 @@ export function resolveAgentPanelEffectiveWidth(input: AgentPanelEffectiveWidthI
 
 	if (input.showBrowserSidebar) {
 		width += input.browserSidebarColumnWidth;
+	}
+
+	if (input.showTerminalSidebar) {
+		width += input.terminalSidebarColumnWidth;
 	}
 
 	return width;

--- a/packages/desktop/src/lib/acp/components/agent-panel/components/agent-panel-pre-composer-stack.svelte
+++ b/packages/desktop/src/lib/acp/components/agent-panel/components/agent-panel-pre-composer-stack.svelte
@@ -17,11 +17,9 @@ import { AgentPanelQueueCardStrip as SharedQueueCardStrip } from "@acepe/ui/agen
 import { AgentPanelTodoHeader as SharedTodoHeader } from "@acepe/ui/agent-panel";
 import CopyButton from "../../messages/copy-button.svelte";
 import PermissionBar from "../../tool-calls/permission-bar.svelte";
-import PreSessionWorktreeCard from "./pre-session-worktree-card.svelte";
 import WorktreeSetupCard from "./worktree-setup-card.svelte";
 import AgentInstallCard from "./agent-install-card.svelte";
 import AgentErrorCard from "./agent-error-card.svelte";
-import { getWorktreeDefaultStore } from "../../worktree/worktree-default-store.svelte.js";
 import type { WorktreeSetupState } from "../logic/worktree-setup-events.js";
 import type { ShipCardData } from "../../ship-card/ship-card-parser.js";
 
@@ -54,16 +52,6 @@ let {
 	onCopyInlineErrorReference,
 	inlineErrorIssueDraft,
 	onIssueFromInlineError,
-	showPreSessionWorktreeCard,
-	worktreePending,
-	worktreeToggleProjectPath,
-	effectiveProjectName,
-	preSessionWorktreeFailure,
-	onPreSessionWorktreeYes,
-	onPreSessionWorktreeNo,
-	onPreSessionWorktreeAlways,
-	onPreSessionWorktreeDismiss,
-	onRetryWorktree,
 	worktreeSetupState,
 	agentInstallState,
 	sessionId,
@@ -116,16 +104,6 @@ let {
 	onCopyInlineErrorReference: () => void;
 	inlineErrorIssueDraft: IssueReportDraft | null;
 	onIssueFromInlineError: () => void;
-	showPreSessionWorktreeCard: boolean;
-	worktreePending: boolean;
-	worktreeToggleProjectPath: string | null;
-	effectiveProjectName: string | null;
-	preSessionWorktreeFailure: string | null;
-	onPreSessionWorktreeYes: () => void;
-	onPreSessionWorktreeNo: () => void;
-	onPreSessionWorktreeAlways: () => void;
-	onPreSessionWorktreeDismiss: () => void;
-	onRetryWorktree: () => void;
 	worktreeSetupState: WorktreeSetupState | null;
 	agentInstallState: {
 		agentId: string;
@@ -204,20 +182,6 @@ let {
 									? resolveIssueActionLabel(inlineErrorIssueDraft)
 									: "Create issue"}
 								onIssueAction={inlineErrorIssueDraft ? onIssueFromInlineError : undefined}
-							/>
-						{/if}
-						{#if showPreSessionWorktreeCard && worktreeToggleProjectPath}
-							<PreSessionWorktreeCard
-								pendingWorktreeEnabled={worktreePending}
-								alwaysEnabled={getWorktreeDefaultStore().globalDefault}
-								failureMessage={preSessionWorktreeFailure}
-								projectPath={worktreeToggleProjectPath}
-								projectName={effectiveProjectName ?? null}
-								onYes={onPreSessionWorktreeYes}
-								onNo={onPreSessionWorktreeNo}
-								onAlways={onPreSessionWorktreeAlways}
-								onDismiss={onPreSessionWorktreeDismiss}
-								onRetry={worktreePending ? onRetryWorktree : undefined}
 							/>
 						{/if}
 						{#if worktreeSetupState?.isVisible}

--- a/packages/desktop/src/lib/acp/components/agent-panel/components/agent-panel-terminal-drawer.svelte
+++ b/packages/desktop/src/lib/acp/components/agent-panel/components/agent-panel-terminal-drawer.svelte
@@ -22,9 +22,10 @@ interface Props {
 	effectiveCwd: string;
 	embeddedTerminals: EmbeddedTerminalStore;
 	onClose: () => void;
+	variant?: "bottom" | "side";
 }
 
-let { panelId, effectiveCwd, embeddedTerminals, onClose }: Props = $props();
+let { panelId, effectiveCwd, embeddedTerminals, onClose, variant = "bottom" }: Props = $props();
 
 // ---- State ----
 
@@ -128,19 +129,21 @@ function handleResizePointerUp(): void {
 }
 </script>
 
-<SharedAgentPanelTerminalDrawer height={clampedHeight}>
-	{#snippet resizeHandle()}
-		<div
-			class="h-px hover:h-[3px] cursor-row-resize shrink-0 bg-border hover:bg-primary/50 transition-all
-				{isResizing ? 'h-[3px] bg-primary/50' : ''}"
-			role="separator"
-			aria-orientation="horizontal"
-			onpointerdown={handleResizePointerDown}
-			onpointermove={handleResizePointerMove}
-			onpointerup={handleResizePointerUp}
-			onpointercancel={handleResizePointerUp}
-		></div>
-	{/snippet}
+<SharedAgentPanelTerminalDrawer height={variant === "bottom" ? clampedHeight : null}>
+	{#if variant === "bottom"}
+		{#snippet resizeHandle()}
+			<div
+				class="h-px hover:h-[3px] cursor-row-resize shrink-0 bg-border hover:bg-primary/50 transition-all
+					{isResizing ? 'h-[3px] bg-primary/50' : ''}"
+				role="separator"
+				aria-orientation="horizontal"
+				onpointerdown={handleResizePointerDown}
+				onpointermove={handleResizePointerMove}
+				onpointerup={handleResizePointerUp}
+				onpointercancel={handleResizePointerUp}
+			></div>
+		{/snippet}
+	{/if}
 
 	{#snippet tabs()}
 		{#each terminalTabs as tab, i (tab.id)}

--- a/packages/desktop/src/lib/acp/components/agent-panel/components/agent-panel.svelte
+++ b/packages/desktop/src/lib/acp/components/agent-panel/components/agent-panel.svelte
@@ -100,6 +100,7 @@ import {
 } from "../../../types/reply-handler.js";
 import { AgentPanelFooter as SharedFooter } from "@acepe/ui/agent-panel";
 import WorktreeFooterButton from "../../shared/worktree-footer-button.svelte";
+import WorktreeTogglePill from "../../shared/worktree-toggle-pill.svelte";
 import AgentPanelContent from "./agent-panel-content.svelte";
 import AgentPanelHeader from "./agent-panel-header.svelte";
 import AgentPanelResizeEdge from "./agent-panel-resize-edge.svelte";
@@ -112,6 +113,7 @@ import { BrowserPanel as BrowserPanelComponent } from "../../browser-panel/index
 import {
 	AgentPanelTrailingPaneLayout,
 	AgentPanelWorktreeCloseConfirmPopover,
+	AgentPanelWorktreeSwitchDialog,
 } from "@acepe/ui/agent-panel";
 import ScrollToBottomButton from "./scroll-to-bottom-button.svelte";
 import {
@@ -151,6 +153,7 @@ import {
 	openSessionRawFileInEditor,
 	openStreamingLog,
 	persistSessionWorktreePathAfterRename,
+	prepareMidSessionWorktreeSwitch,
 	removeWorktreeFromDisk,
 	runCreatePrWorkflow,
 	runMergePrWorkflow,
@@ -1081,6 +1084,7 @@ const hasPlan = $derived(planState.plan !== null);
 const ATTACHED_COLUMN_WIDTH = 450;
 const PLAN_SIDEBAR_COLUMN_WIDTH = 450;
 const BROWSER_SIDEBAR_COLUMN_WIDTH = 500;
+const TERMINAL_SIDEBAR_COLUMN_WIDTH = 500;
 const ATTACHED_COLUMN_GAP_WIDTH = 2;
 
 // Dynamic minimum width reported by the toolbar's intrinsic content measurement.
@@ -1096,6 +1100,9 @@ let streamingShipData = $state<import("../../ship-card/ship-card-parser.js").Shi
 );
 let prCardRenderKey = $state(0);
 let preSessionWorktreeFailure = $state<string | null>(null);
+let worktreeSwitchDialogOpen = $state(false);
+let worktreeSwitchBusy = $state(false);
+let worktreeSwitchError = $state<string | null>(null);
 let agentInputRef = $state<{
 	retrySend: () => void;
 	restoreQueuedMessage: (draft: string, attachments: readonly Attachment[]) => void;
@@ -1266,6 +1273,8 @@ const effectiveWidth = $derived.by(() =>
 		planSidebarColumnWidth: PLAN_SIDEBAR_COLUMN_WIDTH,
 		showBrowserSidebar,
 		browserSidebarColumnWidth: BROWSER_SIDEBAR_COLUMN_WIDTH,
+		showTerminalSidebar: Boolean(isTerminalDrawerOpen && effectivePathForGit),
+		terminalSidebarColumnWidth: TERMINAL_SIDEBAR_COLUMN_WIDTH,
 	})
 );
 
@@ -2114,9 +2123,54 @@ function handlePreSessionWorktreeYes(): void {
 	if (store.globalDefault) {
 		void store.set(false);
 	}
+	// Mid-session switch: the session is live and not yet attached to a worktree.
+	// Surface a confirmation dialog instead of silently flipping pending state,
+	// so the user can choose whether existing changes stay in the source checkout.
+	if (
+		sessionId !== null &&
+		hasMessages &&
+		effectiveActiveWorktreePath === null &&
+		!panelPreparedWorktreeLaunch
+	) {
+		worktreeSwitchError = null;
+		worktreeSwitchDialogOpen = true;
+		return;
+	}
 	if (panelId) {
 		panelStore.setPendingWorktreeEnabled(panelId, true);
 	}
+}
+
+function handleWorktreeSwitchContinue(): void {
+	const projectPath = sessionProjectPath ?? worktreeToggleProjectPath ?? "";
+	const agentId = effectivePanelAgentId;
+	if (!projectPath || !agentId) {
+		worktreeSwitchError = "Cannot create worktree: project or agent missing.";
+		return;
+	}
+	worktreeSwitchBusy = true;
+	worktreeSwitchError = null;
+	void prepareMidSessionWorktreeSwitch({ projectPath, agentId }).match(
+		(result) => {
+			worktreeSwitchBusy = false;
+			worktreeSwitchDialogOpen = false;
+			handlePreparedWorktreeLaunch(result.preparedLaunch);
+			handleWorktreeCreated(result.preparedLaunch.worktree);
+			if (panelId) {
+				panelStore.setPendingWorktreeEnabled(panelId, true);
+			}
+		},
+		(error) => {
+			worktreeSwitchBusy = false;
+			worktreeSwitchError = error.message || "Failed to create worktree.";
+		}
+	);
+}
+
+function handleWorktreeSwitchCancel(): void {
+	if (worktreeSwitchBusy) return;
+	worktreeSwitchDialogOpen = false;
+	worktreeSwitchError = null;
 }
 
 function handlePreSessionWorktreeNo(): void {
@@ -2517,16 +2571,6 @@ async function handlePlanSidebarSendMessage(sid: string, message: string): Promi
 			onCopyInlineErrorReference={handleCopyInlineErrorReference}
 			inlineErrorIssueDraft={inlineErrorIssueDraft}
 			onIssueFromInlineError={handleIssueFromInlineError}
-			{showPreSessionWorktreeCard}
-			{worktreePending}
-			worktreeToggleProjectPath={worktreeToggleProjectPath}
-			effectiveProjectName={effectiveProjectName ?? null}
-			{preSessionWorktreeFailure}
-			onPreSessionWorktreeYes={handlePreSessionWorktreeYes}
-			onPreSessionWorktreeNo={handlePreSessionWorktreeNo}
-			onPreSessionWorktreeAlways={handlePreSessionWorktreeAlways}
-			onPreSessionWorktreeDismiss={handlePreSessionWorktreeDismiss}
-			onRetryWorktree={handleRetryWorktree}
 			{worktreeSetupState}
 			{agentInstallState}
 			{sessionId}
@@ -2687,28 +2731,25 @@ async function handlePlanSidebarSendMessage(sid: string, message: string): Promi
 									label={footerWorktreeStatus.primaryLabel}
 									mode={footerWorktreeStatus.mode}
 								/>
+							{:else if showPreSessionWorktreeCard && worktreeToggleProjectPath}
+								<WorktreeTogglePill
+									enabled={worktreePending}
+									projectPath={worktreeToggleProjectPath}
+									failureMessage={preSessionWorktreeFailure}
+									onToggle={() => {
+										if (worktreePending) {
+											handlePreSessionWorktreeNo();
+										} else {
+											handlePreSessionWorktreeYes();
+										}
+									}}
+									onRetry={handleRetryWorktree}
+									onDismiss={handlePreSessionWorktreeDismiss}
+								/>
 							{/if}
 						</div>
 					{/snippet}
 				</SharedFooter>
-			{/if}
-		</div>
-	{/snippet}
-
-	{#snippet bottomDrawer()}
-		<div style:display={reviewMode ? "none" : undefined}>
-			{#if
-				(viewState.kind === "conversation" || viewState.kind === "ready" || viewState.kind === "error") &&
-				isTerminalDrawerOpen &&
-				panelId &&
-				effectivePathForGit
-			}
-				<AgentPanelTerminalDrawer
-					{panelId}
-					effectiveCwd={effectivePathForGit}
-					embeddedTerminals={panelStore.embeddedTerminals}
-					onClose={() => panelStore.setEmbeddedTerminalDrawerOpen(panelId, false)}
-				/>
 			{/if}
 		</div>
 	{/snippet}
@@ -2718,6 +2759,7 @@ async function handlePlanSidebarSendMessage(sid: string, message: string): Promi
 			<AgentPanelTrailingPaneLayout
 				showPlan={Boolean(hasPlan && planState.plan && showPlanSidebar)}
 				showBrowser={Boolean(showBrowserSidebar)}
+				showTerminal={Boolean(isTerminalDrawerOpen && effectivePathForGit)}
 			>
 				{#snippet plan()}
 					<PlanSidebar
@@ -2743,6 +2785,22 @@ async function handlePlanSidebarSendMessage(sid: string, message: string): Promi
 							onResize={() => {}}
 						/>
 					</div>
+				{/snippet}
+				{#snippet terminal()}
+					{#if effectivePathForGit}
+						<div
+							class="flex flex-col h-full border-l border-border/50 shrink-0"
+							style="min-width: {TERMINAL_SIDEBAR_COLUMN_WIDTH}px; width: {TERMINAL_SIDEBAR_COLUMN_WIDTH}px; max-width: {TERMINAL_SIDEBAR_COLUMN_WIDTH}px;"
+						>
+							<AgentPanelTerminalDrawer
+								{panelId}
+								effectiveCwd={effectivePathForGit}
+								embeddedTerminals={panelStore.embeddedTerminals}
+								variant="side"
+								onClose={() => panelStore.setEmbeddedTerminalDrawerOpen(panelId, false)}
+							/>
+						</div>
+					{/if}
 				{/snippet}
 			</AgentPanelTrailingPaneLayout>
 		{/if}
@@ -2850,4 +2908,21 @@ async function handlePlanSidebarSendMessage(sid: string, message: string): Promi
 	confirmDisabled={worktreeDirtyCheckPending}
 	onCancel={handleWorktreeCloseCancel}
 	onConfirmRemoveAndClose={handleWorktreeRemoveAndClose}
+/>
+
+<AgentPanelWorktreeSwitchDialog
+	bind:open={worktreeSwitchDialogOpen}
+	title="Start using a worktree?"
+	description="Future agent changes can go into a fresh worktree. Existing changes from this session stay in the current checkout."
+	continueLabel="Continue in new worktree"
+	continueHelperText="Existing changes stay in the current checkout. Future turns use the new worktree."
+	moveLabel="Move session changes"
+	moveHelperText="Coming soon — requires proving each file is fully session-owned."
+	cancelLabel="Cancel"
+	moveAvailable={false}
+	moveUnavailableReason="Moving session changes is not available yet. Continue creates a new worktree and leaves existing changes untouched."
+	busy={worktreeSwitchBusy}
+	errorMessage={worktreeSwitchError ?? undefined}
+	onContinue={handleWorktreeSwitchContinue}
+	onCancel={handleWorktreeSwitchCancel}
 />

--- a/packages/desktop/src/lib/acp/components/agent-panel/logic/__tests__/pre-session-worktree-card-visibility.test.ts
+++ b/packages/desktop/src/lib/acp/components/agent-panel/logic/__tests__/pre-session-worktree-card-visibility.test.ts
@@ -18,7 +18,7 @@ describe("shouldShowPreSessionWorktreeCard", () => {
 		expect(shouldShowPreSessionWorktreeCard(baseInput())).toBe(true);
 	});
 
-	it("hides after the user has sent a message", () => {
+	it("stays visible after the user has sent a message", () => {
 		const input = baseInput();
 
 		expect(
@@ -30,6 +30,21 @@ describe("shouldShowPreSessionWorktreeCard", () => {
 				worktreeSetupVisible: input.worktreeSetupVisible,
 				hasMessages: true,
 			})
-		).toBe(false);
+		).toBe(true);
+	});
+
+	it("stays visible after a session attaches", () => {
+		const input = baseInput();
+
+		expect(
+			shouldShowPreSessionWorktreeCard({
+				sessionId: "session-1",
+				pendingProjectSelection: input.pendingProjectSelection,
+				worktreeToggleProjectPath: input.worktreeToggleProjectPath,
+				hasPendingWorktreeSetup: input.hasPendingWorktreeSetup,
+				worktreeSetupVisible: input.worktreeSetupVisible,
+				hasMessages: true,
+			})
+		).toBe(true);
 	});
 });

--- a/packages/desktop/src/lib/acp/components/agent-panel/logic/pre-session-worktree-card-visibility.ts
+++ b/packages/desktop/src/lib/acp/components/agent-panel/logic/pre-session-worktree-card-visibility.ts
@@ -7,11 +7,9 @@ export function shouldShowPreSessionWorktreeCard(input: {
 	readonly hasMessages: boolean;
 }): boolean {
 	return (
-		input.sessionId === null &&
 		!input.pendingProjectSelection &&
 		input.worktreeToggleProjectPath !== null &&
 		!input.hasPendingWorktreeSetup &&
-		!input.worktreeSetupVisible &&
-		!input.hasMessages
+		!input.worktreeSetupVisible
 	);
 }

--- a/packages/desktop/src/lib/acp/components/agent-panel/services/index.ts
+++ b/packages/desktop/src/lib/acp/components/agent-panel/services/index.ts
@@ -38,3 +38,4 @@ export type { CreatePrWorkflowDeps } from "./agent-panel-ship-workflow.js";
 export { runCreatePrWorkflow, runMergePrWorkflow } from "./agent-panel-ship-workflow.js";
 export { subscribeGitWorktreeSetupChannel } from "./agent-panel-worktree-setup-channel.js";
 export { discardPreparedWorktreeSessionLaunch } from "./prepared-worktree-launch-service.js";
+export { prepareMidSessionWorktreeSwitch } from "./mid-session-worktree-switch-service.js";

--- a/packages/desktop/src/lib/acp/components/agent-panel/services/mid-session-worktree-switch-service.ts
+++ b/packages/desktop/src/lib/acp/components/agent-panel/services/mid-session-worktree-switch-service.ts
@@ -1,0 +1,76 @@
+/**
+ * Mid-session worktree switch service (Continue-only path).
+ *
+ * Creates a prepared worktree session launch for an already-active session,
+ * runs the worktree setup orchestration in the background, and returns the
+ * prepared launch so the panel can rebind future sends to the new worktree.
+ *
+ * Existing changes in the source checkout are left untouched. Moving
+ * session-owned changes is intentionally out of scope for this service.
+ */
+
+import { ResultAsync, errAsync, okAsync } from "neverthrow";
+import { toast } from "svelte-sonner";
+
+import { ValidationError, type AppError } from "$lib/acp/errors/app-error.js";
+import { tauriClient } from "$lib/utils/tauri-client.js";
+import type { PreparedWorktreeLaunch } from "../../../types/worktree-info.js";
+import { createLogger } from "../../../utils/logger.js";
+import { runWorktreeSetup } from "../../worktree/worktree-setup-orchestrator.js";
+
+const logger = createLogger({
+	id: "mid-session-worktree-switch-service",
+	name: "MidSessionWorktreeSwitchService",
+});
+
+export interface MidSessionWorktreeSwitchResult {
+	readonly preparedLaunch: PreparedWorktreeLaunch;
+	readonly worktreePath: string;
+}
+
+/**
+ * Prepare a new worktree for the current session and kick off setup.
+ *
+ * The returned `ResultAsync` resolves only after the Tauri prepare call
+ * succeeds. Worktree setup commands run in the background; their failure is
+ * surfaced via toast, not as a failed switch, matching first-send behavior.
+ */
+export function prepareMidSessionWorktreeSwitch(args: {
+	projectPath: string;
+	agentId: string;
+}): ResultAsync<MidSessionWorktreeSwitchResult, AppError> {
+	const { projectPath, agentId } = args;
+
+	if (!projectPath) {
+		return errAsync(
+			new ValidationError("Cannot create a worktree without a project path.", "projectPath")
+		);
+	}
+	if (!agentId) {
+		return errAsync(
+			new ValidationError("Cannot create a worktree without a selected agent.", "agentId")
+		);
+	}
+
+	return tauriClient.git
+		.prepareWorktreeSessionLaunch(projectPath, agentId)
+		.andThen((preparedLaunch) => {
+			void runWorktreeSetup({
+				projectPath,
+				worktreeCwd: preparedLaunch.worktree.directory,
+			}).match(
+				(result) => {
+					if (!result.setupSuccess) toast.warning("Setup script failed");
+				},
+				(error) => {
+					logger.warn("Worktree setup failed", { error });
+					toast.warning("Setup script failed");
+				}
+			);
+
+			return okAsync({
+				preparedLaunch,
+				worktreePath: preparedLaunch.worktree.directory,
+			});
+		});
+}

--- a/packages/desktop/src/lib/acp/components/browser-panel/logic/scroll-sync.test.ts
+++ b/packages/desktop/src/lib/acp/components/browser-panel/logic/scroll-sync.test.ts
@@ -26,6 +26,22 @@ describe("browser panel scroll sync", () => {
 		expect(targets).toContain(window);
 	});
 
+	it("includes overflow ancestors before they become scrollable", () => {
+		const outer = document.createElement("div");
+		outer.style.overflowX = "auto";
+		Object.defineProperty(outer, "scrollWidth", { value: 400, configurable: true });
+		Object.defineProperty(outer, "clientWidth", { value: 400, configurable: true });
+
+		const target = document.createElement("div");
+		outer.appendChild(target);
+		document.body.appendChild(outer);
+
+		const targets = getScrollEventTargets(target);
+
+		expect(targets).toContain(outer);
+		expect(targets).toContain(window);
+	});
+
 	it("re-runs sync callback when a scroll parent scrolls", () => {
 		const outer = document.createElement("div");
 		outer.style.overflowY = "auto";

--- a/packages/desktop/src/lib/acp/components/browser-panel/logic/scroll-sync.ts
+++ b/packages/desktop/src/lib/acp/components/browser-panel/logic/scroll-sync.ts
@@ -1,13 +1,11 @@
-function isScrollable(element: HTMLElement): boolean {
+function canBecomeScrollable(element: HTMLElement): boolean {
 	const style = window.getComputedStyle(element);
 	const overflowX = style.overflowX;
 	const overflowY = style.overflowY;
 	const canScrollX = overflowX === "auto" || overflowX === "scroll" || overflowX === "overlay";
 	const canScrollY = overflowY === "auto" || overflowY === "scroll" || overflowY === "overlay";
-	const hasScrollableXContent = element.scrollWidth > element.clientWidth;
-	const hasScrollableYContent = element.scrollHeight > element.clientHeight;
 
-	return (canScrollX && hasScrollableXContent) || (canScrollY && hasScrollableYContent);
+	return canScrollX || canScrollY;
 }
 
 export function getScrollEventTargets(node: HTMLElement): EventTarget[] {
@@ -15,7 +13,7 @@ export function getScrollEventTargets(node: HTMLElement): EventTarget[] {
 	let currentParent: HTMLElement | null = node.parentElement;
 
 	while (currentParent) {
-		if (isScrollable(currentParent)) {
+		if (canBecomeScrollable(currentParent)) {
 			targets.push(currentParent);
 		}
 		currentParent = currentParent.parentElement;

--- a/packages/desktop/src/lib/acp/components/project-header-overflow-menu.svelte
+++ b/packages/desktop/src/lib/acp/components/project-header-overflow-menu.svelte
@@ -1,8 +1,11 @@
 <script lang="ts">
 import * as DropdownMenu from "@acepe/ui/dropdown-menu";
 import { mergeProps } from "bits-ui";
+import { ArrowDown } from "phosphor-svelte";
 import { ArrowCounterClockwise } from "phosphor-svelte";
-import { DotsThreeVertical } from "phosphor-svelte";
+import { ArrowUp } from "phosphor-svelte";
+import { Gear } from "phosphor-svelte";
+import { ImageSquare } from "phosphor-svelte";
 import { Palette } from "phosphor-svelte";
 import { Trash } from "phosphor-svelte";
 import * as Popover from "$lib/components/ui/popover/index.js";
@@ -18,6 +21,11 @@ interface Props {
 	projectIconSrc?: string | null;
 	onResetProjectIcon?: () => void;
 	onRemoveProject?: () => void;
+	onMoveUp?: () => void;
+	onMoveDown?: () => void;
+	moveUpDisabled?: boolean;
+	moveDownDisabled?: boolean;
+	onChangeProjectIcon?: () => void;
 }
 
 let {
@@ -27,6 +35,11 @@ let {
 	projectIconSrc = null,
 	onResetProjectIcon,
 	onRemoveProject,
+	onMoveUp,
+	onMoveDown,
+	moveUpDisabled = false,
+	moveDownDisabled = false,
+	onChangeProjectIcon,
 }: Props = $props();
 
 let menuOpen = $state(false);
@@ -49,18 +62,16 @@ const hasIcon = $derived(Boolean(projectIconSrc));
 const hasResetProjectIcon = $derived(Boolean(hasIcon && onResetProjectIcon));
 const showColorPicker = $derived(Boolean(onColorChange && !hasIcon));
 const showSettingsSection = $derived(
-	Boolean(showColorPicker || onRemoveProject || hasResetProjectIcon)
+	Boolean(
+		showColorPicker ||
+			onRemoveProject ||
+			hasResetProjectIcon ||
+			onMoveUp ||
+			onMoveDown ||
+			onChangeProjectIcon
+	)
 );
-const displaySectionClass = $derived(
-	`px-2 py-1.5${
-		showColorPicker || onRemoveProject || hasResetProjectIcon ? " border-b border-border/20" : ""
-	}`
-);
-const colorTriggerClass = $derived(
-	`rounded-none px-2 py-1.5 text-[11px]${
-		onRemoveProject || hasResetProjectIcon ? " border-b border-border/20" : ""
-	}`
-);
+const colorTriggerClass = "font-normal border-b-0";
 
 function handleRemoveClick() {
 	menuOpen = false;
@@ -81,31 +92,65 @@ function handleRemoveClick() {
 							bind:this={triggerRef}
 							type="button"
 							class="flex items-center justify-center size-5 min-w-0 shrink-0 rounded text-muted-foreground transition-colors hover:bg-accent hover:text-foreground"
-							aria-label="Project menu"
+							aria-label="Project settings"
 						>
-							<DotsThreeVertical class="h-3.5 w-3.5" weight="bold" />
+							<Gear class="h-3 w-3" weight="fill" />
 						</button>
 					{/snippet}
 				</DropdownMenu.Trigger>
 			{/snippet}
 		</Tooltip.Trigger>
-		<Tooltip.Content side="bottom">Project menu</Tooltip.Content>
+		<Tooltip.Content side="bottom">Project settings</Tooltip.Content>
 	</Tooltip.Root>
 	<DropdownMenu.Content align="end" side="bottom" class="min-w-[200px] p-0 text-[11px]">
 		{#if showSettingsSection}
 			<DropdownMenu.Group>
-				<DropdownMenu.GroupHeading
-					class="px-2 py-1 text-[11px] font-semibold text-muted-foreground border-b border-border/20"
-				>
-					Settings
-				</DropdownMenu.GroupHeading>
+				{#if onMoveUp}
+					<DropdownMenu.Item
+						disabled={moveUpDisabled}
+						class="font-normal border-b-0"
+						onclick={() => {
+							onMoveUp?.();
+							menuOpen = false;
+						}}
+					>
+						<ArrowUp weight="bold" />
+						{"Move Up"}
+					</DropdownMenu.Item>
+				{/if}
+				{#if onMoveDown}
+					<DropdownMenu.Item
+						disabled={moveDownDisabled}
+						class="font-normal border-b-0"
+						onclick={() => {
+							onMoveDown?.();
+							menuOpen = false;
+						}}
+					>
+						<ArrowDown weight="bold" />
+						{"Move Down"}
+					</DropdownMenu.Item>
+				{/if}
+				{#if (onMoveUp || onMoveDown) && (onChangeProjectIcon || showColorPicker || hasResetProjectIcon || onRemoveProject)}{/if}
+				{#if onChangeProjectIcon}
+					<DropdownMenu.Item
+						class="font-normal border-b-0"
+						onclick={() => {
+							onChangeProjectIcon?.();
+							menuOpen = false;
+						}}
+					>
+						<ImageSquare weight="fill" />
+						{"Change icon"}
+					</DropdownMenu.Item>
+				{/if}
 				{#if onColorChange && !hasIcon}
 					<DropdownMenu.Sub>
 						<DropdownMenu.SubTrigger class={colorTriggerClass}>
-							<Palette class="h-3.5 w-3.5 mr-2" weight="fill" />
+							<Palette weight="fill" />
 							<span class="flex-1">{"Color"}</span>
 							<span
-								class="h-3.5 w-3.5 rounded-full border border-border shrink-0"
+								class="size-3 rounded-full border border-border shrink-0"
 								style="background-color: {selectedColorHex};"
 								aria-hidden="true"
 							></span>
@@ -138,22 +183,23 @@ function handleRemoveClick() {
 				{/if}
 				{#if hasIcon && onResetProjectIcon}
 					<DropdownMenu.Item
-						class="rounded-none px-2 py-1.5 text-[11px]"
+						class="font-normal border-b-0"
 						onclick={() => {
 							onResetProjectIcon();
 							menuOpen = false;
 						}}
 					>
-						<ArrowCounterClockwise class="h-3.5 w-3.5 mr-2" weight="bold" />
+						<ArrowCounterClockwise weight="bold" />
 						Reset to letter badge
 					</DropdownMenu.Item>
 				{/if}
+				{#if (onChangeProjectIcon || showColorPicker || hasResetProjectIcon) && onRemoveProject}{/if}
 				{#if onRemoveProject}
 					<DropdownMenu.Item
-						class="text-destructive focus:text-destructive rounded-none px-2 py-1.5 text-[11px]"
+						class="text-destructive focus:text-destructive font-normal border-b-0"
 						onclick={handleRemoveClick}
 					>
-						<Trash class="h-3.5 w-3.5 mr-2" weight="fill" />
+						<Trash weight="fill" />
 						{"Remove Project"}
 					</DropdownMenu.Item>
 				{/if}

--- a/packages/desktop/src/lib/acp/components/project-header.svelte
+++ b/packages/desktop/src/lib/acp/components/project-header.svelte
@@ -20,7 +20,7 @@ interface Props {
 	class?: string;
 	/** Optional content to render after the project name (e.g. settings menu) */
 	trailing?: Snippet;
-	/** Optional actions to render at the end (view toggle, terminal, plus, etc.) */
+	/** Optional actions to render at the end (file explorer, settings, etc.) */
 	actions?: Snippet;
 }
 
@@ -63,11 +63,27 @@ const resolvedIconSrc = $derived(project?.iconPath ?? projectIconSrc);
 			size={16}
 		/>
 	</div>
-		<div class="flex items-center flex-1 min-w-0 h-7 pl-2 cursor-pointer rounded-md transition-colors">
-			<span class="truncate text-xs font-normal text-foreground transition-colors">
-				{displayName}
-			</span>
-		</div>
+	<div class="flex items-center flex-1 min-w-0 h-7 gap-1 pl-2 pr-1 cursor-pointer rounded-md transition-colors">
+		<span class="truncate text-xs font-normal text-foreground transition-colors">
+			{displayName}
+		</span>
+		<svg
+			width="10"
+			height="10"
+			viewBox="0 0 256 256"
+			fill="none"
+			class="shrink-0 text-muted-foreground/70 transition-transform {_expanded ? 'rotate-180' : ''}"
+			aria-hidden="true"
+		>
+			<polyline
+				points="64,96 128,160 192,96"
+				stroke="currentColor"
+				stroke-width="32"
+				stroke-linecap="round"
+				stroke-linejoin="round"
+			/>
+		</svg>
+	</div>
 	{#if actions}
 		<div class="flex items-center">
 			{@render actions()}

--- a/packages/desktop/src/lib/acp/components/session-list/session-list-ui.svelte
+++ b/packages/desktop/src/lib/acp/components/session-list/session-list-ui.svelte
@@ -9,20 +9,14 @@ import { IconPlus } from "@tabler/icons-svelte";
 import { listen } from "@tauri-apps/api/event";
 import { DropdownMenu } from "bits-ui";
 import { ArrowsClockwise } from "phosphor-svelte";
-import { ArrowDown } from "phosphor-svelte";
-import { ArrowCounterClockwise } from "phosphor-svelte";
-import { ArrowUp } from "phosphor-svelte";
 import { BookOpen } from "phosphor-svelte";
-import { Browser } from "phosphor-svelte";
 import { Bug } from "phosphor-svelte";
 import { Check } from "phosphor-svelte";
 import { GitBranch } from "phosphor-svelte";
 import { FolderOpen } from "phosphor-svelte";
-import { ImageSquare } from "phosphor-svelte";
 import { MagnifyingGlass } from "phosphor-svelte";
 import { Recycle } from "phosphor-svelte";
 import { Sparkle } from "phosphor-svelte";
-import { Terminal } from "phosphor-svelte";
 import { TestTube } from "phosphor-svelte";
 import { Wrench } from "phosphor-svelte";
 import type { Component } from "svelte";
@@ -31,7 +25,6 @@ import { SvelteMap, SvelteSet } from "svelte/reactivity";
 import { toast } from "svelte-sonner";
 import type { SessionDisplayItem } from "$lib/acp/types/thread-display-item.js";
 import { Button } from "$lib/components/ui/button/index.js";
-import * as ContextMenu from "$lib/components/ui/context-menu/index.js";
 import * as Dialog from "@acepe/ui/dialog";
 import { Input } from "$lib/components/ui/input/index.js";
 import {
@@ -89,10 +82,6 @@ interface Props {
 	onSelectFile?: (filePath: string, projectPath: string) => void;
 	/** Called when collapsed project paths change (for persistence) */
 	onCollapsedProjectPathsChange?: (paths: string[]) => void;
-	/** Called when terminal button is clicked for a project */
-	onOpenTerminal?: (projectPath: string) => void;
-	/** Called when browser button is clicked for a project */
-	onOpenBrowser?: (projectPath: string) => void;
 	/** Called when git panel button is clicked for a project */
 	onOpenGitPanel?: (projectPath: string) => void;
 	/** Called when PR badge is clicked on a session row */
@@ -132,8 +121,6 @@ let {
 	onProjectClick,
 	onSelectFile,
 	onCollapsedProjectPathsChange,
-	onOpenTerminal,
-	onOpenBrowser,
 	onOpenGitPanel,
 	onOpenPr,
 	onArchiveSession,
@@ -154,11 +141,8 @@ const projectHeaderFocusTargets = new Map<string, HTMLDivElement>();
 let reorderAnnouncement = $state("");
 
 const visibleSessionCounts = new SvelteMap<string, number>();
+const projectHistoryQueries = new SvelteMap<string, string>();
 const sessionListContainers = new Map<string, HTMLDivElement>();
-
-function shouldShowProjectUtilityActions(): boolean {
-	return Boolean(onOpenTerminal) || Boolean(onOpenBrowser);
-}
 
 function shouldShowProjectCreateButton(): boolean {
 	return Boolean(onCreateSessionForProject);
@@ -201,6 +185,7 @@ $effect(() => {
 	for (const projectPath of visibleSessionCounts.keys()) {
 		if (!activeProjectPaths.has(projectPath)) {
 			visibleSessionCounts.delete(projectPath);
+			projectHistoryQueries.delete(projectPath);
 			sessionListContainers.delete(projectPath);
 		}
 	}
@@ -263,13 +248,41 @@ function projectHeaderFocusTarget(
 	};
 }
 
-function getVisibleSessionsForProject(group: SessionGroup): SessionListItem[] {
+function getProjectHistoryQuery(projectPath: string): string {
+	return projectHistoryQueries.get(projectPath) ?? "";
+}
+
+function setProjectHistoryQuery(projectPath: string, query: string): void {
+	if (query.length === 0) {
+		projectHistoryQueries.delete(projectPath);
+		return;
+	}
+	projectHistoryQueries.set(projectPath, query);
+}
+
+function getFilteredSidebarSessionsForProject(group: SessionGroup): SessionListItem[] {
 	const sidebarSessions = getSidebarSessions(group.sessions);
+	const query = getProjectHistoryQuery(group.projectPath).trim().toLowerCase();
+	if (query.length === 0) {
+		return sidebarSessions;
+	}
+	return sidebarSessions.filter((session) => {
+		const haystack = `${session.title} ${session.agentId}`.toLowerCase();
+		return haystack.includes(query);
+	});
+}
+
+function getVisibleSessionsForProject(group: SessionGroup): SessionListItem[] {
+	const sidebarSessions = getFilteredSidebarSessionsForProject(group);
 	const visibleCount = getSessionListVisibleCount(
 		sidebarSessions.length,
 		visibleSessionCounts.get(group.projectPath)
 	);
 	return sidebarSessions.slice(0, visibleCount);
+}
+
+function handleProjectHistorySearchKeydown(event: KeyboardEvent): void {
+	event.stopPropagation();
 }
 
 function ensureSessionListOverflow(projectPath: string, totalSessions: number): void {
@@ -707,9 +720,8 @@ function getMovedProjectOrder(projectPath: string, offset: -1 | 1): string[] | n
 
 async function focusProjectContextTrigger(projectPath: string): Promise<void> {
 	await tick();
-	// V1 intentionally returns focus to the outer header wrapper instead of the bits-ui
-	// ContextMenu.Trigger because the wrapper is reliably focusable and still supports
-	// reopening the context menu with Shift+F10 for consecutive keyboard moves.
+	// Return focus to the outer header wrapper so consecutive keyboard move
+	// actions stay anchored on the same project row.
 	projectHeaderFocusTargets.get(projectPath)?.focus();
 }
 
@@ -868,15 +880,13 @@ function openCreateBranchDialog(projectPath: string): void {
 								}
 							}}
 						>
-							<ContextMenu.Root>
-								<ContextMenu.Trigger class="flex-1 min-w-0">
-									<ProjectHeader
-										projectColor={group.projectColor}
-										projectName={group.projectName}
-										projectIconSrc={group.projectIconSrc}
-										expanded={true}
-										class="group min-w-0 flex-1 cursor-pointer transition-colors"
-									>
+							<ProjectHeader
+								projectColor={group.projectColor}
+								projectName={group.projectName}
+								projectIconSrc={group.projectIconSrc}
+								expanded={true}
+								class="group min-w-0 flex-1 cursor-pointer transition-colors"
+							>
 										{#snippet actions()}
 											<div
 												class="flex items-center gap-0.5"
@@ -899,49 +909,6 @@ function openCreateBranchDialog(projectPath: string): void {
 														{`Open file system in ${group.projectName}`}
 													</Tooltip.Content>
 												</Tooltip.Root>
-												{#if shouldShowProjectUtilityActions() && onOpenTerminal}
-													<Tooltip.Root>
-														<Tooltip.Trigger>
-															<button
-																type="button"
-																class={projectHeaderHoverActionButtonClass}
-																onclick={(event) => {
-																	event.stopPropagation();
-																	onOpenTerminal(group.projectPath);
-																}}
-																aria-label={`Open terminal in ${group.projectName}`}
-															>
-																<Terminal class="h-3 w-3" weight="fill" />
-															</button>
-														</Tooltip.Trigger>
-														<Tooltip.Content>
-															{`Open terminal in ${group.projectName}`}
-														</Tooltip.Content>
-													</Tooltip.Root>
-												{/if}
-												{#if shouldShowProjectUtilityActions() && onOpenBrowser}
-													<Tooltip.Root>
-														<Tooltip.Trigger>
-															<button
-																type="button"
-																class={projectHeaderHoverActionButtonClass}
-																onclick={(event) => {
-																	event.stopPropagation();
-																	onOpenBrowser(group.projectPath);
-																}}
-																aria-label={`Open browser in ${group.projectName}`}
-															>
-																<Browser class="h-3 w-3" weight="fill" />
-															</button>
-														</Tooltip.Trigger>
-														<Tooltip.Content>
-															{`Open browser in ${group.projectName}`}
-														</Tooltip.Content>
-													</Tooltip.Root>
-												{/if}
-											</div>
-										{/snippet}
-										{#snippet trailing()}
 												<ProjectHeaderOverflowMenu
 													projectName={group.projectName}
 													currentColor={group.projectColor}
@@ -949,13 +916,28 @@ function openCreateBranchDialog(projectPath: string): void {
 														? (color) => onProjectColorChange(group.projectPath, color)
 														: undefined}
 													projectIconSrc={group.projectIconSrc}
-												onResetProjectIcon={onResetProjectIcon
-													? () => onResetProjectIcon(group.projectPath)
-													: undefined}
-												onRemoveProject={onRemoveProject
-													? () => onRemoveProject(group.projectPath)
-													: undefined}
-											/>
+													onResetProjectIcon={onResetProjectIcon
+														? () => onResetProjectIcon(group.projectPath)
+														: undefined}
+													onRemoveProject={onRemoveProject
+														? () => onRemoveProject(group.projectPath)
+														: undefined}
+													onMoveUp={() => {
+														void handleProjectContextMove(group.projectPath, -1);
+													}}
+													onMoveDown={() => {
+														void handleProjectContextMove(group.projectPath, 1);
+													}}
+													moveUpDisabled={onReorderProjects === undefined || projectIndex === 0}
+													moveDownDisabled={onReorderProjects === undefined ||
+														projectIndex === sessionGroups.length - 1}
+													onChangeProjectIcon={onChangeProjectIcon
+														? () => onChangeProjectIcon(group.projectPath)
+														: undefined}
+												/>
+											</div>
+										{/snippet}
+										{#snippet trailing()}
 											{#if shouldShowProjectCreateButton()}
 												<div
 													class="flex items-center"
@@ -980,46 +962,7 @@ function openCreateBranchDialog(projectPath: string): void {
 												</div>
 											{/if}
 										{/snippet}
-									</ProjectHeader>
-								</ContextMenu.Trigger>
-									<ContextMenu.Content class="min-w-[180px] p-1 text-[11px]">
-										<ContextMenu.Item
-											disabled={onReorderProjects === undefined || projectIndex === 0}
-											onSelect={() => {
-												void handleProjectContextMove(group.projectPath, -1);
-											}}
-										>
-											<ArrowUp class="mr-2 h-3.5 w-3.5" weight="bold" />
-											{"Move Up"}
-										</ContextMenu.Item>
-										<ContextMenu.Item
-											disabled={
-												onReorderProjects === undefined || projectIndex === sessionGroups.length - 1
-											}
-											onSelect={() => {
-												void handleProjectContextMove(group.projectPath, 1);
-											}}
-										>
-											<ArrowDown class="mr-2 h-3.5 w-3.5" weight="bold" />
-											{"Move Down"}
-										</ContextMenu.Item>
-										{#if onChangeProjectIcon || (onResetProjectIcon && group.projectIconSrc)}
-											<ContextMenu.Separator />
-										{/if}
-										{#if onChangeProjectIcon}
-											<ContextMenu.Item onclick={() => onChangeProjectIcon(group.projectPath)}>
-												<ImageSquare class="mr-2 h-3.5 w-3.5" weight="fill" />
-												{"Change icon..."}
-											</ContextMenu.Item>
-										{/if}
-										{#if onResetProjectIcon && group.projectIconSrc}
-											<ContextMenu.Item onclick={() => onResetProjectIcon(group.projectPath)}>
-												<ArrowCounterClockwise class="mr-2 h-3.5 w-3.5" weight="bold" />
-												{"Reset to letter badge"}
-											</ContextMenu.Item>
-										{/if}
-									</ContextMenu.Content>
-							</ContextMenu.Root>
+							</ProjectHeader>
 						</div>
 						<!-- Session list skeleton (sessions are what we're loading) -->
 						<div class="flex-1 min-h-0 max-h-[22rem] overflow-y-auto overflow-x-hidden px-0.5 pb-0.5">
@@ -1064,15 +1007,13 @@ function openCreateBranchDialog(projectPath: string): void {
 						}
 					}}
 				>
-					<ContextMenu.Root>
-						<ContextMenu.Trigger class="flex-1 min-w-0">
-							<ProjectHeader
-								projectColor={group.projectColor}
-								projectName={group.projectName}
-								projectIconSrc={group.projectIconSrc}
-								expanded={isExpanded}
-								class="group min-w-0 flex-1 cursor-pointer transition-colors"
-							>
+					<ProjectHeader
+						projectColor={group.projectColor}
+						projectName={group.projectName}
+						projectIconSrc={group.projectIconSrc}
+						expanded={isExpanded}
+						class="group min-w-0 flex-1 cursor-pointer transition-colors"
+					>
 								{#snippet actions()}
 									<div
 										class="flex shrink-0 items-center gap-0.5"
@@ -1095,63 +1036,35 @@ function openCreateBranchDialog(projectPath: string): void {
 												{`Open file system in ${group.projectName}`}
 											</Tooltip.Content>
 										</Tooltip.Root>
-										{#if shouldShowProjectUtilityActions() && onOpenTerminal}
-											<Tooltip.Root>
-												<Tooltip.Trigger>
-													<button
-														type="button"
-														class={projectHeaderHoverActionButtonClass}
-														onclick={(event) => {
-															event.stopPropagation();
-															onOpenTerminal(group.projectPath);
-														}}
-														aria-label={`Open terminal in ${group.projectName}`}
-													>
-														<Terminal class="h-3 w-3" weight="fill" />
-													</button>
-												</Tooltip.Trigger>
-												<Tooltip.Content>
-													{`Open terminal in ${group.projectName}`}
-												</Tooltip.Content>
-											</Tooltip.Root>
-										{/if}
-										{#if shouldShowProjectUtilityActions() && onOpenBrowser}
-											<Tooltip.Root>
-												<Tooltip.Trigger>
-													<button
-														type="button"
-														class={projectHeaderHoverActionButtonClass}
-														onclick={(event) => {
-															event.stopPropagation();
-															onOpenBrowser(group.projectPath);
-														}}
-														aria-label={`Open browser in ${group.projectName}`}
-													>
-														<Browser class="h-3 w-3" weight="fill" />
-													</button>
-												</Tooltip.Trigger>
-												<Tooltip.Content>
-													{`Open browser in ${group.projectName}`}
-												</Tooltip.Content>
-											</Tooltip.Root>
-										{/if}
+										<ProjectHeaderOverflowMenu
+											projectName={group.projectName}
+											currentColor={group.projectColor}
+											onColorChange={onProjectColorChange
+												? (color) => onProjectColorChange(group.projectPath, color)
+												: undefined}
+											projectIconSrc={group.projectIconSrc}
+											onResetProjectIcon={onResetProjectIcon
+												? () => onResetProjectIcon(group.projectPath)
+												: undefined}
+											onRemoveProject={onRemoveProject
+												? () => onRemoveProject(group.projectPath)
+												: undefined}
+											onMoveUp={() => {
+												void handleProjectContextMove(group.projectPath, -1);
+											}}
+											onMoveDown={() => {
+												void handleProjectContextMove(group.projectPath, 1);
+											}}
+											moveUpDisabled={onReorderProjects === undefined || projectIndex === 0}
+											moveDownDisabled={onReorderProjects === undefined ||
+												projectIndex === sessionGroups.length - 1}
+											onChangeProjectIcon={onChangeProjectIcon
+												? () => onChangeProjectIcon(group.projectPath)
+												: undefined}
+										/>
 									</div>
 								{/snippet}
 								{#snippet trailing()}
-									<ProjectHeaderOverflowMenu
-										projectName={group.projectName}
-										currentColor={group.projectColor}
-										onColorChange={onProjectColorChange
-											? (color) => onProjectColorChange(group.projectPath, color)
-											: undefined}
-										projectIconSrc={group.projectIconSrc}
-										onResetProjectIcon={onResetProjectIcon
-											? () => onResetProjectIcon(group.projectPath)
-											: undefined}
-										onRemoveProject={onRemoveProject
-											? () => onRemoveProject(group.projectPath)
-											: undefined}
-									/>
 									{#if shouldShowProjectCreateButton()}
 										<div
 											class="flex shrink-0 items-center"
@@ -1176,57 +1089,40 @@ function openCreateBranchDialog(projectPath: string): void {
 										</div>
 									{/if}
 								{/snippet}
-							</ProjectHeader>
-						</ContextMenu.Trigger>
-							<ContextMenu.Content class="min-w-[180px] p-1 text-[11px]">
-								<ContextMenu.Item
-									disabled={onReorderProjects === undefined || projectIndex === 0}
-									onSelect={() => {
-										void handleProjectContextMove(group.projectPath, -1);
-									}}
-								>
-									<ArrowUp class="mr-2 h-3.5 w-3.5" weight="bold" />
-									{"Move Up"}
-								</ContextMenu.Item>
-								<ContextMenu.Item
-									disabled={onReorderProjects === undefined || projectIndex === sessionGroups.length - 1}
-									onSelect={() => {
-										void handleProjectContextMove(group.projectPath, 1);
-									}}
-								>
-									<ArrowDown class="mr-2 h-3.5 w-3.5" weight="bold" />
-									{"Move Down"}
-								</ContextMenu.Item>
-								{#if onChangeProjectIcon || (onResetProjectIcon && group.projectIconSrc)}
-									<ContextMenu.Separator />
-								{/if}
-								{#if onChangeProjectIcon}
-									<ContextMenu.Item onclick={() => onChangeProjectIcon(group.projectPath)}>
-										<ImageSquare class="mr-2 h-3.5 w-3.5" weight="fill" />
-										{"Change icon..."}
-									</ContextMenu.Item>
-								{/if}
-								{#if onResetProjectIcon && group.projectIconSrc}
-									<ContextMenu.Item onclick={() => onResetProjectIcon(group.projectPath)}>
-										<ArrowCounterClockwise class="mr-2 h-3.5 w-3.5" weight="bold" />
-										{"Reset to letter badge"}
-									</ContextMenu.Item>
-								{/if}
-							</ContextMenu.Content>
-					</ContextMenu.Root>
+					</ProjectHeader>
 				</div>
 
 						<!-- Content area: sessions -->
 						{#if isExpanded}
-							{@const sidebarSessions = getSidebarSessions(group.sessions)}
+							{@const filteredSessions = getFilteredSidebarSessionsForProject(group)}
 							{@const visibleSessions = getVisibleSessionsForProject(group)}
 							<div
+								class="shrink-0 px-1 pb-1"
+								role="presentation"
+								onclick={(event) => event.stopPropagation()}
+								onkeydown={handleProjectHistorySearchKeydown}
+							>
+								<Input
+									type="search"
+									value={getProjectHistoryQuery(group.projectPath)}
+									placeholder="Search project history..."
+									class="h-7 rounded-md border-border/70 bg-background/70 px-2 text-[11px]"
+									data-sidebar-project-history-search
+									oninput={(event) =>
+										setProjectHistoryQuery(group.projectPath, event.currentTarget.value)}
+								/>
+							</div>
+							<div
 								class="min-h-0 max-h-[22rem] overflow-y-auto overflow-x-hidden px-0.5 pb-0.5"
-								use:sessionListContainer={{ projectPath: group.projectPath, totalSessions: sidebarSessions.length }}
-								onscroll={() => handleSessionListScroll(group.projectPath, sidebarSessions.length)}
+								use:sessionListContainer={{ projectPath: group.projectPath, totalSessions: filteredSessions.length }}
+								onscroll={() => handleSessionListScroll(group.projectPath, filteredSessions.length)}
 							>
 								{#if scanningProjectPaths.has(group.projectPath) && group.sessions.length === 0}
 									<SessionListSkeleton sessionCount={3} />
+								{:else if filteredSessions.length === 0}
+									<div class="px-2 py-6 text-center text-[11px] text-muted-foreground">
+										No sessions found
+									</div>
 								{:else}
 									<VirtualizedSessionList
 										sessions={visibleSessions}

--- a/packages/desktop/src/lib/acp/components/session-list/session-list.svelte
+++ b/packages/desktop/src/lib/acp/components/session-list/session-list.svelte
@@ -40,10 +40,6 @@ interface Props {
 	onSelectFile?: (filePath: string, projectPath: string) => void;
 	/** Called when collapsed project paths change */
 	onCollapsedProjectPathsChange?: (paths: string[]) => void;
-	/** Called when terminal button is clicked for a project */
-	onOpenTerminal?: (projectPath: string) => void;
-	/** Called when browser button is clicked for a project */
-	onOpenBrowser?: (projectPath: string) => void;
 	/** Called when git panel button is clicked for a project */
 	onOpenGitPanel?: (projectPath: string) => void;
 	/** Called when PR badge is clicked on a session row */
@@ -83,8 +79,6 @@ let {
 	onRemoveProject,
 	onSelectFile,
 	onCollapsedProjectPathsChange,
-	onOpenTerminal,
-	onOpenBrowser,
 	onOpenGitPanel,
 	onOpenPr,
 	onArchiveSession,
@@ -193,8 +187,6 @@ function handleCreateSessionForProject(projectPath: string, agentId?: string) {
 	{onProjectClick}
 	{onSelectFile}
 	{onCollapsedProjectPathsChange}
-	{onOpenTerminal}
-	{onOpenBrowser}
 	{onOpenGitPanel}
 	{onOpenPr}
 	{onArchiveSession}

--- a/packages/desktop/src/lib/acp/components/shared/worktree-toggle-pill.svelte
+++ b/packages/desktop/src/lib/acp/components/shared/worktree-toggle-pill.svelte
@@ -1,0 +1,63 @@
+<script lang="ts">
+	import { AgentPanelWorktreeTogglePill } from "@acepe/ui/agent-panel";
+	import * as Popover from "$lib/components/ui/popover/index.js";
+	import SetupCommandsEditor from "$lib/components/settings-page/sections/worktrees/setup-commands-editor.svelte";
+
+	interface Props {
+		/** Pre-session toggle state — true if a worktree will be created on next send. */
+		enabled: boolean;
+		/** Project path for the setup-scripts popover. When null, no label click action. */
+		projectPath: string | null;
+		failureMessage?: string | null;
+		onToggle: () => void;
+		onRetry?: () => void;
+		onDismiss?: () => void;
+		busy?: boolean;
+	}
+
+	let {
+		enabled,
+		projectPath,
+		failureMessage = null,
+		onToggle,
+		onRetry,
+		onDismiss,
+		busy = false,
+	}: Props = $props();
+
+	let anchorRef = $state<HTMLElement | null>(null);
+	let setupOpen = $state(false);
+
+	function handleLabelClick() {
+		setupOpen = true;
+	}
+</script>
+
+<div bind:this={anchorRef} class="inline-flex items-center">
+	<AgentPanelWorktreeTogglePill
+		label="Worktree"
+		{enabled}
+		{failureMessage}
+		{busy}
+		{onToggle}
+		{onRetry}
+		{onDismiss}
+		onLabelClick={projectPath ? handleLabelClick : undefined}
+	/>
+</div>
+
+{#if projectPath}
+	<Popover.Root bind:open={setupOpen}>
+		<Popover.Content
+			customAnchor={anchorRef ?? undefined}
+			align="start"
+			side="bottom"
+			sideOffset={6}
+			class="w-[28rem] max-w-[90vw] p-3"
+		>
+			{#key projectPath}
+				<SetupCommandsEditor {projectPath} />
+			{/key}
+		</Popover.Content>
+	</Popover.Root>
+{/if}

--- a/packages/desktop/src/lib/components/main-app-view/components/content/empty-states.svelte
+++ b/packages/desktop/src/lib/components/main-app-view/components/content/empty-states.svelte
@@ -5,7 +5,7 @@ import { copyTextToClipboard } from "$lib/acp/components/agent-panel/logic/clipb
 import AgentSelector from "$lib/acp/components/agent-selector.svelte";
 import BranchPicker from "$lib/acp/components/branch-picker/branch-picker.svelte";
 import ProjectSelector from "$lib/acp/components/project-selector.svelte";
-import PreSessionWorktreeCard from "$lib/acp/components/agent-panel/components/pre-session-worktree-card.svelte";
+import WorktreeTogglePill from "$lib/acp/components/shared/worktree-toggle-pill.svelte";
 import { getWorktreeDefaultStore } from "$lib/acp/components/worktree/worktree-default-store.svelte.js";
 import { getErrorCauseDetails } from "$lib/acp/errors/error-cause-details.js";
 import { loadWorktreeEnabled } from "$lib/acp/components/worktree/worktree-storage.js";
@@ -445,44 +445,6 @@ function handleEmptyStateSessionCreated(sessionId: string) {
 					/>
 				</div>
 			{/if}
-			{#if projectPath}
-				<div class="mb-2">
-					<PreSessionWorktreeCard
-						pendingWorktreeEnabled={effectiveWorktreePending}
-						alwaysEnabled={globalWorktreeDefault}
-						{projectPath}
-						onYes={() => {
-							const store = getWorktreeDefaultStore();
-							if (store.globalDefault) {
-								void store.set(false);
-							}
-							preparedWorktreeLaunch = null;
-							worktreePending = true;
-						}}
-						onNo={() => {
-							const store = getWorktreeDefaultStore();
-							if (store.globalDefault) {
-								void store.set(false);
-							}
-							preparedWorktreeLaunch = null;
-							worktreePending = false;
-						}}
-						onAlways={() => {
-							const store = getWorktreeDefaultStore();
-							const toggled = !store.globalDefault;
-							void store.set(toggled);
-							if (!toggled) {
-								preparedWorktreeLaunch = null;
-							}
-							worktreePending = toggled;
-						}}
-						onDismiss={() => {
-							preparedWorktreeLaunch = null;
-							worktreePending = false;
-						}}
-					/>
-				</div>
-			{/if}
 			<AgentInput
 				panelId={EMPTY_STATE_PANEL_ID}
 				projectPath={projectPath ?? undefined}
@@ -524,6 +486,18 @@ function handleEmptyStateSessionCreated(sessionId: string) {
 			</AgentInput>
 			{#if projectPath}
 				<div class="mt-2 flex h-7 items-center">
+					<WorktreeTogglePill
+						enabled={effectiveWorktreePending}
+						{projectPath}
+						onToggle={() => {
+							const store = getWorktreeDefaultStore();
+							if (store.globalDefault) {
+								void store.set(false);
+							}
+							preparedWorktreeLaunch = null;
+							worktreePending = !worktreePending;
+						}}
+					/>
 					<div class="ml-auto h-full min-w-0 w-fit max-w-[12rem]">
 						<BranchPicker
 							{projectPath}
@@ -537,7 +511,7 @@ function handleEmptyStateSessionCreated(sessionId: string) {
 					</div>
 				</div>
 			{/if}
-		</div>
+			</div>
 	{:else}
 		<p class="text-muted-foreground text-sm">
 			{"Create a new session to begin working with an AI agent on your project."}

--- a/packages/desktop/src/lib/components/main-app-view/components/content/kanban-view.svelte
+++ b/packages/desktop/src/lib/components/main-app-view/components/content/kanban-view.svelte
@@ -35,7 +35,7 @@ import TodoHeader from "$lib/acp/components/todo-header.svelte";
 import AgentInput from "$lib/acp/components/agent-input/agent-input-ui.svelte";
 import AgentSelector from "$lib/acp/components/agent-selector.svelte";
 import ProjectSelector from "$lib/acp/components/project-selector.svelte";
-import PreSessionWorktreeCard from "$lib/acp/components/agent-panel/components/pre-session-worktree-card.svelte";
+import WorktreeTogglePill from "$lib/acp/components/shared/worktree-toggle-pill.svelte";
 import PrChecksSurface from "$lib/acp/components/shared/pr-checks-surface.svelte";
 import { getWorktreeDefaultStore } from "$lib/acp/components/worktree/worktree-default-store.svelte.js";
 import { loadWorktreeEnabled } from "$lib/acp/components/worktree/worktree-storage.js";
@@ -1338,41 +1338,18 @@ function handleRejectPlanApproval(sessionId: string): void {
 				{#if canShowNewSessionInput}
 					{#if selectedProject}
 						<div class="mb-2">
-							<PreSessionWorktreeCard
-								pendingWorktreeEnabled={effectiveWorktreePending}
-								alwaysEnabled={globalWorktreeDefault}
+							<WorktreeTogglePill
+								enabled={effectiveWorktreePending}
 								projectPath={selectedProject.path}
-								projectName={selectedProject.name}
-								onYes={() => {
+								onToggle={() => {
 									const store = getWorktreeDefaultStore();
-								if (store.globalDefault) {
-									void store.set(false);
-								}
-								preparedWorktreeLaunch = null;
-								worktreePending = true;
-							}}
-							onNo={() => {
-								const store = getWorktreeDefaultStore();
-								if (store.globalDefault) {
-									void store.set(false);
-								}
-								preparedWorktreeLaunch = null;
-								worktreePending = false;
-							}}
-							onAlways={() => {
-								const store = getWorktreeDefaultStore();
-								const toggled = !store.globalDefault;
-								void store.set(toggled);
-								if (!toggled) {
+									if (store.globalDefault) {
+										void store.set(false);
+									}
 									preparedWorktreeLaunch = null;
-								}
-								worktreePending = toggled;
-							}}
-							onDismiss={() => {
-								preparedWorktreeLaunch = null;
-								worktreePending = false;
-							}}
-						/>
+									worktreePending = !worktreePending;
+								}}
+							/>
 						</div>
 					{/if}
 					{#key newSessionComposerKey}

--- a/packages/desktop/src/lib/components/main-app-view/components/sidebar/app-sidebar.svelte
+++ b/packages/desktop/src/lib/components/main-app-view/components/sidebar/app-sidebar.svelte
@@ -11,7 +11,6 @@ import {
 import ProjectIconPickerDialog from "$lib/acp/components/project-icon-picker-dialog.svelte";
 import type { SessionListItem } from "$lib/acp/components/session-list/session-list-types.js";
 import type { SessionDisplayItem } from "$lib/acp/types/thread-display-item.js";
-import { DEFAULT_BROWSER_HOME_URL } from "$lib/acp/constants/browser-defaults.js";
 import { LOGGER_IDS } from "$lib/acp/constants/logger-ids.js";
 import type { Project, ProjectManager } from "$lib/acp/logic/project-manager.svelte.js";
 import {
@@ -150,14 +149,6 @@ function handleRemoveProject(projectPath: string) {
 
 function handleSelectFile(filePath: string, projectPath: string) {
 	panelStore.openFilePanel(filePath, projectPath);
-}
-
-function handleOpenTerminal(projectPath: string) {
-	panelStore.toggleTerminalPanel(projectPath);
-}
-
-function handleOpenBrowser(projectPath: string) {
-	panelStore.openBrowserPanel(projectPath, DEFAULT_BROWSER_HOME_URL, "acepe.dev");
 }
 
 function handleOpenGitPanel(projectPath: string) {
@@ -477,8 +468,6 @@ const visibleSessions = $derived.by(() => {
 			isSessionOpen={(sessionId) => panelStore.isSessionOpen(sessionId)}
 			onSelectFile={handleSelectFile}
 			onCollapsedProjectPathsChange={(paths) => appState.handleCollapsedProjectPathsChange(paths)}
-			onOpenTerminal={handleOpenTerminal}
-			onOpenBrowser={handleOpenBrowser}
 			onOpenGitPanel={handleOpenGitPanel}
 			onOpenPr={handleOpenPr}
 			onArchiveSession={handleArchiveSession}

--- a/packages/desktop/src/lib/components/main-app-view/components/sidebar/sidebar-footer.svelte
+++ b/packages/desktop/src/lib/components/main-app-view/components/sidebar/sidebar-footer.svelte
@@ -66,7 +66,7 @@ const releaseUrl = $derived(
 	{#if releaseUrl}
 		<button
 			onclick={() => openUrl(releaseUrl)}
-			class="ml-auto text-[9px] text-muted-foreground/50 hover:text-muted-foreground transition-colors"
+			class="ml-auto text-[12px] text-muted-foreground/50 hover:text-muted-foreground transition-colors"
 			title={`Open release notes for v${appVersion}`}
 		>
 			v{appVersion}

--- a/packages/desktop/vite.config.js
+++ b/packages/desktop/vite.config.js
@@ -1,5 +1,6 @@
 import { sveltekit } from "@sveltejs/kit/vite";
 import tailwindcss from "@tailwindcss/vite";
+import { fileURLToPath } from "node:url";
 import { defineConfig } from "vitest/config";
 
 const host = process.env.TAURI_DEV_HOST;
@@ -24,6 +25,12 @@ export default defineConfig({
 		format: "es",
 	},
 	plugins: [sveltekit(), tailwindcss()],
+
+	resolve: {
+		alias: {
+			runed: fileURLToPath(new URL("./node_modules/runed/dist/index.js", import.meta.url)),
+		},
+	},
 
 	// Pre-bundle icon libraries to avoid HMR issues with dynamic imports
 	optimizeDeps: {

--- a/packages/ui/src/components/agent-panel/__tests__/agent-panel-leaf-widgets.test.ts
+++ b/packages/ui/src/components/agent-panel/__tests__/agent-panel-leaf-widgets.test.ts
@@ -2,7 +2,7 @@ import { expect, test } from "bun:test";
 import {
 	AgentPanelErrorCard,
 	AgentPanelInstallCard,
-	AgentPanelPreSessionWorktreeCard,
+	AgentPanelWorktreeTogglePill,
 	AgentPanelScrollToBottomButton,
 	AgentPanelWorktreeSetupCard,
 	AgentPanelWorktreeStatusDisplay,
@@ -10,7 +10,7 @@ import {
 import {
 	AgentPanelErrorCard as RootAgentPanelErrorCard,
 	AgentPanelInstallCard as RootAgentPanelInstallCard,
-	AgentPanelPreSessionWorktreeCard as RootAgentPanelPreSessionWorktreeCard,
+	AgentPanelWorktreeTogglePill as RootAgentPanelWorktreeTogglePill,
 	AgentPanelScrollToBottomButton as RootAgentPanelScrollToBottomButton,
 	AgentPanelWorktreeSetupCard as RootAgentPanelWorktreeSetupCard,
 	AgentPanelWorktreeStatusDisplay as RootAgentPanelWorktreeStatusDisplay,
@@ -20,13 +20,13 @@ test("shared leaf widget exports are defined", () => {
 	expect(AgentPanelScrollToBottomButton).toBeDefined();
 	expect(AgentPanelErrorCard).toBeDefined();
 	expect(AgentPanelInstallCard).toBeDefined();
-	expect(AgentPanelPreSessionWorktreeCard).toBeDefined();
+	expect(AgentPanelWorktreeTogglePill).toBeDefined();
 	expect(AgentPanelWorktreeSetupCard).toBeDefined();
 	expect(AgentPanelWorktreeStatusDisplay).toBeDefined();
 	expect(RootAgentPanelScrollToBottomButton).toBeDefined();
 	expect(RootAgentPanelErrorCard).toBeDefined();
 	expect(RootAgentPanelInstallCard).toBeDefined();
-	expect(RootAgentPanelPreSessionWorktreeCard).toBeDefined();
+	expect(RootAgentPanelWorktreeTogglePill).toBeDefined();
 	expect(RootAgentPanelWorktreeSetupCard).toBeDefined();
 	expect(RootAgentPanelWorktreeStatusDisplay).toBeDefined();
 });

--- a/packages/ui/src/components/agent-panel/agent-input-mode-pill.svelte
+++ b/packages/ui/src/components/agent-panel/agent-input-mode-pill.svelte
@@ -43,8 +43,6 @@
 		if (modeId === buildModeId) return "var(--build-icon)";
 		return "currentColor";
 	}
-
-	const selectedIndex = $derived(modes.findIndex((m) => m.id === currentModeId));
 </script>
 
 <div
@@ -54,11 +52,14 @@
 >
 	{#each modes as mode (mode.id)}
 		{@const isSelected = mode.id === currentModeId}
+		{@const label = modeLabel(mode)}
 		<button
 			type="button"
 			{disabled}
 			aria-pressed={isSelected}
-			class="inline-flex h-7 flex-1 items-center justify-center gap-1 px-2 text-[11px] font-medium leading-none transition-colors
+			aria-label={label}
+			title={label}
+			class="inline-flex h-7 w-7 shrink-0 items-center justify-center transition-colors
 				{isSelected ? 'bg-background dark:bg-input/30 text-foreground' : 'text-muted-foreground hover:text-foreground'}
 				{disabled ? 'cursor-default opacity-50' : 'cursor-pointer'}"
 			onclick={() => { if (!disabled) onModeChange(mode.id); }}
@@ -68,7 +69,6 @@
 			{:else}
 				<BuildIcon size="sm" class="shrink-0" style="color: {isSelected ? iconColor(mode.id) : 'currentColor'}" />
 			{/if}
-			{modeLabel(mode)}
 		</button>
 	{/each}
 </div>

--- a/packages/ui/src/components/agent-panel/agent-panel-terminal-drawer.svelte
+++ b/packages/ui/src/components/agent-panel/agent-panel-terminal-drawer.svelte
@@ -3,16 +3,19 @@
 
 	interface Props {
 		children?: Snippet;
-		height: number;
+		height?: number | null;
 		resizeHandle?: Snippet;
 		tabs: Snippet;
 		body: Snippet;
 	}
 
-	let { children: _children, height, resizeHandle, tabs, body }: Props = $props();
+	let { children: _children, height = null, resizeHandle, tabs, body }: Props = $props();
 </script>
 
-<div class="flex flex-col bg-background" style="height: {height}px; contain: layout;">
+<div
+	class="flex flex-col bg-background {height === null ? 'h-full' : ''}"
+	style={height === null ? "contain: layout;" : `height: ${height}px; contain: layout;`}
+>
 	{#if resizeHandle}
 		{@render resizeHandle()}
 	{/if}

--- a/packages/ui/src/components/agent-panel/agent-panel-trailing-pane-layout.svelte
+++ b/packages/ui/src/components/agent-panel/agent-panel-trailing-pane-layout.svelte
@@ -1,5 +1,5 @@
 <!--
-  Hosts optional plan sidebar and browser column; host app renders each region via snippets.
+  Hosts optional trailing pane columns; host app renders each region via snippets.
 -->
 <script lang="ts">
 	import type { Snippet } from "svelte";
@@ -7,13 +7,17 @@
 	let {
 		showPlan,
 		showBrowser,
+		showTerminal,
 		plan,
 		browser,
+		terminal,
 	}: {
 		showPlan: boolean;
 		showBrowser: boolean;
+		showTerminal?: boolean;
 		plan: Snippet;
 		browser: Snippet;
+		terminal?: Snippet;
 	} = $props();
 </script>
 
@@ -22,4 +26,7 @@
 {/if}
 {#if showBrowser}
 	{@render browser()}
+{/if}
+{#if showTerminal && terminal}
+	{@render terminal()}
 {/if}

--- a/packages/ui/src/components/agent-panel/agent-panel-worktree-switch-dialog.svelte
+++ b/packages/ui/src/components/agent-panel/agent-panel-worktree-switch-dialog.svelte
@@ -1,0 +1,145 @@
+<!--
+  Mid-session worktree switch confirmation dialog.
+
+  Presentational only. All copy and callbacks come from the host. The host owns
+  Tauri calls, session state mutations, and the move-vs-continue decision logic.
+
+  v1 ships Continue-only as the primary action. The Move-session-changes action
+  is rendered when `moveAvailable` is true but the host is expected to gate this
+  behind real ownership proof; the dialog never claims safety itself.
+-->
+<script lang="ts">
+	import * as Dialog from "../dialog/index.js";
+
+	let {
+		open = $bindable(false),
+		title,
+		description,
+		continueLabel,
+		continueHelperText,
+		moveLabel,
+		moveHelperText,
+		cancelLabel,
+		moveAvailable = false,
+		moveUnavailableReason,
+		otherLocalChangesMessage,
+		sessionFileCount = 0,
+		sessionFiles = [],
+		filesHeading,
+		busy = false,
+		errorMessage,
+		onContinue,
+		onMove,
+		onCancel,
+	}: {
+		open?: boolean;
+		title: string;
+		description: string;
+		continueLabel: string;
+		continueHelperText: string;
+		moveLabel: string;
+		moveHelperText?: string;
+		cancelLabel: string;
+		moveAvailable?: boolean;
+		moveUnavailableReason?: string;
+		otherLocalChangesMessage?: string;
+		sessionFileCount?: number;
+		sessionFiles?: readonly string[];
+		filesHeading?: string;
+		busy?: boolean;
+		errorMessage?: string;
+		onContinue: () => void;
+		onMove?: () => void;
+		onCancel: () => void;
+	} = $props();
+
+	let filesExpanded = $state(false);
+
+	function handleOpenChange(next: boolean) {
+		if (!next && !busy) onCancel();
+	}
+</script>
+
+<Dialog.Root {open} onOpenChange={handleOpenChange}>
+	<Dialog.Content class="max-w-md p-0 overflow-hidden">
+		<div class="px-4 pt-4">
+			<Dialog.Title class="text-base font-semibold">{title}</Dialog.Title>
+			<Dialog.Description class="text-sm text-muted-foreground mt-1 leading-snug">
+				{description}
+			</Dialog.Description>
+		</div>
+
+		{#if sessionFileCount > 0}
+			<div class="px-4 pt-3">
+				<button
+					type="button"
+					class="text-xs text-muted-foreground hover:text-foreground transition-colors"
+					onclick={() => (filesExpanded = !filesExpanded)}
+					aria-expanded={filesExpanded}
+				>
+					{filesHeading ?? `${sessionFileCount} session file${sessionFileCount === 1 ? "" : "s"}`}
+					<span aria-hidden="true">{filesExpanded ? "▾" : "▸"}</span>
+				</button>
+				{#if filesExpanded}
+					<ul class="mt-2 max-h-40 overflow-auto rounded border border-border/40 bg-muted/30 px-2 py-1.5 text-xs font-mono">
+						{#each sessionFiles as path (path)}
+							<li class="truncate" title={path}>{path}</li>
+						{/each}
+					</ul>
+				{/if}
+			</div>
+		{/if}
+
+		{#if otherLocalChangesMessage}
+			<p class="px-4 pt-2 text-xs text-muted-foreground">{otherLocalChangesMessage}</p>
+		{/if}
+
+		{#if !moveAvailable && moveUnavailableReason}
+			<p class="px-4 pt-2 text-xs text-muted-foreground" aria-live="polite">
+				{moveUnavailableReason}
+			</p>
+		{/if}
+
+		{#if errorMessage}
+			<p class="px-4 pt-2 text-xs text-destructive" role="alert" aria-live="assertive">
+				{errorMessage}
+			</p>
+		{/if}
+
+		<div class="mt-4 flex flex-col border-t border-border/40">
+			<button
+				type="button"
+				class="flex flex-col items-start gap-0.5 px-4 py-3 text-left hover:bg-accent disabled:opacity-50 disabled:cursor-not-allowed transition-colors border-b border-border/30"
+				onclick={onContinue}
+				disabled={busy}
+				autofocus
+			>
+				<span class="text-sm font-medium">{continueLabel}</span>
+				<span class="text-xs text-muted-foreground leading-snug">{continueHelperText}</span>
+			</button>
+
+			{#if onMove}
+				<button
+					type="button"
+					class="flex flex-col items-start gap-0.5 px-4 py-3 text-left hover:bg-accent disabled:opacity-50 disabled:cursor-not-allowed transition-colors border-b border-border/30"
+					onclick={onMove}
+					disabled={busy || !moveAvailable}
+				>
+					<span class="text-sm font-medium">{moveLabel}</span>
+					{#if moveHelperText}
+						<span class="text-xs text-muted-foreground leading-snug">{moveHelperText}</span>
+					{/if}
+				</button>
+			{/if}
+
+			<button
+				type="button"
+				class="px-4 py-2.5 text-sm text-muted-foreground hover:text-foreground hover:bg-muted disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
+				onclick={onCancel}
+				disabled={busy}
+			>
+				{cancelLabel}
+			</button>
+		</div>
+	</Dialog.Content>
+</Dialog.Root>

--- a/packages/ui/src/components/agent-panel/index.ts
+++ b/packages/ui/src/components/agent-panel/index.ts
@@ -76,6 +76,7 @@ export { default as AgentPanelStatusStrip } from "./agent-panel-status-strip.sve
 export { default as AgentPanelTerminalDrawer } from "./agent-panel-terminal-drawer.svelte";
 export { default as AgentPanelTrailingPaneLayout } from "./agent-panel-trailing-pane-layout.svelte";
 export { default as AgentPanelWorktreeCloseConfirmPopover } from "./agent-panel-worktree-close-confirm-popover.svelte";
+export { default as AgentPanelWorktreeSwitchDialog } from "./agent-panel-worktree-switch-dialog.svelte";
 export { default as AgentSelectionGrid } from "./agent-selection-grid.svelte";
 export type { AgentGridItem } from "./agent-selection-grid-types.js";
 export { default as AgentToolBrowser } from "./agent-tool-browser.svelte";
@@ -120,7 +121,7 @@ export { default as AgentPanelPermissionBarIcon } from "./permission-bar-icon.sv
 export { default as AgentPanelPermissionBarProgress } from "./permission-bar-progress.svelte";
 export { default as AgentPanelPlanHeader } from "./plan-header.svelte";
 export { default as AgentPanelPrStatusCard } from "./pr-status-card.svelte";
-export { default as AgentPanelPreSessionWorktreeCard } from "./pre-session-worktree-card.svelte";
+export { default as AgentPanelWorktreeTogglePill } from "./worktree-toggle-pill.svelte";
 export { default as AgentPanelQueueCardStrip } from "./queue-card-strip.svelte";
 export { default as AgentPanelReviewNavigation } from "./review-navigation.svelte";
 export { default as AgentPanelReviewTabStrip } from "./review-tab-strip.svelte";

--- a/packages/ui/src/components/agent-panel/worktree-toggle-pill.svelte
+++ b/packages/ui/src/components/agent-panel/worktree-toggle-pill.svelte
@@ -1,0 +1,104 @@
+<script lang="ts">
+	import { Tree, WarningCircle } from "phosphor-svelte";
+	import { Button } from "../button/index.js";
+
+	interface Props {
+		/** Pill label, e.g. "Worktree". */
+		label: string;
+		/** When true, the toggle renders in "enabled" appearance. */
+		enabled: boolean;
+		/** When non-null, switches to the failure variant. */
+		failureMessage?: string | null;
+		failureLabel?: string;
+		retryLabel?: string;
+		dismissLabel?: string;
+		/** When true, disables the toggle (e.g. while a worktree is being created). */
+		busy?: boolean;
+		onToggle: () => void;
+		onRetry?: () => void;
+		onDismiss?: () => void;
+		/** When provided, clicking the label/icon opens setup (e.g. a popover). */
+		onLabelClick?: () => void;
+	}
+
+	let {
+		label,
+		enabled,
+		failureMessage = null,
+		failureLabel = "Worktree failed",
+		retryLabel = "Retry",
+		dismissLabel = "Dismiss",
+		busy = false,
+		onToggle,
+		onRetry,
+		onDismiss,
+		onLabelClick,
+	}: Props = $props();
+</script>
+
+{#if failureMessage}
+	<div class="inline-flex h-7 items-center gap-1.5 px-2" data-state="failed">
+		<WarningCircle size={12} weight="fill" class="shrink-0 text-destructive" />
+		<span class="shrink-0 text-[0.6875rem] font-medium text-foreground">{failureLabel}</span>
+		<span class="min-w-0 max-w-[180px] truncate text-[0.6875rem] text-muted-foreground"
+			>{failureMessage}</span
+		>
+		{#if onRetry}
+			<Button variant="headerAction" size="headerAction" onclick={onRetry}>
+				{retryLabel}
+			</Button>
+		{/if}
+		{#if onDismiss}
+			<Button variant="headerAction" size="headerAction" onclick={onDismiss}>
+				{dismissLabel}
+			</Button>
+		{/if}
+	</div>
+{:else}
+	<div class="inline-flex h-7 items-center" data-state={enabled ? "on" : "off"}>
+		<!-- Label area: clickable to open setup scripts when onLabelClick is provided -->
+		{#if onLabelClick}
+			<button
+				type="button"
+				onclick={onLabelClick}
+				class="flex h-full items-center gap-1.5 pl-2 pr-1.5 text-[0.6875rem] text-muted-foreground transition-colors hover:text-foreground"
+			>
+				<Tree
+					size={12}
+					weight={enabled ? "fill" : "regular"}
+					class="shrink-0 {enabled ? 'text-success' : ''}"
+				/>
+				<span>{label}</span>
+			</button>
+		{:else}
+			<span class="flex h-full items-center gap-1.5 pl-2 pr-1.5 text-[0.6875rem] text-muted-foreground">
+				<Tree
+					size={12}
+					weight={enabled ? "fill" : "regular"}
+					class="shrink-0 {enabled ? 'text-success' : ''}"
+				/>
+				<span>{label}</span>
+			</span>
+		{/if}
+		<!-- Toggle switch -->
+		<button
+			type="button"
+			onclick={onToggle}
+			disabled={busy}
+			aria-pressed={enabled}
+			class="flex h-full items-center pr-2 disabled:cursor-not-allowed disabled:opacity-60"
+		>
+			<span
+				class="relative inline-flex h-3.5 w-6 shrink-0 items-center rounded-full transition-colors duration-200 {enabled
+					? 'bg-success/80'
+					: 'bg-foreground/15'}"
+			>
+				<span
+					class="absolute h-2.5 w-2.5 rounded-full bg-white shadow-sm transition-transform duration-200 {enabled
+						? 'translate-x-[calc(100%-1px)]'
+						: 'translate-x-px'}"
+				></span>
+			</span>
+		</button>
+	</div>
+{/if}

--- a/packages/ui/src/components/app-layout/app-sidebar-layout.svelte
+++ b/packages/ui/src/components/app-layout/app-sidebar-layout.svelte
@@ -22,7 +22,7 @@ interface Props {
 </script>
 
 <aside
-	class="shrink-0 flex w-[280px] flex-col h-full overflow-hidden gap-0"
+	class="shrink-0 flex w-[280px] flex-col h-full overflow-hidden gap-0 pl-1.5"
 >
 	<!-- Queue Section -->
 	{#if queueSection}

--- a/packages/ui/src/components/app-layout/project-tab-bar.svelte
+++ b/packages/ui/src/components/app-layout/project-tab-bar.svelte
@@ -30,52 +30,53 @@
 		<div class="flex min-w-0 items-stretch gap-1 overflow-x-auto">
 			{#each projects as project (project.path)}
 				{@const isActive = project.path === activeProjectPath}
-				<button
-					type="button"
-					role="tab"
-					aria-selected={isActive}
-					class="group/project-tab relative flex min-w-0 items-center gap-1.5 rounded-md px-2 py-1 text-xs transition-colors cursor-pointer {isActive
-						? 'bg-accent text-foreground'
-						: 'bg-accent/50 text-muted-foreground hover:bg-accent hover:text-foreground'}"
-					onclick={() => onSelectProject(project.path)}
-					title={project.name}
-				>
-					<ProjectLetterBadge
-						name={project.name}
-						color={project.color}
-						iconSrc={project.iconSrc ?? null}
-						size={14}
-						class="shrink-0"
-					/>
-					<span class="truncate max-w-[160px]">{project.name}</span>
+				<div class="group/session-badge relative flex min-w-0">
+					<button
+						type="button"
+						role="tab"
+						aria-selected={isActive}
+						class="group/project-tab relative flex min-w-0 items-center gap-1.5 rounded-md px-2 py-1 text-xs transition-colors cursor-pointer {project.sessionCount !=
+							null && onCreateSession
+							? 'pr-6'
+							: ''} {isActive
+							? 'bg-accent text-foreground'
+							: 'bg-accent/50 text-muted-foreground hover:bg-accent hover:text-foreground'}"
+						onclick={() => onSelectProject(project.path)}
+						title={project.name}
+					>
+						<ProjectLetterBadge
+							name={project.name}
+							color={project.color}
+							iconSrc={project.iconSrc ?? null}
+							size={14}
+							class="shrink-0"
+						/>
+						<span class="truncate max-w-[160px]">{project.name}</span>
 						{#if project.sessionCount != null}
-							{#if onCreateSession}
-								<span class="group/session-badge relative ml-0.5 inline-flex h-4 min-w-4 shrink-0 items-center justify-center">
-									<span
-										class="inline-flex h-4 min-w-4 items-center justify-center rounded px-1 text-[10px] leading-none text-muted-foreground bg-foreground/10 transition-opacity duration-150 group-hover/session-badge:opacity-0"
-										aria-label="{project.sessionCount} sessions"
-									>
-										{project.sessionCount}
-									</span>
-									<button
-										type="button"
-										class="absolute inset-0 flex items-center justify-center rounded opacity-0 transition-opacity duration-150 group-hover/session-badge:opacity-100 bg-foreground/10 text-muted-foreground hover:text-foreground"
-										aria-label="New session in {project.name}"
-										onclick={(e) => { e.stopPropagation(); onCreateSession(project.path); }}
-									>
-										<IconPlus class="h-2.5 w-2.5" />
-									</button>
-								</span>
-							{:else}
-								<span
-									class="ml-0.5 inline-flex h-4 min-w-4 shrink-0 items-center justify-center rounded px-1 text-[10px] leading-none text-muted-foreground bg-foreground/10"
-									aria-label="{project.sessionCount} sessions"
-								>
-									{project.sessionCount}
-								</span>
-							{/if}
+							<span
+								class="ml-0.5 inline-flex h-4 min-w-4 shrink-0 items-center justify-center rounded px-1 text-[10px] leading-none text-muted-foreground bg-foreground/10 transition-opacity duration-150 {onCreateSession
+									? 'group-hover/session-badge:opacity-0'
+									: ''}"
+								aria-label="{project.sessionCount} sessions"
+							>
+								{project.sessionCount}
+							</span>
 						{/if}
-				</button>
+					</button>
+					{#if project.sessionCount != null && onCreateSession}
+						<button
+							type="button"
+							class="absolute right-2 top-1/2 flex h-4 min-w-4 -translate-y-1/2 items-center justify-center rounded bg-foreground/10 text-muted-foreground opacity-0 transition-opacity duration-150 group-hover/session-badge:opacity-100 hover:text-foreground"
+							aria-label="New session in {project.name}"
+							onclick={(e) => {
+								e.stopPropagation();
+								onCreateSession(project.path);
+							}}
+						>
+							<IconPlus class="h-2.5 w-2.5" />
+						</button>
+					{/if}
+				</div>
 			{/each}
 		</div>
 	</div>

--- a/packages/ui/src/components/dropdown-menu/dropdown-menu-item.classes.ts
+++ b/packages/ui/src/components/dropdown-menu/dropdown-menu-item.classes.ts
@@ -12,10 +12,9 @@ export function buildDropdownMenuItemClassName(hasHighlightContext: boolean): st
 		"dark:data-[variant=destructive]:data-highlighted:bg-destructive/20",
 		"data-[variant=destructive]:data-highlighted:text-destructive",
 		"data-[variant=destructive]:*:[svg]:!text-destructive",
-		"relative flex cursor-default items-center gap-2",
-		"px-2 py-1 text-[11px] font-medium",
+		"relative flex cursor-default items-center gap-1.5",
+		"px-2 py-0.5 text-[11px] font-medium",
 		"outline-hidden select-none",
-		"border-b border-border/20 last:border-b-0",
 		"data-[disabled]:pointer-events-none data-[disabled]:opacity-50",
 		"data-[inset]:ps-8",
 		"[&_svg:not([class*='text-'])]:text-muted-foreground",
@@ -24,6 +23,6 @@ export function buildDropdownMenuItemClassName(hasHighlightContext: boolean): st
 		"data-[highlighted]:[&_svg:not([class*='text-'])]:text-current",
 		"data-[selected]:[&_svg:not([class*='text-'])]:text-current",
 		"aria-selected:[&_svg:not([class*='text-'])]:text-current",
-		"[&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+		"[&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-3",
 	].join(" ");
 }

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -90,7 +90,7 @@ export {
 	AgentPanelFooterChrome,
 	AgentPanelHeader,
 	AgentPanelInstallCard,
-	AgentPanelPreSessionWorktreeCard,
+	AgentPanelWorktreeTogglePill,
 	AgentPanelLayout,
 	AgentPanelModifiedFileRow,
 	AgentPanelModifiedFilesTrailingControls,

--- a/packages/website/package.json
+++ b/packages/website/package.json
@@ -36,7 +36,9 @@
 		"phosphor-svelte": "^3.1.0",
 		"pino": "^10.1.0",
 		"postgres": "^3.4.5",
+		"runed": "^0.35.1",
 		"shiki": "^3.22.0",
+		"streamdown": "2.5.0",
 		"tailwind-merge": "^3.4.0",
 		"tw-animate-css": "^1.4.0",
 		"vaul-svelte": "^1.0.0-next.7"

--- a/packages/website/src/routes/dev/worktree-composer/+page.svelte
+++ b/packages/website/src/routes/dev/worktree-composer/+page.svelte
@@ -1,0 +1,285 @@
+<script lang="ts">
+import { AgentPanelFooter, AgentPanelWorktreeTogglePill } from "@acepe/ui/agent-panel";
+import { InputContainer } from "@acepe/ui/input-container";
+import Seo from "$lib/components/seo/seo.svelte";
+import { CaretDown, FolderOpen, GitBranch, Paperclip, Robot, Tree, ArrowUp } from "phosphor-svelte";
+
+type WorktreePreviewState = "off" | "on" | "active" | "failed";
+
+const previewStates: readonly WorktreePreviewState[] = ["off", "on", "active", "failed"];
+
+let worktreeState = $state<WorktreePreviewState>("off");
+let setupOpen = $state(false);
+let autonomous = $state(false);
+let currentModeId = $state("build");
+
+const worktreeEnabled = $derived(worktreeState === "on");
+const showPreSessionPill = $derived(worktreeState === "off" || worktreeState === "on" || worktreeState === "failed");
+
+function setWorktreeState(nextState: WorktreePreviewState): void {
+	worktreeState = nextState;
+	if (nextState !== "on" && nextState !== "off") {
+		setupOpen = false;
+	}
+}
+
+function toggleWorktree(): void {
+	worktreeState = worktreeEnabled ? "off" : "on";
+}
+</script>
+
+<Seo
+	title="Dev: Worktree composer preview"
+	description="Internal preview surface for the worktree composer component."
+	noindex
+/>
+
+<main class="min-h-screen bg-background text-foreground">
+	<section class="mx-auto flex min-h-screen w-full max-w-6xl flex-col px-6 py-8">
+		<header class="mb-8 flex flex-wrap items-end justify-between gap-4">
+			<div>
+				<p class="mb-2 text-xs font-medium uppercase tracking-[0.22em] text-muted-foreground">
+					Dev-only component preview
+				</p>
+				<h1 class="text-3xl font-semibold tracking-tight">Worktree composer footer</h1>
+				<p class="mt-2 max-w-2xl text-sm text-muted-foreground">
+					Full prompt container preview with the new worktree pill placed below the composer on the left.
+				</p>
+			</div>
+
+			<div class="flex rounded-xl border border-border/60 bg-card/50 p-1">
+				{#each previewStates as state (state)}
+					<button
+						type="button"
+						class="rounded-lg px-3 py-1.5 text-xs font-medium capitalize transition-colors {worktreeState === state
+							? 'bg-accent text-foreground'
+							: 'text-muted-foreground hover:text-foreground'}"
+						aria-pressed={worktreeState === state}
+						onclick={() => setWorktreeState(state)}
+					>
+						{state}
+					</button>
+				{/each}
+			</div>
+		</header>
+
+		<div class="grid flex-1 grid-cols-[minmax(0,1fr)_18rem] gap-6">
+			<section class="min-w-0 rounded-2xl border border-border/70 bg-card/40 shadow-2xl shadow-black/20">
+				<div class="flex h-11 items-center justify-between border-b border-border/50 px-4">
+					<div class="flex items-center gap-2">
+						<span class="size-2 rounded-full bg-success"></span>
+						<span class="text-sm font-medium">New session</span>
+					</div>
+					<span class="text-xs text-muted-foreground">desktop composer layout</span>
+				</div>
+
+				<div class="flex min-h-[34rem] flex-col justify-end">
+					<div class="px-5 pb-4">
+						<div class="mx-auto w-full max-w-3xl">
+							<InputContainer
+								class="border border-border/50 bg-background/80 shadow-xl shadow-black/20"
+								contentClass="px-3 py-2"
+							>
+								{#snippet content()}
+									<div class="mb-2 flex flex-wrap gap-1.5">
+										<span class="inline-flex h-6 items-center gap-1 rounded-full border border-border/60 bg-input/30 px-2 text-xs text-muted-foreground">
+											<Paperclip size={12} />
+											agent-panel.svelte
+										</span>
+										<span class="inline-flex h-6 items-center gap-1 rounded-full border border-border/60 bg-input/30 px-2 text-xs text-muted-foreground">
+											<Paperclip size={12} />
+											worktree-toggle-pill.svelte
+										</span>
+									</div>
+
+									<div class="flex min-w-0 gap-1.5">
+										<div class="relative min-h-7 flex-1">
+											<div
+												role="textbox"
+												aria-multiline="true"
+												aria-label="Prompt"
+												tabindex="0"
+												contenteditable="true"
+												spellcheck={false}
+												class="min-h-7 max-h-[400px] overflow-y-auto whitespace-pre-wrap break-words text-sm leading-relaxed text-foreground outline-none"
+											></div>
+											<div class="pointer-events-none absolute left-0 top-0 select-none text-sm leading-relaxed text-muted-foreground">
+												Ask an agent to implement the worktree UX…
+											</div>
+										</div>
+										<div class="flex shrink-0 items-end gap-1.5">
+											<div class="inline-flex h-7 shrink-0 items-center gap-px" role="group" aria-label="Mode">
+												{#each ["plan", "build"] as mode (mode)}
+													<button
+														type="button"
+														aria-pressed={currentModeId === mode}
+														class="inline-flex h-7 items-center justify-center gap-1 px-2 text-[11px] font-medium leading-none transition-colors {currentModeId === mode
+															? 'bg-accent/50 text-foreground'
+															: 'text-muted-foreground hover:text-foreground'}"
+														onclick={() => {
+															currentModeId = mode;
+														}}
+													>
+														{mode === "plan" ? "Plan" : "Build"}
+													</button>
+												{/each}
+											</div>
+											<button
+												type="button"
+												class="flex h-7 w-7 shrink-0 items-center justify-center rounded-full bg-foreground text-background transition-colors hover:bg-foreground/85"
+												aria-label="Send message"
+											>
+												<ArrowUp size={14} />
+											</button>
+										</div>
+									</div>
+								{/snippet}
+
+								{#snippet footer()}
+									<div class="flex min-w-0 items-center">
+										<button
+											type="button"
+											class="inline-flex h-7 items-center gap-1 px-2 text-[11px] font-medium text-foreground/85 transition-colors hover:bg-accent/50 hover:text-foreground"
+										>
+											<img src="/svgs/agents/copilot/copilot-icon-dark.svg" alt="" class="h-3 w-3" />
+											GPT-5.5
+											<CaretDown size={10} weight="bold" class="text-muted-foreground" />
+										</button>
+										<div class="h-full w-px bg-border/50"></div>
+										<button
+											type="button"
+											class="inline-flex h-7 items-center gap-1 px-2 text-[11px] font-medium text-muted-foreground transition-colors hover:bg-accent/50 hover:text-foreground"
+										>
+											<FolderOpen size={13} />
+											acepe
+										</button>
+									</div>
+
+									<div class="ml-auto flex items-center gap-1">
+										<div class="flex h-7 items-center gap-1.5 px-1.5 text-sm text-muted-foreground" role="status" aria-label="Context usage">
+											<span class="font-mono font-medium tabular-nums">18k/200k</span>
+											<div class="flex items-center gap-[1px]" aria-hidden="true">
+												{#each Array.from({ length: 10 }) as _, index (index)}
+													<span class="h-[10px] w-[3px] rounded-[1px] {index === 0 ? 'bg-success opacity-100' : 'bg-border opacity-55'}"></span>
+												{/each}
+											</div>
+										</div>
+										<button
+											type="button"
+											class="flex h-7 w-7 items-center justify-center transition-colors hover:bg-accent/50 {autonomous
+												? 'text-purple-400'
+												: 'text-muted-foreground hover:text-foreground'}"
+											aria-label="Autonomous"
+											aria-pressed={autonomous}
+											onclick={() => {
+												autonomous = !autonomous;
+											}}
+										>
+											<Robot size={14} weight={autonomous ? "fill" : "regular"} />
+										</button>
+									</div>
+								{/snippet}
+							</InputContainer>
+
+							<div class="relative">
+								<AgentPanelFooter
+									browserTitle="Toggle browser"
+									browserAriaLabel="Toggle browser"
+									terminalTitle="Toggle terminal"
+									terminalAriaLabel="Toggle terminal"
+								>
+									{#snippet left()}
+										<div class="flex items-center divide-x divide-border/50">
+											{#if showPreSessionPill}
+												<div class="px-1">
+													<AgentPanelWorktreeTogglePill
+														label="Worktree"
+														enabled={worktreeEnabled}
+														failureMessage={worktreeState === "failed"
+															? "Branch setup command exited 1"
+															: null}
+														onToggle={toggleWorktree}
+														onRetry={() => setWorktreeState("on")}
+														onDismiss={() => setWorktreeState("off")}
+													>
+														{#snippet trailing()}
+															<button
+																type="button"
+																class="flex h-5 w-5 items-center justify-center rounded text-muted-foreground transition-colors hover:bg-foreground/5 hover:text-foreground"
+																aria-label="Setup scripts"
+																aria-expanded={setupOpen}
+																onclick={() => {
+																	setupOpen = !setupOpen;
+																}}
+															>
+																<CaretDown
+																	size={10}
+																	weight="bold"
+																	class="transition-transform duration-150 {setupOpen ? 'rotate-180' : ''}"
+																/>
+															</button>
+														{/snippet}
+													</AgentPanelWorktreeTogglePill>
+												</div>
+											{:else}
+												<button
+													type="button"
+													class="inline-flex h-7 items-center gap-1.5 px-3 text-[0.6875rem] font-medium text-foreground transition-colors hover:bg-accent/50"
+												>
+													<Tree size={12} weight="fill" class="text-success" />
+													<span>acepe-worktree-ux</span>
+												</button>
+											{/if}
+										</div>
+									{/snippet}
+								</AgentPanelFooter>
+
+								{#if setupOpen && showPreSessionPill && worktreeState !== "failed"}
+									<div class="absolute bottom-9 left-1 z-10 w-[28rem] rounded-xl border border-border/70 bg-popover p-3 text-popover-foreground shadow-2xl shadow-black/30">
+										<div class="mb-3 flex items-center justify-between">
+											<div>
+												<h2 class="text-sm font-medium">Setup scripts</h2>
+												<p class="text-xs text-muted-foreground">Commands run after creating the worktree.</p>
+											</div>
+											<GitBranch size={14} class="text-muted-foreground" />
+										</div>
+										<div class="space-y-2">
+											<div class="rounded-lg border border-border/60 bg-background/70 px-3 py-2 font-mono text-xs text-muted-foreground">
+												bun install --frozen-lockfile
+											</div>
+											<div class="rounded-lg border border-border/60 bg-background/70 px-3 py-2 font-mono text-xs text-muted-foreground">
+												bun run check
+											</div>
+										</div>
+									</div>
+								{/if}
+							</div>
+						</div>
+					</div>
+				</div>
+			</section>
+
+			<aside class="rounded-2xl border border-border/70 bg-card/40 p-4">
+				<h2 class="text-sm font-semibold">States</h2>
+				<div class="mt-4 space-y-3 text-sm">
+					<div>
+						<p class="font-medium">Off</p>
+						<p class="text-muted-foreground">Muted tree icon. Click pill to enable worktree for the next send.</p>
+					</div>
+					<div>
+						<p class="font-medium">On</p>
+						<p class="text-muted-foreground">Filled green tree icon. Caret opens setup scripts.</p>
+					</div>
+					<div>
+						<p class="font-medium">Active</p>
+						<p class="text-muted-foreground">Pill is replaced by the existing active worktree footer button.</p>
+					</div>
+					<div>
+						<p class="font-medium">Failed</p>
+						<p class="text-muted-foreground">Inline destructive status with Retry and Dismiss actions.</p>
+					</div>
+				</div>
+			</aside>
+		</div>
+	</section>
+</main>

--- a/packages/website/src/routes/dev/worktree-composer/+page.ts
+++ b/packages/website/src/routes/dev/worktree-composer/+page.ts
@@ -1,0 +1,10 @@
+import { dev } from "$app/environment";
+import { error } from "@sveltejs/kit";
+
+export function load() {
+	if (!dev) {
+		error(404, "Not found");
+	}
+
+	return {};
+}

--- a/packages/website/vite.config.ts
+++ b/packages/website/vite.config.ts
@@ -1,9 +1,15 @@
 import { sveltekit } from "@sveltejs/kit/vite";
 import tailwindcss from "@tailwindcss/vite";
+import { fileURLToPath } from "node:url";
 import { defineConfig } from "vitest/config";
 
 export default defineConfig({
 	plugins: [tailwindcss(), sveltekit()],
+	resolve: {
+		alias: {
+			runed: fileURLToPath(new URL("./node_modules/runed/dist/index.js", import.meta.url)),
+		},
+	},
 
 	test: {
 		expect: { requireAssertions: true },


### PR DESCRIPTION
## Problem

When starting a new session, the model selector shows a pre-filled model (e.g. GPT 5.4) based on saved preferences. However, if the user sends a message without explicitly re-clicking the selector, the backend ignores the displayed model and uses its own default (e.g. Claude Sonnet).

## Root Cause

`getProvisionalModelId()` returned `null` when the user never interacted with the selector — even though `preferredDefaultModelId` was being used for display via `resolveToolbarModelId`. The session creation path then sent no `initialModelId`, letting the backend pick freely.

## Fix

Fall back to `preferredDefaultModelId` when `provisionalModelId` is null:

```ts
// Before
getProvisionalModelId: () => provisionalModelId,

// After
getProvisionalModelId: () => provisionalModelId ?? preferredDefaultModelId,
```

This ensures the `initialModelId` sent during session creation matches what the user sees in the selector. The fallback is validated downstream (`session-connection-manager` checks against available models) and only applies to new sessions (`props.sessionId ? null : host.getProvisionalModelId()`).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the “pre-filled” model being ignored when starting a new session and adds a mid-session Worktree switch confirmation so future turns can continue in a new worktree without silently moving existing changes.

- New Features
  - Mid-session Worktree switch dialog in the agent panel (Continue-only path): existing changes stay in the source checkout; future turns run in the new worktree. Backed by a new `prepareMidSessionWorktreeSwitch` service.
  - Worktree toggle pill is now visible mid-session and after attach; terminal can render as a right-side trailing pane for better space use.

- Bug Fixes
  - Model selector: when `provisionalModelId` is null, fall back to `preferredDefaultModelId` so `initialModelId` matches what the UI shows on new session creation.
  - Browser panel scroll-sync now subscribes to overflow ancestors before they become scrollable, fixing webview bleed during horizontal scrolling.

<sup>Written for commit c240b4cf570ea073a5a10706fbf13ce0102aa928. Summary will update on new commits. <a href="https://cubic.dev/pr/flazouh/acepe/pull/199?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

