### PR TITLE
fix: prevent ghost panel flood on reload + UI polish

### DIFF
--- a/packages/desktop/src/lib/acp/components/session-list/session-list-ui.svelte
+++ b/packages/desktop/src/lib/acp/components/session-list/session-list-ui.svelte
@@ -1097,7 +1097,7 @@ function openCreateBranchDialog(projectPath: string): void {
 							{@const filteredSessions = getFilteredSidebarSessionsForProject(group)}
 							{@const visibleSessions = getVisibleSessionsForProject(group)}
 							<div
-								class="shrink-0 px-1 pb-1"
+								class="shrink-0 px-1 pt-1 pb-1"
 								role="presentation"
 								onclick={(event) => event.stopPropagation()}
 								onkeydown={handleProjectHistorySearchKeydown}
@@ -1106,7 +1106,7 @@ function openCreateBranchDialog(projectPath: string): void {
 									type="search"
 									value={getProjectHistoryQuery(group.projectPath)}
 									placeholder="Search project history..."
-									class="h-7 rounded-md border-border/70 bg-background/70 px-2 text-[11px]"
+									class="h-6 rounded-md border-border/70 bg-background/70 px-2 py-0 text-[11px] md:text-[11px]"
 									data-sidebar-project-history-search
 									oninput={(event) =>
 										setProjectHistoryQuery(group.projectPath, event.currentTarget.value)}

--- a/packages/desktop/src/lib/components/main-app-view/logic/live-session-panel-sync.ts
+++ b/packages/desktop/src/lib/components/main-app-view/logic/live-session-panel-sync.ts
@@ -56,12 +56,28 @@ export function buildLiveSessionPanelSignal(input: LiveSessionPanelSyncInput): s
 	].join("|");
 }
 
+/**
+ * Tracks whether the initial sync pass has run.
+ * On the first call after startup, live sessions that have no panel are
+ * seeded into the suppression map instead of being materialized. This
+ * prevents hundreds of stale live sessions from auto-opening panels on
+ * every reload (the suppression map is in-memory and lost on restart).
+ * Only genuinely *new* activity (signal change) after the first pass will
+ * materialize a panel.
+ */
+let initialSyncComplete = false;
+
+export function resetLiveSessionPanelSync(): void {
+	initialSyncComplete = false;
+}
+
 export function syncLiveSessionPanels(
 	inputs: readonly LiveSessionPanelSyncInput[],
 	controller: LiveSessionPanelSyncController,
 	width: number
 ): readonly string[] {
 	const materializedSessionIds: string[] = [];
+	const isFirstRun = !initialSyncComplete;
 
 	for (const input of inputs) {
 		if (!isLiveSessionPanelCandidate(input)) {
@@ -74,9 +90,17 @@ export function syncLiveSessionPanels(
 			continue;
 		}
 
+		// On the first sync pass, seed suppression instead of materializing.
+		// This prevents re-opening all live sessions after a reload.
+		if (isFirstRun) {
+			controller.syncSuppression(input.sessionId, signal);
+			continue;
+		}
+
 		controller.materialize(input.sessionId, width);
 		materializedSessionIds.push(input.sessionId);
 	}
 
+	initialSyncComplete = true;
 	return materializedSessionIds;
 }

--- a/packages/desktop/src/lib/components/main-app-view/tests/live-session-panel-sync.test.ts
+++ b/packages/desktop/src/lib/components/main-app-view/tests/live-session-panel-sync.test.ts
@@ -5,6 +5,7 @@ import {
 	isLiveSessionPanelCandidate,
 	type LiveSessionPanelSyncController,
 	type LiveSessionPanelSyncInput,
+	resetLiveSessionPanelSync,
 	syncLiveSessionPanels,
 } from "../logic/live-session-panel-sync.js";
 
@@ -111,8 +112,31 @@ describe("isLiveSessionPanelCandidate", () => {
 });
 
 describe("syncLiveSessionPanels", () => {
+	// After the initial sync pass (which seeds suppression without materializing),
+	// subsequent calls materialize new live sessions as expected.
+	// Each test resets module state and runs an empty initial pass first.
+	function completeInitialSync(controller: LiveSessionPanelSyncController): void {
+		resetLiveSessionPanelSync();
+		syncLiveSessionPanels([], controller, 450);
+	}
+
+	it("does not materialize on the very first sync pass (initial seed)", () => {
+		resetLiveSessionPanelSync();
+		const { controller, materializedSessionIds } = createController();
+
+		const synchronized = syncLiveSessionPanels(
+			[makeInput({ sessionId: "session-1" })],
+			controller,
+			450
+		);
+
+		expect(synchronized).toEqual([]);
+		expect(materializedSessionIds).toEqual([]);
+	});
+
 	it("materializes live sessions that do not yet have panels", () => {
 		const { controller, materializedSessionIds } = createController();
+		completeInitialSync(controller);
 
 		const synchronized = syncLiveSessionPanels(
 			[makeInput({ sessionId: "session-1" })],
@@ -126,6 +150,7 @@ describe("syncLiveSessionPanels", () => {
 
 	it("does not materialize non-live sessions", () => {
 		const { controller, materializedSessionIds } = createController();
+		completeInitialSync(controller);
 
 		const synchronized = syncLiveSessionPanels(
 			[makeInput({ sessionId: "session-1", connectionPhase: "connected", activityPhase: "idle" })],
@@ -144,6 +169,7 @@ describe("syncLiveSessionPanels", () => {
 			[],
 			new Map([["session-1", signal]])
 		);
+		completeInitialSync(controller);
 
 		const synchronized = syncLiveSessionPanels([input], controller, 450);
 
@@ -159,6 +185,7 @@ describe("syncLiveSessionPanels", () => {
 			[],
 			new Map([["session-1", previousSignal]])
 		);
+		completeInitialSync(controller);
 
 		const synchronized = syncLiveSessionPanels(
 			[makeInput({ sessionId: "session-1", updatedAtMs: 2000 })],
@@ -173,6 +200,7 @@ describe("syncLiveSessionPanels", () => {
 
 	it("does not materialize sessions that already have panels", () => {
 		const { controller, materializedSessionIds } = createController(["session-1"]);
+		completeInitialSync(controller);
 
 		const synchronized = syncLiveSessionPanels(
 			[makeInput({ sessionId: "session-1" })],

--- a/packages/ui/src/components/agent-panel/worktree-toggle-pill.svelte
+++ b/packages/ui/src/components/agent-panel/worktree-toggle-pill.svelte
@@ -61,23 +61,23 @@
 			<button
 				type="button"
 				onclick={onLabelClick}
-				class="flex h-full items-center gap-1.5 pl-2 pr-1.5 text-[0.6875rem] text-muted-foreground transition-colors hover:text-foreground"
+				class="flex h-full items-center gap-1.5 pl-2 pr-1.5 text-xs font-mono text-muted-foreground transition-colors hover:text-foreground"
 			>
 				<Tree
 					size={12}
 					weight={enabled ? "fill" : "regular"}
 					class="shrink-0 {enabled ? 'text-success' : ''}"
 				/>
-				<span>{label}</span>
+				<span class="lowercase">{label}</span>
 			</button>
 		{:else}
-			<span class="flex h-full items-center gap-1.5 pl-2 pr-1.5 text-[0.6875rem] text-muted-foreground">
+			<span class="flex h-full items-center gap-1.5 pl-2 pr-1.5 text-xs font-mono text-muted-foreground">
 				<Tree
 					size={12}
 					weight={enabled ? "fill" : "regular"}
 					class="shrink-0 {enabled ? 'text-success' : ''}"
 				/>
-				<span>{label}</span>
+				<span class="lowercase">{label}</span>
 			</span>
 		{/if}
 		<!-- Toggle switch -->
@@ -95,8 +95,8 @@
 			>
 				<span
 					class="absolute h-2.5 w-2.5 rounded-full bg-white shadow-sm transition-transform duration-200 {enabled
-						? 'translate-x-[calc(100%-1px)]'
-						: 'translate-x-px'}"
+						? 'translate-x-[12px]'
+						: 'translate-x-[2px]'}"
 				></span>
 			</span>
 		</button>


### PR DESCRIPTION
## Summary

Fixes a critical bug where hundreds of ghost agent panels accumulate on every app reload, plus three UI polish issues.

## Changes

### 🐛 Fix: Ghost panel flood on reload
**Problem:** Every time the app reloads, `syncLiveSessionPanels` re-materializes panels for ALL live sessions because the suppression map (in-memory only) is lost on reload. This caused 200+ ghost tabs to reappear.

**Fix:** Added an `initialSyncComplete` guard in `live-session-panel-sync.ts`. The first sync pass now seeds the suppression map with existing live sessions without materializing panels. Subsequent reactive updates materialize normally for genuinely new activity only.

### 🎨 Fix: Worktree toggle pill styling
- Changed text from `text-[0.6875rem]` to `text-xs font-mono lowercase` to match branch name styling
- Fixed toggle knob alignment: symmetric 2px padding instead of asymmetric 1px

### 🎨 Fix: Session list search bar sizing  
- Reduced height from `h-7` to `h-6`
- Shrunk text to 11px
- Added `pt-1` padding above the search container

## Testing
- All 12 tests in `live-session-panel-sync.test.ts` pass (including new test for initial seed behavior)
- TypeScript check passes
- Manually verified: 0 panels after reload (was 207)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents ghost agent panels from reappearing on reload by seeding suppression on the first sync pass. Also tweaks the worktree toggle pill and session list search bar for better alignment and sizing.

- **Bug Fixes**
  - First sync seeds suppression for existing live sessions without materializing panels; only new activity opens panels.
  - Added `resetLiveSessionPanelSync()` and tests for the initial seed behavior.

- **UI Polish**
  - Worktree toggle pill: `text-xs` `font-mono` lowercase label; fixed knob translation for symmetric padding.
  - Session list search: height `h-6`, 11px text, added `pt-1`.

<sup>Written for commit 3d6175d958a2ba84ffa9123ecb8d6d5e9de623ee. Summary will update on new commits. <a href="https://cubic.dev/pr/flazouh/acepe/pull/200?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

