### PR TITLE
fix(ui): hide redundant permission config option from toolbar

### DIFF
--- a/packages/desktop/src/lib/acp/components/agent-input/agent-input-ui.svelte
+++ b/packages/desktop/src/lib/acp/components/agent-input/agent-input-ui.svelte
@@ -413,6 +413,7 @@ const toolbarConfigOptions = $derived.by((): AgentInputConfigOption[] => {
 			name: option.name,
 			category: option.category,
 			type: option.type,
+			description: option.description ?? null,
 			currentValue,
 			options,
 		};

--- a/packages/desktop/src/lib/acp/components/agent-input/agent-input-ui.svelte
+++ b/packages/desktop/src/lib/acp/components/agent-input/agent-input-ui.svelte
@@ -1811,7 +1811,7 @@ $effect(() => {
 		<SharedAgentPanelComposer
 			class="border-t-0 p-0"
 			inputClass="flex-shrink-0 border border-border bg-input/30"
-			contentClass={voiceOverlayActive ? "relative px-3 py-2.5" : "px-3 py-2.5"}
+			contentClass={voiceOverlayActive ? "relative px-4 py-3" : "px-4 py-3"}
 		>
 			{#snippet content()}
 				<AgentInputComposerBody

--- a/packages/desktop/src/lib/acp/components/agent-input/logic/toolbar-config-options.ts
+++ b/packages/desktop/src/lib/acp/components/agent-input/logic/toolbar-config-options.ts
@@ -6,6 +6,18 @@ import { supportsReasoningEffortPicker } from "../../model-selector-logic.js";
 
 const EXCLUDED_TOOLBAR_CONFIG_OPTION_CATEGORIES = new Set(["mode", "model"]);
 
+function isPermissionConfigOption(configOption: ConfigOptionData): boolean {
+	const id = configOption.id.toLowerCase();
+	const name = configOption.name.toLowerCase();
+	return (
+		id === "bypasspermissions" ||
+		id.includes("allow_all") ||
+		id.includes("allowall") ||
+		name.includes("allow all") ||
+		name.includes("bypass permission")
+	);
+}
+
 function includesNormalizedFragment(value: string, fragment: string): boolean {
 	return value.toLowerCase().includes(fragment);
 }
@@ -62,6 +74,10 @@ export function getToolbarConfigOptions(
 	for (const configOption of configOptions) {
 		const normalizedCategory = configOption.category.toLowerCase();
 		if (EXCLUDED_TOOLBAR_CONFIG_OPTION_CATEGORIES.has(normalizedCategory)) {
+			continue;
+		}
+
+		if (isPermissionConfigOption(configOption)) {
 			continue;
 		}
 

--- a/packages/desktop/src/lib/acp/components/agent-input/logic/toolbar-config-options.vitest.ts
+++ b/packages/desktop/src/lib/acp/components/agent-input/logic/toolbar-config-options.vitest.ts
@@ -227,4 +227,40 @@ describe("toolbar-config-options", () => {
 			])
 		).toEqual([]);
 	});
+
+	it("filters out permission-related options already covered by autonomous toggle", () => {
+		expect(
+			getToolbarConfigOptions([
+				{
+					id: "bypassPermissions",
+					name: "Bypass Permissions",
+					category: "permissions",
+					type: "boolean",
+					currentValue: true,
+				},
+				{
+					id: "allow_all",
+					name: "Allow All",
+					category: "tools",
+					type: "boolean",
+					currentValue: false,
+				},
+				{
+					id: "fast_mode",
+					name: "Fast Mode",
+					category: "fast_mode",
+					type: "boolean",
+					currentValue: false,
+				},
+			])
+		).toEqual([
+			{
+				id: "fast_mode",
+				name: "Fast Mode",
+				category: "fast_mode",
+				type: "boolean",
+				currentValue: false,
+			},
+		]);
+	});
 });

--- a/packages/ui/src/components/agent-panel/agent-input-config-option-selector.svelte
+++ b/packages/ui/src/components/agent-panel/agent-input-config-option-selector.svelte
@@ -9,6 +9,7 @@
 	import { Brain, Lightning, ShieldCheck } from "phosphor-svelte";
 
 	import * as DropdownMenu from "../dropdown-menu/index.js";
+	import { Tooltip, TooltipContent, TooltipTrigger } from "../tooltip/index.js";
 	import { Colors } from "../../lib/colors.js";
 	import type { AgentInputConfigOption } from "./agent-input-config-option-types.js";
 
@@ -102,6 +103,11 @@
 
 	const buttonTitle = $derived(`${configOption.name}: ${currentValueLabel}`);
 
+	const effectiveDescription = $derived.by(() => {
+		if (configOption.description) return configOption.description;
+		return null;
+	});
+
 	function handleSelect(value: string) {
 		if (value !== currentValue) {
 			onValueChange(configOption.id, value);
@@ -165,25 +171,40 @@
 		</DropdownMenu.Content>
 	</DropdownMenu.Root>
 {:else}
-	<button
-		type="button"
-		{disabled}
-		aria-pressed={isBooleanEnabled}
-		onclick={handleBooleanToggle}
-		title={buttonTitle}
-		class="flex items-center justify-center w-7 h-7 transition-colors rounded-none
-			{disabled
-			? 'text-muted-foreground/50 cursor-not-allowed'
-			: isBooleanEnabled
-				? 'bg-accent/60 text-foreground hover:bg-accent/80'
-				: 'text-muted-foreground hover:bg-accent/50 hover:text-foreground'}"
-	>
-		{#if isReasoningConfigOption}
-			<Brain class={iconClass} size={14} weight={iconWeight} style={iconStyle} />
-		{:else if isFastConfigOption}
-			<Lightning class={iconClass} size={14} weight={iconWeight} style={iconStyle} />
-		{:else}
-			<ShieldCheck size={14} weight="fill" style="color: {iconColor}" />
-		{/if}
-	</button>
+	<Tooltip>
+		<TooltipTrigger>
+			{#snippet child({ props: triggerProps })}
+				<button
+					{...triggerProps}
+					type="button"
+					{disabled}
+					aria-pressed={isBooleanEnabled}
+					onclick={handleBooleanToggle}
+					aria-label={buttonTitle}
+					class="flex items-center justify-center w-7 h-7 transition-colors rounded-none
+						{disabled
+						? 'text-muted-foreground/50 cursor-not-allowed'
+						: isBooleanEnabled
+							? 'bg-accent/60 text-foreground hover:bg-accent/80'
+							: 'text-muted-foreground hover:bg-accent/50 hover:text-foreground'}"
+				>
+					{#if isReasoningConfigOption}
+						<Brain class={iconClass} size={14} weight={iconWeight} style={iconStyle} />
+					{:else if isFastConfigOption}
+						<Lightning class={iconClass} size={14} weight={iconWeight} style={iconStyle} />
+					{:else}
+						<ShieldCheck size={14} weight="fill" style="color: {iconColor}" />
+					{/if}
+				</button>
+			{/snippet}
+		</TooltipTrigger>
+		<TooltipContent class="max-w-xs">
+			<div class="flex flex-col gap-0.5">
+				<span class="font-medium">{configOption.name}: {currentValueLabel}</span>
+				{#if effectiveDescription}
+					<span class="text-muted-foreground">{effectiveDescription}</span>
+				{/if}
+			</div>
+		</TooltipContent>
+	</Tooltip>
 {/if}

--- a/packages/ui/src/components/agent-panel/agent-input-config-option-types.ts
+++ b/packages/ui/src/components/agent-panel/agent-input-config-option-types.ts
@@ -3,6 +3,8 @@ export interface AgentInputConfigOption {
 	name: string;
 	category: string;
 	type: string;
+	/** Human-readable explanation of what this option controls. */
+	description?: string | null;
 	currentValue: string | number | boolean | null;
 	options?: readonly { value: string | number | boolean; name: string }[];
 }


### PR DESCRIPTION
## Problem

The agent's permission-bypass config option ("Allow All" / "Bypass Permissions") was rendering as a cryptic blue shield icon in the composer toolbar. Users couldn't tell what it did — hovering only showed "Allow All: On/Off" with no explanation.

Worse, it **duplicated the autonomous toggle** (robot icon) which already controls the same behavior: both skip tool permission prompts.

## Solution

1. **Remove the redundant option from the toolbar** — filter out permission-related config options (`bypassPermissions`, `allow_all`, "Allow All", etc.) since they're fully controlled by the existing autonomous toggle.

2. **Improve tooltips for remaining config options** — boolean config toggles now show a rich tooltip with name, state, and description (when the agent provides one), replacing the bare native `title` tooltip.

## Changes

| File | What |
|------|------|
| `toolbar-config-options.ts` | Added `isPermissionConfigOption()` filter |
| `toolbar-config-options.vitest.ts` | Test covering the new filter |
| `agent-input-config-option-selector.svelte` | Rich tooltip for boolean options |
| `agent-input-config-option-types.ts` | Added `description` field |
| `agent-input-ui.svelte` | Wire `description` through from backend |

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hide the redundant "Allow All"/"Bypass Permissions" option from the composer toolbar and add clear tooltips to remaining boolean toggles. Also increase composer content padding for better spacing.

- **Bug Fixes**
  - Filter out permission-related config options already controlled by autonomous mode (e.g., `bypassPermissions`, `allow_all`, "Allow All").
  - Replace native title with a rich tooltip showing name, state, and optional description.
  - Wire `description` from backend to UI, update types, and add tests for the new filter.

<sup>Written for commit 862277314986b689d4e7619dec911831969b1d84. Summary will update on new commits. <a href="https://cubic.dev/pr/flazouh/acepe/pull/204?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

