### PR TITLE
fix(website): declare streamdown as a direct dependency

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -163,6 +163,7 @@
         "pino": "^10.1.0",
         "postgres": "^3.4.5",
         "shiki": "^3.22.0",
+        "streamdown": "2.5.0",
         "tailwind-merge": "^3.4.0",
         "tw-animate-css": "^1.4.0",
         "vaul-svelte": "^1.0.0-next.7",

--- a/packages/website/package.json
+++ b/packages/website/package.json
@@ -37,6 +37,7 @@
 		"pino": "^10.1.0",
 		"postgres": "^3.4.5",
 		"shiki": "^3.22.0",
+		"streamdown": "2.5.0",
 		"tailwind-merge": "^3.4.0",
 		"tw-animate-css": "^1.4.0",
 		"vaul-svelte": "^1.0.0-next.7"


### PR DESCRIPTION
## Why

The merged landing PR (#208) failed to **deploy** on Railway:

```
[@tailwindcss/vite:generate:build] Can't resolve 'streamdown/styles.css' in '/app/packages/website/src/routes'
```

`layout.css` imports `streamdown/styles.css` (it renders `@acepe/ui`'s streamdown-markdown in demos), but the website never declared `streamdown` directly, so it isn't resolvable from `packages/website` in a clean production build. The last successful deploy predated that import, so #208 was simply the first deploy to hit it — the breakage is not in the landing diff.

## Fix

Declare `streamdown@2.5.0` as a direct website dependency — mirrors the existing direct `shiki` dep, added for the same component.

## Verification

Ran Railway's exact build command locally (`bun install` + `bun run --cwd packages/website build`):
- Before: fails at `Can't resolve 'streamdown/styles.css'`
- After: `streamdown/styles.css` resolves, **✓ built in 1m 6s**, adapter-node done (the only remaining local stop was `DATABASE_URL is required` in postbuild analyse, which Railway provides via the linked Postgres).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add `streamdown@2.5.0` as a direct website dependency to fix the Railway build error resolving `streamdown/styles.css`. This makes the `layout.css` import work so the landing page demos build and deploy.

<sup>Written for commit cc52427561f06cc029a4a4e30f923094bd834abc. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/flazouh/acepe/pull/209?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

