### PR TITLE
fix: guard initialSyncComplete against empty first call

### DIFF
--- a/packages/desktop/src/lib/components/main-app-view/logic/live-session-panel-sync.ts
+++ b/packages/desktop/src/lib/components/main-app-view/logic/live-session-panel-sync.ts
@@ -101,6 +101,8 @@ export function syncLiveSessionPanels(
 		materializedSessionIds.push(input.sessionId);
 	}
 
-	initialSyncComplete = true;
+	if (inputs.length > 0) {
+		initialSyncComplete = true;
+	}
 	return materializedSessionIds;
 }


### PR DESCRIPTION
## Problem

As identified by cubic in #200, `initialSyncComplete` was set unconditionally after every `syncLiveSessionPanels` call — including when `inputs` is empty.

If the first reactive `$effect` run in `app-queue-row.svelte` fires before sessions have loaded (`liveSessionSyncInputs` is empty), the guard is consumed immediately. The next non-empty call then treats all live sessions as genuinely new and materializes their panels — recreating the ghost-panel flood the guard was meant to prevent.

## Fix

Gate the `initialSyncComplete = true` flip behind `inputs.length > 0`. An empty-inputs call is a no-op that must not advance the first-run state machine.

```diff
-\tinitialSyncComplete = true;
+\tif (inputs.length > 0) {
+\t\tinitialSyncComplete = true;
+\t}
```

Fixes the cubic finding from #200.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevent ghost panels by guarding the initial sync against an empty first call. `initialSyncComplete` now flips only when `syncLiveSessionPanels` receives non-empty inputs.

- **Bug Fixes**
  - Gate `initialSyncComplete = true` behind `inputs.length > 0` so empty calls don’t advance the first-run guard.

<sup>Written for commit f68c500d673ecdecba68e944386e191e1d7743db. Summary will update on new commits. <a href="https://cubic.dev/pr/flazouh/acepe/pull/201?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

