### PR TITLE
feat(ui): composer padding polish and voice menu UX

### DIFF
--- a/packages/desktop/src/lib/acp/components/agent-input/agent-input-ui.svelte
+++ b/packages/desktop/src/lib/acp/components/agent-input/agent-input-ui.svelte
@@ -1810,7 +1810,7 @@ $effect(() => {
 		<SharedAgentPanelComposer
 			class="border-t-0 p-0"
 			inputClass="flex-shrink-0 border border-border bg-input/30"
-			contentClass={voiceOverlayActive ? "relative p-1.5" : "p-1.5"}
+			contentClass={voiceOverlayActive ? "relative px-3 py-2.5" : "px-3 py-2.5"}
 		>
 			{#snippet content()}
 				<AgentInputComposerBody

--- a/packages/desktop/src/lib/components/main-app-view/components/content/empty-states.svelte
+++ b/packages/desktop/src/lib/components/main-app-view/components/content/empty-states.svelte
@@ -418,7 +418,7 @@ function handleEmptyStateSessionCreated(sessionId: string) {
 </script>
 
 <div class="flex flex-col items-center justify-center h-full w-full py-6">
-	<h1 class="mb-4 text-center font-sans text-[1.9rem] font-semibold tracking-tight text-foreground sm:text-4xl">
+	<h1 class="mb-4 text-center font-sans text-[1.65rem] font-semibold tracking-tight text-foreground sm:text-[2rem]">
 		What do you want to build?
 	</h1>
 

--- a/packages/ui/src/components/agent-panel/agent-input-mode-pill.svelte
+++ b/packages/ui/src/components/agent-panel/agent-input-mode-pill.svelte
@@ -4,6 +4,7 @@
 -->
 <script lang="ts">
 	import { BuildIcon, PlanIcon } from "../icons/index.js";
+	import { Tooltip, TooltipContent, TooltipTrigger } from "../tooltip/index.js";
 
 	interface Mode {
 		readonly id: string;
@@ -17,6 +18,8 @@
 		buildModeId?: string;
 		planLabel?: string;
 		buildLabel?: string;
+		planDescription?: string;
+		buildDescription?: string;
 		disabled?: boolean;
 		onModeChange: (modeId: string) => void;
 	}
@@ -28,6 +31,8 @@
 		buildModeId = "build",
 		planLabel = "Plan",
 		buildLabel = "Build",
+		planDescription = "Think through the approach before writing code. The agent researches, asks clarifying questions, and proposes a plan without making changes.",
+		buildDescription = "Execute the work. The agent edits files, runs commands, and applies changes directly.",
 		disabled = false,
 		onModeChange,
 	}: Props = $props();
@@ -36,6 +41,12 @@
 		if (mode.id === planModeId) return mode.label ?? planLabel;
 		if (mode.id === buildModeId) return mode.label ?? buildLabel;
 		return mode.label ?? mode.id;
+	}
+
+	function modeDescription(modeId: string): string | null {
+		if (modeId === planModeId) return planDescription;
+		if (modeId === buildModeId) return buildDescription;
+		return null;
 	}
 
 	function iconColor(modeId: string): string {
@@ -53,22 +64,37 @@
 	{#each modes as mode (mode.id)}
 		{@const isSelected = mode.id === currentModeId}
 		{@const label = modeLabel(mode)}
-		<button
-			type="button"
-			{disabled}
-			aria-pressed={isSelected}
-			aria-label={label}
-			title={label}
-			class="inline-flex h-7 w-7 shrink-0 items-center justify-center transition-colors
-				{isSelected ? 'bg-background dark:bg-input/30 text-foreground' : 'text-muted-foreground hover:text-foreground'}
-				{disabled ? 'cursor-default opacity-50' : 'cursor-pointer'}"
-			onclick={() => { if (!disabled) onModeChange(mode.id); }}
-		>
-			{#if mode.id === planModeId}
-				<PlanIcon size="sm" class="shrink-0" style="color: {isSelected ? iconColor(mode.id) : 'currentColor'}" />
-			{:else}
-				<BuildIcon size="sm" class="shrink-0" style="color: {isSelected ? iconColor(mode.id) : 'currentColor'}" />
-			{/if}
-		</button>
+		{@const description = modeDescription(mode.id)}
+		<Tooltip>
+			<TooltipTrigger>
+				{#snippet child({ props: triggerProps })}
+					<button
+						{...triggerProps}
+						type="button"
+						{disabled}
+						aria-pressed={isSelected}
+						aria-label={label}
+						class="inline-flex h-7 w-7 shrink-0 items-center justify-center transition-colors
+							{isSelected ? 'bg-background dark:bg-input/30 text-foreground' : 'text-muted-foreground hover:text-foreground'}
+							{disabled ? 'cursor-default opacity-50' : 'cursor-pointer'}"
+						onclick={() => { if (!disabled) onModeChange(mode.id); }}
+					>
+						{#if mode.id === planModeId}
+							<PlanIcon size="sm" class="shrink-0" style="color: {isSelected ? iconColor(mode.id) : 'currentColor'}" />
+						{:else}
+							<BuildIcon size="sm" class="shrink-0" style="color: {isSelected ? iconColor(mode.id) : 'currentColor'}" />
+						{/if}
+					</button>
+				{/snippet}
+			</TooltipTrigger>
+			<TooltipContent class="max-w-xs">
+				<div class="flex flex-col gap-0.5">
+					<span class="font-medium">{label}</span>
+					{#if description}
+						<span class="text-muted-foreground">{description}</span>
+					{/if}
+				</div>
+			</TooltipContent>
+		</Tooltip>
 	{/each}
 </div>

--- a/packages/ui/src/components/agent-panel/agent-input-voice-model-menu.svelte
+++ b/packages/ui/src/components/agent-panel/agent-input-voice-model-menu.svelte
@@ -44,12 +44,70 @@
 
 	let menuOpen = $state(false);
 
+	interface TierMeta {
+		label: string;
+		description: string;
+	}
+
+	const TIER_ORDER: readonly string[] = ["tiny", "base", "small", "medium", "large"];
+
+	const TIER_META: Record<string, TierMeta> = {
+		tiny: { label: "Tiny", description: "Fastest · least accurate" },
+		base: { label: "Base", description: "Fast · basic accuracy" },
+		small: { label: "Small", description: "Balanced · recommended" },
+		medium: { label: "Medium", description: "Slower · more accurate" },
+		large: { label: "Large", description: "Slowest · most accurate" },
+	};
+
+	function tierFor(modelId: string): string {
+		const head = modelId.split(".")[0] ?? modelId;
+		return head.toLowerCase();
+	}
+
+	function variantLabelFor(modelId: string): string {
+		return modelId.endsWith(".en") ? "English" : "Multilingual";
+	}
+
 	function formatBytes(bytes: number): string {
 		if (bytes >= 1024 * 1024 * 1024) {
 			return `${(bytes / (1024 * 1024 * 1024)).toFixed(1)} GB`;
 		}
 		return `${Math.round(bytes / (1024 * 1024))} MB`;
 	}
+
+	interface ModelGroup {
+		tier: string;
+		meta: TierMeta;
+		models: AgentInputVoiceModel[];
+	}
+
+	const groupedModels = $derived.by<readonly ModelGroup[]>(() => {
+		const byTier = new Map<string, AgentInputVoiceModel[]>();
+		const extraOrder: string[] = [];
+		for (const model of models) {
+			const tier = tierFor(model.id);
+			const bucket = byTier.get(tier);
+			if (bucket) {
+				bucket.push(model);
+			} else {
+				byTier.set(tier, [model]);
+				if (!TIER_ORDER.includes(tier)) {
+					extraOrder.push(tier);
+				}
+			}
+		}
+		const orderedTiers = [...TIER_ORDER, ...extraOrder];
+		const result: ModelGroup[] = [];
+		for (const tier of orderedTiers) {
+			const tierModels = byTier.get(tier);
+			if (!tierModels || tierModels.length === 0) {
+				continue;
+			}
+			const meta = TIER_META[tier] ?? { label: tier, description: "" };
+			result.push({ tier, meta, models: tierModels });
+		}
+		return result;
+	});
 </script>
 
 <DropdownMenu.Root bind:open={menuOpen}>
@@ -66,7 +124,7 @@
 			</button>
 		{/snippet}
 	</DropdownMenu.Trigger>
-	<DropdownMenu.Content align="end" side="top" sideOffset={8} class="min-w-[220px]">
+	<DropdownMenu.Content align="end" side="top" sideOffset={8} class="min-w-[260px]">
 		<DropdownMenu.Group>
 			<DropdownMenu.GroupHeading class="text-[10px]">
 				{menuLabel}
@@ -78,61 +136,75 @@
 				{loadingLabel}
 			</div>
 		{:else}
-			{#each models as model (model.id)}
-				{@const isSelected = selectedModelId === model.id}
-				{@const isDownloading = downloadingModelId === model.id}
-
-				{#if model.isDownloaded}
-					<DropdownMenu.Item onSelect={() => onSelectModel(model.id)}>
-						<div class="flex w-full items-center gap-2">
-							<Check
-								class={isSelected ? "size-3 shrink-0 text-foreground" : "size-3 shrink-0 text-transparent"}
-								weight="bold"
-							/>
-							<div class="flex flex-1 items-center min-w-0">
-								<span class="truncate text-xs font-medium">{model.name}</span>
-							</div>
-							<span class="shrink-0 text-[10px] leading-none text-muted-foreground/40">
-								{formatBytes(model.sizeBytes)}
-							</span>
-						</div>
-					</DropdownMenu.Item>
-				{:else}
-					<div
-						class="model-row relative z-10 flex items-center gap-2 px-2 py-1 text-xs font-medium select-none border-b border-border/20 last:border-b-0"
-					>
-						<Check class="size-3 shrink-0 text-transparent" weight="bold" />
-						<div class="flex flex-1 items-center min-w-0">
-							<span class="truncate text-xs font-medium text-muted-foreground">
-								{model.name}
-							</span>
-						</div>
-
-						{#if isDownloading}
-							<VoiceDownloadProgress
-								ariaLabel={`Downloading ${model.name}`}
-								compact={true}
-								label=""
-								percent={downloadPercent}
-								segmentCount={20}
-								showPercent={false}
-							/>
-						{:else}
-							<Button
-								variant="headerAction"
-								size="headerAction"
-								class="h-5 shrink-0 gap-0.5 px-1.5 py-0 text-[10px] leading-none font-mono"
-								onclick={(e: MouseEvent) => {
-									e.stopPropagation();
-									onDownloadModel(model.id);
-								}}
-							>
-								<span>{formatBytes(model.sizeBytes)}</span>
-								<DownloadSimple class="size-2" weight="bold" />
-							</Button>
-						{/if}
-					</div>
+			{#each groupedModels as group, groupIndex (group.tier)}
+				{#if groupIndex > 0}
+					<DropdownMenu.Separator />
 				{/if}
+				<div class="flex items-baseline justify-between gap-2 px-2 pt-1.5 pb-0.5">
+					<span class="text-[11px] font-semibold text-foreground">{group.meta.label}</span>
+					{#if group.meta.description}
+						<span class="truncate text-[10px] text-muted-foreground">
+							{group.meta.description}
+						</span>
+					{/if}
+				</div>
+				{#each group.models as model (model.id)}
+					{@const isSelected = selectedModelId === model.id}
+					{@const isDownloading = downloadingModelId === model.id}
+					{@const variantLabel = variantLabelFor(model.id)}
+
+					{#if model.isDownloaded}
+						<DropdownMenu.Item class="min-h-7 py-1" onSelect={() => onSelectModel(model.id)}>
+							<div class="flex w-full items-center gap-2">
+								<Check
+									class={isSelected ? "size-3 shrink-0 text-foreground" : "size-3 shrink-0 text-transparent"}
+									weight="bold"
+								/>
+								<div class="flex flex-1 items-center min-w-0">
+									<span class="truncate text-xs font-medium">{variantLabel}</span>
+								</div>
+								<span class="shrink-0 text-[10px] leading-none text-muted-foreground/40">
+									{formatBytes(model.sizeBytes)}
+								</span>
+							</div>
+						</DropdownMenu.Item>
+					{:else}
+						<div
+							class="model-row relative z-10 flex min-h-7 items-center gap-2 px-2 py-1 text-xs font-medium select-none"
+						>
+							<Check class="size-3 shrink-0 text-transparent" weight="bold" />
+							<div class="flex flex-1 items-center min-w-0">
+								<span class="truncate text-xs font-medium text-muted-foreground">
+									{variantLabel}
+								</span>
+							</div>
+
+							{#if isDownloading}
+								<VoiceDownloadProgress
+									ariaLabel={`Downloading ${model.name}`}
+									compact={true}
+									label=""
+									percent={downloadPercent}
+									segmentCount={20}
+									showPercent={false}
+								/>
+							{:else}
+								<Button
+									variant="headerAction"
+									size="headerAction"
+									class="h-5 shrink-0 gap-0.5 px-1.5 py-0 text-[10px] leading-none font-mono"
+									onclick={(e: MouseEvent) => {
+										e.stopPropagation();
+										onDownloadModel(model.id);
+									}}
+								>
+									<span>{formatBytes(model.sizeBytes)}</span>
+									<DownloadSimple class="size-2" weight="bold" />
+								</Button>
+							{/if}
+						</div>
+					{/if}
+				{/each}
 			{/each}
 		{/if}
 	</DropdownMenu.Content>

--- a/packages/ui/src/components/agent-panel/agent-panel-composer.svelte
+++ b/packages/ui/src/components/agent-panel/agent-panel-composer.svelte
@@ -21,6 +21,7 @@
 		class?: string;
 		inputClass?: string;
 		contentClass?: string;
+		footerClass?: string;
 		disabledReason?: string | null;
 		children?: Snippet;
 	}
@@ -34,6 +35,7 @@
 		class: className = "",
 		inputClass = "border border-border/50 bg-background/70",
 		contentClass = "px-3 py-1.5",
+		footerClass = "",
 		disabledReason = null,
 		children,
 	}: Props = $props();
@@ -72,7 +74,7 @@
 </script>
 
 <div class={cn("shrink-0 border-t border-border/50 p-3", className)}>
-	<InputContainer class={inputClass} {contentClass}>
+	<InputContainer class={inputClass} {contentClass} {footerClass}>
 		{#snippet content()}
 			{#if contentSnippet}
 				{@render contentSnippet()}

--- a/packages/ui/src/components/input-container/input-container.svelte
+++ b/packages/ui/src/components/input-container/input-container.svelte
@@ -6,6 +6,8 @@
 		class?: string;
 		/** Class applied to the content area. Defaults to "px-3 py-2". */
 		contentClass?: string;
+		/** Class applied to the footer area (in addition to the layout defaults). */
+		footerClass?: string;
 		/** Named content snippet (used by desktop input). Mutually exclusive with children. */
 		content?: Snippet;
 		/** Optional footer snippet rendered below content with a top border. */
@@ -17,6 +19,7 @@
 	let {
 		class: className = "",
 		contentClass = "px-3 py-2",
+		footerClass = "",
 		content,
 		footer,
 		children,
@@ -34,7 +37,7 @@
 		{/if}
 	</div>
 	{#if footer}
-		<div class="flex items-center justify-between gap-2 h-7 border-t border-border/50 overflow-hidden rounded-b-[inherit]">
+		<div class={cn("flex items-center justify-between gap-2 h-7 border-t border-border/50 overflow-hidden rounded-b-[inherit]", footerClass)}>
 			{@render footer()}
 		</div>
 	{/if}


### PR DESCRIPTION
A small batch of composer/voice UX tweaks made interactively while reviewing the app.

## Changes

### Composer prompt container
- Bump interior padding to \`px-3 py-2.5\` so text and the send button no longer hug the borders.
- Toolbar row remains flush with the container edges so the circular icon buttons can hit the bottom corners cleanly (the hover ring extends into the corner instead of being trapped behind extra padding).

### \`InputContainer\` / \`AgentPanelComposer\` shared API
- Add an optional \`footerClass\` prop so hosts can opt into footer padding without touching shared defaults. Existing call sites are unaffected.

### Voice model menu
- Group models by tier (\`Tiny / Base / Small / Medium / Large\`) with a one-line tradeoff description per tier (\`Fastest · least accurate\`, \`Balanced · recommended\`, …) and a separator between groups.
- Rows now show only \`English\` / \`Multilingual\` since the tier is the section header — less repetition, easier to scan.
- Align row heights for downloaded vs. not-downloaded models (\`min-h-7 + py-1\`) so the vertical rhythm is consistent regardless of whether a row shows a download button or just a size.
- Robust to future catalog entries: unknown tiers fall back to the raw label with no description rather than disappearing.

### Mode pill (Plan / Build)
- Replace the native \`title\` attribute with a rich \`Tooltip\` (label + muted description) explaining when to use each mode.
- Descriptions are exposed as \`planDescription\` / \`buildDescription\` props for host overrides.

### Empty state heading
- Reduce \"What do you want to build?\" font size by 4px (\`1.9rem\` → \`1.65rem\`, \`text-4xl\` → \`text-[2rem]\`) for a slightly less heavy welcome screen. Stays centered.

## Verification
- \`bun run check\` (TypeScript) passes in \`packages/desktop\`.
- Changes are presentational only; no store, transport, or canonical state touched.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Polishes the composer layout and upgrades the voice model menu for clearer choices and more consistent spacing. Adds a tooltip-based mode switch and lightens the empty state heading.

- New Features
  - Composer: increased interior padding to px-3 py-2.5 so text and the send button don’t hug the edges; toolbar stays flush with the container.
  - `InputContainer` / `AgentPanelComposer`: added optional `footerClass` prop for opt‑in footer padding.
  - Voice model menu: grouped by tier with short tradeoff notes, rows show only “English” / “Multilingual,” consistent row heights, safe fallback for unknown tiers, and a wider menu for readability.
  - Mode pill (Plan / Build): replaced native title with a rich `Tooltip`; descriptions are overridable via `planDescription` / `buildDescription`.
  - Empty state: reduced “What do you want to build?” font size for a calmer first view.

<sup>Written for commit cd5a60d4de7fde57a6b8a500a23d0315d6fd7af7. Summary will update on new commits. <a href="https://cubic.dev/pr/flazouh/acepe/pull/202?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

