### PR TITLE
fix(website): give the pitch page an explicit canonical URL

### DIFF
--- a/packages/website/src/routes/pitch/+page.svelte
+++ b/packages/website/src/routes/pitch/+page.svelte
@@ -111,6 +111,7 @@ const slideSummaryClass = `max-w-3xl ${slideDescriptionClass}`;
 <Seo
 	title="Investor Pitch"
 	description="Acepe investor pitch: the platform-neutral operating layer for agentic development."
+	canonical="/pitch"
 	noindex
 />
 


### PR DESCRIPTION
## Why

The pitch route's `<Seo>` omitted `canonical`, so it fell through to the `page.url` fallback from `$app/state`. Under a bare `render(Page)` in vitest there's no app context, so reading `page.url` threw `Cannot read properties of undefined (reading 'page')` — failing all three pitch contract test files (4 tests) and keeping the **Frontend** CI check red on every PR.

This is pre-existing on `main`, reproduced at the bare `origin/main` commit; it's what forced the two prior landing/deploy PRs to merge with `--admin`.

## Fix

Pass `canonical="/pitch"`, like every other route. Removes the incidental `$app/state` dependency from the render path and aligns the pitch page with the codebase's explicit-canonical convention.

## Verification

`bunx vitest run src/routes/pitch/` → **4 files / 13 tests passed** (was 3 files / 4 tests failing).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add canonical="/pitch" to the pitch page’s `Seo` to remove the `$app/state` `page.url` fallback that crashed under vitest.
This fixes the pitch contract tests and restores the Frontend CI check.

<sup>Written for commit bdbcf573ca2c1879d072f7f06853e761254051f3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/flazouh/acepe/pull/210?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

